### PR TITLE
feat(ci): create macos release pipeline

### DIFF
--- a/ci/macos.Jenkinsfile
+++ b/ci/macos.Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.41'
+library 'status-jenkins-lib@v1.9.43'
 
 def isPRBuild = utils.isPRBuild()
 
@@ -37,23 +37,37 @@ pipeline {
   }
 
   stages {
-    stage('Build DMG') {
+    stage('Smoke Test') {
       steps { script {
-        nix.flake("dmg")
+        nix.flake('smoke-test-bundle')
       } }
     }
 
-    stage('Smoke Test') {
+    stage('Build MacOS App Bundle') {
+      steps { script {
+        nix.flake('bin-macos-app')
+      } }
+    }
+
+    stage('Sign & Notarize') {
+      when {
+        expression { utils.isReleaseBuild() }
+      }
       steps {
-        sh 'nix build .#smoke-test-bundle --out-link result-smoke -L --extra-experimental-features "nix-command flakes"'
-        sh 'cat result-smoke/smoke-test.log'
+        script {
+          logos.codesignApp(
+            bundlePath: 'result/LogosBasecamp.app',
+            outputPath: env.ARTIFACT,
+            mode: 'both',
+            timeout: '30m'
+          )
+        }
       }
     }
 
     stage('Package') {
       steps {
-        sh 'mkdir -p pkg'
-        sh "cp result/LogosBasecamp-*.dmg '${env.ARTIFACT}'"
+        sh "./scripts/create-dmg.sh --bundle result/LogosBasecamp.app --output ${env.ARTIFACT}"
       }
     }
 
@@ -65,9 +79,9 @@ pipeline {
     }
 
     stage('Archive') {
-      steps {
+      steps { script {
         archiveArtifacts(env.ARTIFACT)
-      }
+      } }
     }
   }
 

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/create-dmg.sh --bundle PATH --output PATH
+
+BUNDLE_PATH=""
+OUTPUT_PATH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bundle) BUNDLE_PATH="$2"; shift 2 ;;
+    --output) OUTPUT_PATH="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "$BUNDLE_PATH" ]] || { echo "Error: --bundle is required" >&2; exit 1; }
+[[ -n "$OUTPUT_PATH" ]] || { echo "Error: --output is required" >&2; exit 1; }
+[[ -d "$BUNDLE_PATH" ]] || { echo "Error: Bundle not found: $BUNDLE_PATH" >&2; exit 1; }
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+DMG_STAGING=$(mktemp -d)
+trap "chmod -R u+w '${DMG_STAGING}' 2>/dev/null; rm -rf '${DMG_STAGING}'" EXIT
+
+cp -a "$BUNDLE_PATH" "${DMG_STAGING}/"
+ln -s /Applications "${DMG_STAGING}/Applications"
+
+hdiutil create -volname "LogosBasecamp" \
+    -srcfolder "${DMG_STAGING}" \
+    -ov -format UDZO \
+    -puppetstrings \
+    "${OUTPUT_PATH}"
+
+echo "DMG created: ${OUTPUT_PATH}"

--- a/scripts/sign-and-notarize.sh
+++ b/scripts/sign-and-notarize.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 ###############################################################################
 # macOS Code Signing & Notarization for LogosBasecamp.app
 #
+# Supports modes:
+#   --mode sign      - Sign only
+#   --mode notarize  - Notarize only (requires pre-signed app)
+#   --mode both      - Sign and notarize (default)
+#
+# Usage:
+#   ./scripts/sign-and-notarize.sh [--dmg PATH] [--bundle PATH] [--output PATH] [--mode MODE] [--timeout TIMEOUT]
+#
 # Required env vars:
 #   MACOS_CODESIGN_IDENT       - Developer ID Application identity
 #   MACOS_NOTARY_ISSUER_ID     - App Store Connect API issuer ID
@@ -13,189 +21,288 @@ set -euo pipefail
 #   MACOS_KEYCHAIN_FILE        - Path to the .p12 certificate file
 ###############################################################################
 
