### PR TITLE
fix issue with what paths to user for plugins & modules depending if the app is distributed or running for dev purposes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
           };
           src = ./.;
           
-          # Plugin packages
+          # Plugin packages (development builds)
           counterPlugin = import ./nix/counter.nix { 
             inherit pkgs common src; 
           };
@@ -55,7 +55,18 @@
             inherit pkgs common src; 
           };
           
-          # App package
+          # Plugin packages (distributed builds for DMG/AppImage)
+          mainUIPluginDistributed = import ./nix/main-ui.nix { 
+            inherit pkgs common src logosSdk logosPackageManager logosLiblogos;
+            distributed = true;
+          };
+          
+          packageManagerUIPluginDistributed = import ./nix/package-manager-ui.nix { 
+            inherit pkgs common src logosSdk logosPackageManager logosLiblogos;
+            distributed = true;
+          };
+          
+          # App package (development build)
           app = import ./nix/app.nix { 
             inherit pkgs common src logosLiblogos logosSdk logosPackageManager logosCapabilityModule;
             counterPlugin = counterPlugin;
@@ -65,10 +76,21 @@
             webviewAppPlugin = webviewAppPlugin;
           };
           
+          # App package (distributed build for DMG/AppImage)
+          appDistributed = import ./nix/app.nix { 
+            inherit pkgs common src logosLiblogos logosSdk logosPackageManager logosCapabilityModule;
+            counterPlugin = counterPlugin;
+            counterQmlPlugin = counterQmlPlugin;
+            mainUIPlugin = mainUIPluginDistributed;
+            packageManagerUIPlugin = packageManagerUIPluginDistributed;
+            webviewAppPlugin = webviewAppPlugin;
+          };
+          
           # macOS distribution packages (only for Darwin)
           appBundle = if pkgs.stdenv.isDarwin then
             import ./nix/macos-bundle.nix {
-              inherit pkgs app src;
+              inherit pkgs src;
+              app = appDistributed;
             }
           else null;
           
@@ -82,7 +104,8 @@
           # Linux AppImage (only for Linux)
           appImage = if pkgs.stdenv.isLinux then
             import ./nix/appimage.nix {
-              inherit pkgs app src;
+              inherit pkgs src;
+              app = appDistributed;
               version = common.version;
             }
           else null;

--- a/logos_dapps/main_ui/CMakeLists.txt
+++ b/logos_dapps/main_ui/CMakeLists.txt
@@ -207,11 +207,20 @@ if(_liblogos_found)
     endif()
 endif()
 
+# Option for distributed builds (DMG/AppImage)
+option(LOGOS_DISTRIBUTED_BUILD "Build for distribution (DMG/AppImage)" OFF)
+
 # Add Qt definitions
 target_compile_definitions(main_ui PRIVATE
     QT_PLUGIN
     QT_DEPRECATED_WARNINGS
 )
