### PR TITLE
support installing plugins inside folders

### DIFF
--- a/app/window.cpp
+++ b/app/window.cpp
@@ -59,8 +59,8 @@ void Window::setupUi()
 
     QString pluginsDir = QCoreApplication::applicationDirPath() + "/../plugins/";
     
-    // First, load the package_manager_ui plugin
-    QString packageManagerPluginPath = pluginsDir + "package_manager_ui" + pluginExtension;
+    // First, load the package_manager_ui plugin (now in subdirectory)
+    QString packageManagerPluginPath = pluginsDir + "package_manager_ui/package_manager_ui" + pluginExtension;
     QPluginLoader packageManagerLoader(packageManagerPluginPath);
     QWidget* packageManagerWidget = nullptr;
     
@@ -83,8 +83,8 @@ void Window::setupUi()
         qWarning() << "Failed to load package_manager_ui plugin:" << packageManagerLoader.errorString();
     }
 
-    // Load the main_ui plugin with the appropriate extension
-    QString mainUiPluginPath = pluginsDir + "main_ui" + pluginExtension;
+    // Load the main_ui plugin with the appropriate extension (now in subdirectory)
+    QString mainUiPluginPath = pluginsDir + "main_ui/main_ui" + pluginExtension;
     QPluginLoader loader(mainUiPluginPath);
 
     QWidget* mainContent = nullptr;