-APP_BUNDLE="./LogosBasecamp.app"
-CONTENTS="${APP_BUNDLE}/Contents"
-ENTITLEMENTS="entitlements.plist"
-KEYCHAIN_NAME="build.keychain"
+# Needed since Apple time server can sometimes timeout
+codesign_with_retry() {
+    local attempts=3
+    local delay=15
+    local i=1
+    while (( i <= attempts )); do
+        if codesign "$@"; then
+            return 0
+        fi
+        echo "  codesign attempt ${i}/${attempts} failed, retrying in ${delay}s..."
+        sleep "$delay"
+        (( i++ ))
+    done
+    echo "ERROR: codesign failed after ${attempts} attempts"
+    return 1
+}
 
-# Codesign options — hardened runtime required for notarization
+DMG_PATH=""
+BUNDLE_PATH=""
+OUTPUT_PATH=""
+MODE="both"
+TIMEOUT="30m"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dmg)
+      DMG_PATH="$2"
+      shift 2
+      ;;
+    --bundle)
+      BUNDLE_PATH="$2"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate mode
+if [[ ! "$MODE" =~ ^(sign|notarize|both)$ ]]; then
+  echo "Error: --mode must be 'sign', 'notarize', or 'both'" >&2
+  exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+CERTS_DIR="/Users/jenkins/certs"
+mkdir -p "${CERTS_DIR}"
+trap "rm -rf '${TEMP_DIR}' '${CERTS_DIR}'" EXIT
+
+APP_BUNDLE="${TEMP_DIR}/LogosBasecamp.app"
+CONTENTS="${APP_BUNDLE}/Contents"
+ENTITLEMENTS="./app/macos/LogosBasecamp.entitlements"
+KEYCHAIN_NAME="build.keychain"
+KEYCHAIN_DB_PATH="${HOME}/Library/Keychains/${KEYCHAIN_NAME}-db"
+
+# Codesign options - hardened runtime required for notarization
 CODESIGN_OPTS=(
     --force
     --timestamp
     --options runtime
+    --keychain "${KEYCHAIN_DB_PATH}"
     --sign "${MACOS_CODESIGN_IDENT}"
 )
 
-###############################################################################
-# 0. Create entitlements file (adjust as needed for your app)
-###############################################################################
-cat > "${ENTITLEMENTS}" <<'EOF'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-</dict>
-</plist>
-EOF
+# Determine APP_BUNDLE path and copy to writable temp directory
+if [[ -n "$DMG_PATH" ]]; then
+  [[ -f "$DMG_PATH" ]] || { echo "Error: DMG not found: $DMG_PATH" >&2; exit 1; }
+
+  echo "Extracting DMG."
+  MOUNT_POINT="${TEMP_DIR}/mnt"
+
+  mkdir -p "$MOUNT_POINT"
+  hdiutil attach -readonly -mountpoint "$MOUNT_POINT" "$DMG_PATH"
+  cp -a "$MOUNT_POINT/LogosBasecamp.app" "$APP_BUNDLE"
+  hdiutil detach "$MOUNT_POINT"
+elif [[ -n "$BUNDLE_PATH" ]]; then
+  [[ -d "$BUNDLE_PATH" ]] || { echo "Error: Bundle not found: $BUNDLE_PATH" >&2; exit 1; }
+
+  echo "Copying bundle to temp directory."
+  cp -a "$BUNDLE_PATH" "$APP_BUNDLE"
+else
+  [[ -d "./LogosBasecamp.app" ]] || { echo "Error: Bundle not found at ./LogosBasecamp.app" >&2; exit 1; }
+
+  echo "Copying bundle to temp directory."
+  cp -a "./LogosBasecamp.app" "$APP_BUNDLE"
+fi
+
+chmod -R u+w "$APP_BUNDLE"
 
 ###############################################################################
-# 1. Set up a temporary keychain and import the certificate
+# SIGN MODE
 ###############################################################################