+
+# Add distributed build flag if enabled
+if(LOGOS_DISTRIBUTED_BUILD)
+    target_compile_definitions(main_ui PRIVATE LOGOS_DISTRIBUTED_BUILD)
+    message(STATUS "Building main_ui for distribution (LOGOS_DISTRIBUTED_BUILD enabled)")
+endif()
 
 target_link_libraries(main_ui 
     PRIVATE 

--- a/logos_dapps/main_ui/src/MainUIBackend.cpp
+++ b/logos_dapps/main_ui/src/MainUIBackend.cpp
@@ -610,14 +610,22 @@ void MainUIBackend::openInstallPluginDialog()
 void MainUIBackend::installPluginFromPath(const QString& filePath)
 {
     QFileInfo fileInfo(filePath);
-    QString userPluginsDir = userPluginsDirectory();
+    
+#ifdef LOGOS_DISTRIBUTED_BUILD
+    // For distributed builds (DMG/AppImage), always use Application Support
+    QString targetDir = userPluginsDirectory();
+#else
+    // For development builds (nix), use bundled plugins directory
+    QString targetDir = pluginsDirectory();
+#endif
+    
     QDir dir;
     
-    if (!dir.exists(userPluginsDir)) {
-        dir.mkpath(userPluginsDir);
+    if (!dir.exists(targetDir)) {
+        dir.mkpath(targetDir);
     }
     
-    QString targetPath = userPluginsDir + "/" + fileInfo.fileName();
+    QString targetPath = targetDir + "/" + fileInfo.fileName();
     
     if (QFile::exists(targetPath)) {
         QFile::remove(targetPath);
@@ -650,14 +658,22 @@ void MainUIBackend::openInstallCoreModuleDialog()
 void MainUIBackend::installCoreModuleFromPath(const QString& filePath)
 {
     QFileInfo fileInfo(filePath);
-    QString modulesDir = modulesDirectory();
+    
+#ifdef LOGOS_DISTRIBUTED_BUILD
+    // For distributed builds (DMG/AppImage), use Application Support
+    QString targetDir = userModulesDirectory();
+#else
+    // For development builds (nix), use bundled modules directory
+    QString targetDir = modulesDirectory();
+#endif
+    
     QDir dir;
     
-    if (!dir.exists(modulesDir)) {
-        dir.mkpath(modulesDir);
+    if (!dir.exists(targetDir)) {
+        dir.mkpath(targetDir);
     }
     
-    QString targetPath = modulesDir + "/" + fileInfo.fileName();
+    QString targetPath = targetDir + "/" + fileInfo.fileName();
     
     if (QFile::exists(targetPath)) {
         QFile::remove(targetPath);
@@ -681,6 +697,11 @@ QString MainUIBackend::userPluginsDirectory() const
 QString MainUIBackend::modulesDirectory() const
 {
     return QCoreApplication::applicationDirPath() + "/../modules";
+}
+
+QString MainUIBackend::userModulesDirectory() const
+{
+    return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/modules";
 }
 
 QJsonObject MainUIBackend::readQmlPluginMetadata(const QString& pluginName) const

--- a/logos_dapps/main_ui/src/MainUIBackend.h
+++ b/logos_dapps/main_ui/src/MainUIBackend.h
@@ -97,6 +97,7 @@ private:
     QString pluginsDirectory() const;
     QString userPluginsDirectory() const;
     QString modulesDirectory() const;
+    QString userModulesDirectory() const;
     bool isQmlPlugin(const QString& name) const;
     QJsonObject readQmlPluginMetadata(const QString& pluginName) const;
     void updateModuleStats();

--- a/logos_dapps/package_manager_ui/CMakeLists.txt
+++ b/logos_dapps/package_manager_ui/CMakeLists.txt
@@ -199,11 +199,20 @@ if(_liblogos_found)
     endif()
 endif()
 
+# Option for distributed builds (DMG/AppImage)
+option(LOGOS_DISTRIBUTED_BUILD "Build for distribution (DMG/AppImage)" OFF)
+
 # Add Qt definitions
 target_compile_definitions(package_manager_ui PRIVATE
     QT_PLUGIN
     QT_DEPRECATED_WARNINGS
 )
+
+# Add distributed build flag if enabled
+if(LOGOS_DISTRIBUTED_BUILD)
+    target_compile_definitions(package_manager_ui PRIVATE LOGOS_DISTRIBUTED_BUILD)
+    message(STATUS "Building package_manager_ui for distribution (LOGOS_DISTRIBUTED_BUILD enabled)")
+endif()
 
 target_link_libraries(package_manager_ui 
     PRIVATE 

--- a/nix/main-ui.nix
+++ b/nix/main-ui.nix
@@ -1,5 +1,5 @@
 # Builds the main UI plugin
-{ pkgs, common, src, logosSdk, logosPackageManager, logosLiblogos }:
+{ pkgs, common, src, logosSdk, logosPackageManager, logosLiblogos, distributed ? false }:
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-main-ui-plugin";
@@ -96,6 +96,7 @@ pkgs.stdenv.mkDerivation {
       -GNinja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+      -DLOGOS_DISTRIBUTED_BUILD=${if distributed then "ON" else "OFF"} \
       -DLOGOS_CPP_SDK_ROOT=$(pwd)/logos-cpp-sdk \
       -DLOGOS_LIBLOGOS_ROOT=${logosLiblogos}
     

--- a/nix/package-manager-ui.nix
+++ b/nix/package-manager-ui.nix
@@ -1,5 +1,5 @@
 # Builds the package manager UI plugin
-{ pkgs, common, src, logosSdk, logosPackageManager, logosLiblogos }:
+{ pkgs, common, src, logosSdk, logosPackageManager, logosLiblogos, distributed ? false }:
 
 pkgs.stdenv.mkDerivation {
   pname = "${common.pname}-package-manager-ui-plugin";
@@ -96,6 +96,7 @@ pkgs.stdenv.mkDerivation {
       -GNinja \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0 \
+      -DLOGOS_DISTRIBUTED_BUILD=${if distributed then "ON" else "OFF"} \
       -DLOGOS_CPP_SDK_ROOT=$(pwd)/logos-cpp-sdk \
       -DLOGOS_LIBLOGOS_ROOT=${logosLiblogos}
     


### PR DESCRIPTION
This ensures installing apps & modules works correctly in all environments, and for both using the package manager or install from filesystem