--- a/flake.lock
+++ b/flake.lock
@@ -335,11 +335,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768343028,
-        "narHash": "sha256-4LvsuZTDTlLtfMF4C69ls+lmkYJWD7LZitS04Mc+8UI=",
+        "lastModified": 1769122817,
+        "narHash": "sha256-QlZAAcYFdiZpX480+frfF/uOkKlWeW+p/aYOujqS7PY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "a76d33f5519af0ee12317c8f149eee2ac5d292a0",
+        "rev": "fb7a9d6888dc59dd29437e8d3a2d38fc9f0e8696",
         "type": "github"
       },
       "original": {
@@ -408,11 +408,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768343028,
-        "narHash": "sha256-4LvsuZTDTlLtfMF4C69ls+lmkYJWD7LZitS04Mc+8UI=",
+        "lastModified": 1769122817,
+        "narHash": "sha256-QlZAAcYFdiZpX480+frfF/uOkKlWeW+p/aYOujqS7PY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "a76d33f5519af0ee12317c8f149eee2ac5d292a0",
+        "rev": "fb7a9d6888dc59dd29437e8d3a2d38fc9f0e8696",
         "type": "github"
       },
       "original": {
@@ -457,11 +457,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768343028,
-        "narHash": "sha256-4LvsuZTDTlLtfMF4C69ls+lmkYJWD7LZitS04Mc+8UI=",
+        "lastModified": 1769122817,
+        "narHash": "sha256-QlZAAcYFdiZpX480+frfF/uOkKlWeW+p/aYOujqS7PY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "a76d33f5519af0ee12317c8f149eee2ac5d292a0",
+        "rev": "fb7a9d6888dc59dd29437e8d3a2d38fc9f0e8696",
         "type": "github"
       },
       "original": {
@@ -500,11 +500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769048946,
-        "narHash": "sha256-GmLZIq3jxDzi2gqtpvNabOGfP+9533j/3R7OKMke/ds=",
+        "lastModified": 1769183417,
+        "narHash": "sha256-Z6XJmFjoYyYvTW7JbdkpMiKgLxH22h68K2d9DaF+IP8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "09fc12be0d6eae1ca07d1226845c3910ab5c967b",
+        "rev": "69256ccdadc906d7e6be19bbe324648ebbd2e58c",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769096303,
-        "narHash": "sha256-QrufgBvNi97cH1BrS8h4XY9HzgpkIQtWTS782wqG3YM=",
+        "lastModified": 1769183626,
+        "narHash": "sha256-b/L8gGg7x7uhlS2BAXSXwwKCYXbxizaTHfuVcOw0aOY=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "d5a34837eef0cbf87f289bbc9c411fcd9e97a877",
+        "rev": "80b75b51bd05117720ed3fe0d8d9880763bb5bd6",
         "type": "github"
       },
       "original": {
@@ -552,11 +552,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769048946,
-        "narHash": "sha256-GmLZIq3jxDzi2gqtpvNabOGfP+9533j/3R7OKMke/ds=",
+        "lastModified": 1769183417,
+        "narHash": "sha256-Z6XJmFjoYyYvTW7JbdkpMiKgLxH22h68K2d9DaF+IP8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "09fc12be0d6eae1ca07d1226845c3910ab5c967b",
+        "rev": "69256ccdadc906d7e6be19bbe324648ebbd2e58c",
         "type": "github"
       },
       "original": {

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -228,22 +228,26 @@ pkgs.stdenv.mkDerivation rec {
       cp -L "${logosPackageManager}/lib/package_manager_plugin.$OS_EXT" "$out/modules/"
     fi
     
-    # Copy UI plugins to plugins directory (separate from liblogos modules)
+    # Copy UI plugins to plugins directory (each in its own subdirectory)
     if [ -f "${counterPlugin}/lib/counter.$OS_EXT" ]; then
-      cp -L "${counterPlugin}/lib/counter.$OS_EXT" "$out/plugins/"
-      echo "Copied counter.$OS_EXT to plugins/"
+      mkdir -p "$out/plugins/counter"
+      cp -L "${counterPlugin}/lib/counter.$OS_EXT" "$out/plugins/counter/"
+      echo "Copied counter.$OS_EXT to plugins/counter/"
     fi
     if [ -f "${mainUIPlugin}/lib/main_ui.$OS_EXT" ]; then
-      cp -L "${mainUIPlugin}/lib/main_ui.$OS_EXT" "$out/plugins/"
-      echo "Copied main_ui.$OS_EXT to plugins/"
+      mkdir -p "$out/plugins/main_ui"
+      cp -L "${mainUIPlugin}/lib/main_ui.$OS_EXT" "$out/plugins/main_ui/"
+      echo "Copied main_ui.$OS_EXT to plugins/main_ui/"
     fi
     if [ -f "${packageManagerUIPlugin}/lib/package_manager_ui.$OS_EXT" ]; then
-      cp -L "${packageManagerUIPlugin}/lib/package_manager_ui.$OS_EXT" "$out/plugins/"
-      echo "Copied package_manager_ui.$OS_EXT to plugins/"
+      mkdir -p "$out/plugins/package_manager_ui"
+      cp -L "${packageManagerUIPlugin}/lib/package_manager_ui.$OS_EXT" "$out/plugins/package_manager_ui/"
+      echo "Copied package_manager_ui.$OS_EXT to plugins/package_manager_ui/"
     fi
     if [ -f "${webviewAppPlugin}/lib/webview_app.$OS_EXT" ]; then
-      cp -L "${webviewAppPlugin}/lib/webview_app.$OS_EXT" "$out/plugins/"
-      echo "Copied webview_app.$OS_EXT to plugins/"
+      mkdir -p "$out/plugins/webview_app"
+      cp -L "${webviewAppPlugin}/lib/webview_app.$OS_EXT" "$out/plugins/webview_app/"
+      echo "Copied webview_app.$OS_EXT to plugins/webview_app/"
     fi
 
     if [ -d "${counterQmlPlugin}/qml_plugins/counter_qml" ]; then

--- a/nix/macos-bundle.nix
+++ b/nix/macos-bundle.nix
@@ -80,8 +80,8 @@ pkgs.stdenv.mkDerivation rec {
       cp -L "${app}/modules"/*.dylib "$out/LogosApp.app/Contents/modules/" 2>/dev/null || true
     fi
     
+    # Copy all plugin directories (each plugin is now in its own subdirectory)
     if [ -d "${app}/plugins" ]; then
-      cp -L "${app}/plugins"/*.dylib "$out/LogosApp.app/Contents/plugins/" 2>/dev/null || true
       for pluginDir in "${app}/plugins"/*; do
         if [ -d "$pluginDir" ]; then
           cp -R "$pluginDir" "$out/LogosApp.app/Contents/plugins/"


### PR DESCRIPTION
Modules & Apps were all isntalled in the same folder each with a flat structure.
However:
- QML plugins are more like folders (that will be inside .lgx packages)
- We need to avoid conflicts (for example modules/plugins that come with libraries with conflicting names)
- Better isolation (a plugin should only have its own folder as its context)

This adds support to installing as a folder for apps (modules later)