-echo "==> Setting up keychain..."
-security delete-keychain "${KEYCHAIN_NAME}" 2>/dev/null || true
-security create-keychain -p "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_NAME}"
-security unlock-keychain -p "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_NAME}"
+if [[ "$MODE" =~ ^(sign|both)$ ]]; then
+  echo "Starting signing phase."
 
-# Import cert
-security import "${MACOS_KEYCHAIN_FILE}" \
-    -k "${KEYCHAIN_NAME}" \
-    -P "${MACOS_KEYCHAIN_PASS}" \
-    -T /usr/bin/codesign \
-    -T /usr/bin/security
+  ###############################################################################
+  # 1. Remove all existing signatures
+  ###############################################################################
+  echo "Removing existing signatures..."
+  find "${APP_BUNDLE}" -name "_CodeSignature" -exec rm -rf {} + 2>/dev/null || true
 
-security set-key-partition-list \
-    -S apple-tool:,apple:,codesign: \
-    -s -k "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_NAME}"
+  ###############################################################################
+  # 2. Set up a temporary keychain and import the certificate
+  ###############################################################################
+  echo "Setting up keychain at ${KEYCHAIN_DB_PATH}"
+  security delete-keychain "${KEYCHAIN_DB_PATH}" 2>/dev/null || true
+  security create-keychain -p "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_DB_PATH}"
+  security unlock-keychain -p "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_DB_PATH}"
+  security set-keychain-settings -lut 21600 "${KEYCHAIN_DB_PATH}"
 
-# CRITICAL: Explicitly include login + System keychains so Apple root certs are found
-security list-keychains -d user -s \
-    "${KEYCHAIN_NAME}" \
-    "$HOME/Library/Keychains/login.keychain-db" \
-    "/Library/Keychains/System.keychain"
+  ###############################################################################
+  # 3. Import Trust Chain from Apple
+  ###############################################################################
+  echo "Downloading Apple Trust Chain."
+  curl -fsSL -o "${CERTS_DIR}/AppleRootCA-G2.cer"  https://www.apple.com/certificateauthority/AppleRootCA-G2.cer
+  curl -fsSL -o "${CERTS_DIR}/AppleWWDRCAG2.cer"   https://www.apple.com/certificateauthority/AppleWWDRCAG2.cer
+  curl -fsSL -o "${CERTS_DIR}/DeveloperIDG2CA.cer" https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
 
-echo "==> Keychain search list:"
-security list-keychains
-echo "==> Available identities:"
-security find-identity -v -p codesigning
+  echo "Importing Apple Trust Chain from local storage."
+  security import "${CERTS_DIR}/AppleRootCA-G2.cer"   -k "${KEYCHAIN_DB_PATH}" -t cert
+  security import "${CERTS_DIR}/AppleWWDRCAG2.cer"    -k "${KEYCHAIN_DB_PATH}" -t cert
+  security import "${CERTS_DIR}/DeveloperIDG2CA.cer"  -k "${KEYCHAIN_DB_PATH}" -t cert
 
-###############################################################################
-# 2. Sign dylibs in pre-installed modules/ and plugins/ directories
-###############################################################################
-echo "==> Signing dylibs in modules/..."
-find "${CONTENTS}/modules" -name '*.dylib' -type f 2>/dev/null | while read -r dylib; do
-    echo "  Signing: ${dylib}"
-    codesign --force --options runtime --sign "${MACOS_CODESIGN_IDENT}" --timestamp "${dylib}"
-done
+  # Ensure the system looks at our build keychain first
+  security list-keychains -d user -s "${KEYCHAIN_DB_PATH}" /Library/Keychains/System.keychain
 
-echo "==> Signing dylibs in plugins/..."
-find "${CONTENTS}/plugins" -name '*.dylib' -type f 2>/dev/null | while read -r dylib; do
-    echo "  Signing: ${dylib}"
-    codesign --force --options runtime --sign "${MACOS_CODESIGN_IDENT}" --timestamp "${dylib}"
-done
+  ###############################################################################
+  # 4. Import Identity and Set Permissions
+  ###############################################################################
+  echo "Extracting identity from P12."
+  openssl pkcs12 -in "${MACOS_KEYCHAIN_FILE}" \
+      -passin pass:"${MACOS_KEYCHAIN_PASS}" \
+      -nodes -out "${TEMP_DIR}/cert_and_key.pem"
 
-###############################################################################
-# 3. Sign all dylibs in Frameworks/
-###############################################################################
-echo "==> Signing dylibs in Frameworks..."
-find "${CONTENTS}/Frameworks" -name '*.dylib' -type f | while read -r dylib; do
-    echo "  Signing: ${dylib}"
-    codesign "${CODESIGN_OPTS[@]}" "${dylib}"
-done
+  echo "Importing identity from PEM."
+  security import "${TEMP_DIR}/cert_and_key.pem" \
+      -k "${KEYCHAIN_DB_PATH}" \
+      -T /usr/bin/codesign
 
-###############################################################################
-# 4. Sign all dylibs in Resources/qt/
-###############################################################################
-echo "==> Signing dylibs in Resources/qt..."
-find "${CONTENTS}/Resources/qt" -type f -name '*.dylib' | while read -r dylib; do
-    echo "  Signing: ${dylib}"
-    codesign "${CODESIGN_OPTS[@]}" "${dylib}"
-done
+  # Allow codesign to access the key without UI prompts (required on Sequoia)
+  security set-key-partition-list \
+      -S apple-tool:,apple:,codesign: \
+      -s -k "${MACOS_KEYCHAIN_PASS}" \
+      "${KEYCHAIN_DB_PATH}"
 
-###############################################################################
-# 5. Sign Qt frameworks (binary inside Versions/A/ then the .framework dir)
-###############################################################################
-echo "==> Signing Qt frameworks..."
-find "${CONTENTS}/Frameworks" -name '*.framework' -type d -maxdepth 1 | sort | while read -r fw; do
-    fw_name=$(basename "${fw}" .framework)
-    fw_binary="${fw}/Versions/A/${fw_name}"
+  echo "Debug: Keychain contents"
+  echo "Available identities in ${KEYCHAIN_DB_PATH}:"
+  security find-identity -v "${KEYCHAIN_DB_PATH}" || echo "No identities found"
 
-    if [[ -f "${fw_binary}" ]]; then
-        echo "  Signing framework binary: ${fw_binary}"
-        codesign "${CODESIGN_OPTS[@]}" "${fw_binary}"
-    fi
+  echo "Re-unlocking keychain before signing."
+  security unlock-keychain -p "${MACOS_KEYCHAIN_PASS}" "${KEYCHAIN_DB_PATH}"
 
-    echo "  Signing framework bundle: ${fw}"
-    codesign "${CODESIGN_OPTS[@]}" "${fw}"
-done
+  ###############################################################################
+  # 5. Sign all dylibs (modules/, plugins/, Frameworks/, Resources/qt/)
+  ###############################################################################
+  echo "Signing dylibs."
+  while IFS= read -r dylib; do
+      [[ -n "$dylib" ]] || continue
+      echo "  Signing: ${dylib}"
+      codesign_with_retry "${CODESIGN_OPTS[@]}" "$dylib" \
+          || { echo "ERROR: failed to sign ${dylib}"; exit 1; }
+  done < <(find \
+      "${CONTENTS}/modules" \
+      "${CONTENTS}/plugins" \
+      "${CONTENTS}/Frameworks" \
+      "${CONTENTS}/Resources/qt" \
+      -name '*.dylib' -type f 2>/dev/null | sort)
 
-###############################################################################
-# 6. Sign executables in Contents/MacOS/
-###############################################################################
-echo "==> Signing executables..."
-# Sign all Mach-O binaries first (with entitlements)
-for exe in "${CONTENTS}/MacOS/LogosBasecamp.bin" \
-           "${CONTENTS}/MacOS/logos-basecamp" \
-           "${CONTENTS}/MacOS/logos_host" \
-           "${CONTENTS}/MacOS/logoscore"; do
-    if [[ -f "${exe}" ]]; then
-        echo "  Signing: ${exe}"
-        codesign "${CODESIGN_OPTS[@]}" --entitlements "${ENTITLEMENTS}" "${exe}"
-    fi
-done
+  ###############################################################################
+  # 6. Sign Qt frameworks (binary first, then bundle - order within fw matters)
+  ###############################################################################
+  echo "Signing Qt frameworks."
+  while IFS= read -r fw; do
+      fw_name=$(basename "${fw}" .framework)
+      fw_binary="${fw}/Versions/A/${fw_name}"
 
-# Sign the shell script wrapper last (no --options runtime for scripts)
-echo "  Signing wrapper: ${CONTENTS}/MacOS/LogosBasecamp"
-codesign --force --timestamp --sign "${MACOS_CODESIGN_IDENT}" "${CONTENTS}/MacOS/LogosBasecamp"
+      if [[ -f "${fw_binary}" ]]; then
+          echo "  Signing framework binary: ${fw_binary}"
+          codesign_with_retry "${CODESIGN_OPTS[@]}" "${fw_binary}" \
+              || { echo "ERROR: failed to sign ${fw_binary}"; exit 1; }
+      fi
 
-###############################################################################
-# 7. Sign the top-level app bundle
-###############################################################################
-echo "==> Signing app bundle..."
-codesign "${CODESIGN_OPTS[@]}" --entitlements "${ENTITLEMENTS}" "${APP_BUNDLE}"
+      echo "  Signing framework bundle: ${fw}"
+      codesign_with_retry "${CODESIGN_OPTS[@]}" "${fw}" \
+          || { echo "ERROR: failed to sign ${fw}"; exit 1; }
+  done < <(find "${CONTENTS}/Frameworks" -name '*.framework' -type d -maxdepth 1 2>/dev/null | sort)
 
-###############################################################################
-# 8. Verify
-###############################################################################
-echo "==> Verifying signature..."
-codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
+  ###############################################################################
+  # 7. Sign executables in Contents/MacOS/
+  ###############################################################################
+  echo "Signing executables."
+  for exe in \
+      "${CONTENTS}/MacOS/LogosBasecamp.bin" \
+      "${CONTENTS}/MacOS/logos-basecamp" \
+      "${CONTENTS}/MacOS/logos_host" \
+      "${CONTENTS}/MacOS/ui-host" \
+      "${CONTENTS}/MacOS/logoscore"; do
+      if [[ -f "${exe}" ]]; then
+          echo "  Signing: ${exe}"
+          codesign_with_retry "${CODESIGN_OPTS[@]}" --entitlements "${ENTITLEMENTS}" "${exe}" \
+              || { echo "ERROR: failed to sign ${exe}"; exit 1; }
+      fi
+  done
 
-echo "==> Checking Gatekeeper assessment..."
-spctl --assess --type execute --verbose=2 "${APP_BUNDLE}" || true
+  if [[ -f "${CONTENTS}/MacOS/LogosBasecamp" ]]; then
+      echo "  Signing wrapper: ${CONTENTS}/MacOS/LogosBasecamp"
+      codesign_with_retry "${CODESIGN_OPTS[@]}" "${CONTENTS}/MacOS/LogosBasecamp" \
+          || { echo "ERROR: failed to sign wrapper"; exit 1; }
+  fi
 
-###############################################################################
-# 9. Create ZIP for notarization
-###############################################################################
-echo "==> Creating ZIP for notarization..."
-NOTARIZE_ZIP="LogosBasecamp.zip"
-ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARIZE_ZIP}"
+  ###############################################################################
+  # 8. Sign the top-level app bundle
+  ###############################################################################
+  echo "Signing app bundle."
+  codesign_with_retry "${CODESIGN_OPTS[@]}" --entitlements "${ENTITLEMENTS}" "${APP_BUNDLE}" \
+      || { echo "ERROR: failed to sign app bundle"; exit 1; }
 
-###############################################################################
-# 10. Submit for notarization
-###############################################################################
-echo "==> Submitting for notarization..."
-xcrun notarytool submit "${NOTARIZE_ZIP}" \
-    --issuer "${MACOS_NOTARY_ISSUER_ID}" \
-    --key-id "${MACOS_NOTARY_KEY_ID}" \
-    --key "${MACOS_NOTARY_KEY_FILE}" \
-    --wait \
-    --timeout 30m
+  ###############################################################################
+  # 9. Verify
+  ###############################################################################
+  echo "Verifying signature."
+  codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}" \
+      || { echo "ERROR: Signature verification failed, aborting before notarization."; exit 1; }
 
-###############################################################################
-# 11. Staple the notarization ticket
-###############################################################################
-echo "==> Stapling notarization ticket..."
-xcrun stapler staple "${APP_BUNDLE}"
+  echo "Signing phase complete"
+fi
 
+# NOTARIZE MODE
 ###############################################################################
-# 12. Final verification
-###############################################################################
-echo "==> Final verification..."
-spctl --assess --type execute --verbose=2 "${APP_BUNDLE}"
-codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
+if [[ "$MODE" =~ ^(notarize|both)$ ]]; then
+  echo "Starting notarization phase."
 
-###############################################################################
-# 13. Cleanup
-###############################################################################
-echo "==> Cleaning up keychain..."
-security delete-keychain "${KEYCHAIN_NAME}"
-rm -f "${ENTITLEMENTS}"
+  ###############################################################################
+  # 10. Create ZIP for notarization
+  ###############################################################################
+  echo "Creating ZIP for notarization."
+  NOTARIZE_ZIP="${TEMP_DIR}/LogosBasecamp-$$.zip"
+  ditto -c -k --keepParent "${APP_BUNDLE}" "${NOTARIZE_ZIP}"
 
-echo "==> Done! ${APP_BUNDLE} is signed and notarized."
+  ###############################################################################
+  # 11. Submit for notarization
+  ###############################################################################
+  echo "Submitting for notarization."
+  xcrun notarytool submit "${NOTARIZE_ZIP}" \
+      --issuer "${MACOS_NOTARY_ISSUER_ID}" \
+      --key-id "${MACOS_NOTARY_KEY_ID}" \
+      --key "${MACOS_NOTARY_KEY_FILE}" \
+      --wait \
+      --timeout "${TIMEOUT}" \
+      || { echo "ERROR: notarytool submission failed or returned Invalid."; exit 1; }
+
+  ###############################################################################
+  # 14. Staple the notarization ticket
+  ###############################################################################
+  echo "Stapling notarization ticket."
+  xcrun stapler staple "${APP_BUNDLE}" \
+      || { echo "ERROR: stapler failed."; exit 1; }
+
+  ###############################################################################
+  # 12. Final verification
+  ###############################################################################
+  echo "Final verification."
+  codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}" \
+      || { echo "ERROR: Final signature verification failed."; exit 1; }
+  spctl --assess --type execute --verbose=2 "${APP_BUNDLE}" \
+      || { echo "ERROR: Final Gatekeeper check failed."; exit 1; }
+
+  security delete-keychain "${KEYCHAIN_DB_PATH}" 2>/dev/null || true
+
+  echo "Notarization phase complete"
+fi


### PR DESCRIPTION
- added necessary functions to jenkins lib to mask sensitive signing and notarization certs and passwords
- updated script for signing and notarization to work on our CI hosts
  - this includes among other things downloading Apple certificates and
    importing them to the temporary keychain we create for signing
- updated Jenkinsfile to do signing and notarization only on releases

Referenced issue:
* https://github.com/logos-co/logos-basecamp/issues/27