### PR TITLE
unify dev and portable launcher files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ nix build
 ./run-dev.sh
 
 # Build + run directly
-nix build && ./result/bin/logos-basecamp
+nix build && ./result/bin/LogosBasecamp
 ```
 
 ## Testing
@@ -28,7 +28,7 @@ nix build .#logos-qt-mcp -o result-mcp
 node tests/ui-tests.mjs
 
 # UI integration tests headless (CI mode)
-node tests/ui-tests.mjs --ci ./result/bin/logos-basecamp
+node tests/ui-tests.mjs --ci ./result/bin/LogosBasecamp
 
 # Hermetic CI test via Nix
 nix build .#integration-test -L

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The local build produces a standard Nix derivation whose dependencies live in `/
 
 ```bash
 nix build '.#app'
-./result/bin/logos-basecamp
+./result/bin/LogosBasecamp
 ```
 
 Local builds require **local** `.lgx` packages, generated with:
@@ -176,7 +176,7 @@ nix build
 nix build .#logos-qt-mcp -o result-mcp
 
 # Run headless (launches the app, runs tests, kills the app):
-node tests/ui-tests.mjs --ci ./result/bin/logos-basecamp
+node tests/ui-tests.mjs --ci ./result/bin/LogosBasecamp
 
 # Or run against an already-running app:
 node tests/ui-tests.mjs

--- a/docs/project.md
+++ b/docs/project.md
@@ -468,7 +468,7 @@ All directory paths are managed via the `LogosBasecampPaths` utility class.
 
 | Artifact | Description |
 |----------|-------------|
-| `bin/logos-basecamp` | Main application executable |
+| `bin/LogosBasecamp` | Main application executable |
 | `lib/liblogos_core.{so,dylib}` | Core library (from logos-liblogos) |
 | `bin/logos_host` | Module subprocess host (from logos-liblogos) |
 | `modules/` | Embedded Logos Module bundles |
@@ -495,7 +495,7 @@ Nix provides reproducible builds with all dependencies managed automatically.
 nix build
 ```
 
-The result includes the application binary at `result/bin/logos-basecamp` with all embedded modules.
+The result includes the application binary at `result/bin/LogosBasecamp` with all embedded modules.
 
 **Build individual outputs:**
 
@@ -516,7 +516,7 @@ nix build '.#smoke-test' -L
 
 # Integration tests
 nix build '.#logos-qt-mcp' -o result-mcp
-node tests/ui-tests.mjs --ci ./result/bin/logos-basecamp
+node tests/ui-tests.mjs --ci ./result/bin/LogosBasecamp
 ```
 
 **Development shell:**
@@ -608,7 +608,7 @@ End-to-end UI tests using the `logos-qt-mcp` framework:
 
 ```bash
 nix build '.#logos-qt-mcp' -o result-mcp
-node tests/ui-tests.mjs --ci ./result/bin/logos-basecamp
+node tests/ui-tests.mjs --ci ./result/bin/LogosBasecamp
 ```
 
 ### QML Inspector

--- a/flake.nix
+++ b/flake.nix
@@ -208,7 +208,7 @@
 
           # Full logos-qt-mcp package (includes test-framework, mcp-server, qt-plugin)
           # Use: nix build .#logos-qt-mcp -o result-mcp
-          # Then: LOGOS_QT_MCP=./result-mcp node tests/ui-tests.mjs --ci ./result/bin/logos-basecamp
+          # Then: LOGOS_QT_MCP=./result-mcp node tests/ui-tests.mjs --ci ./result/bin/LogosBasecamp
           logos-qt-mcp = logosQtMcp;
 
           # Smoke test (also exposed as a package so it can be built standalone)

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -94,8 +94,8 @@ pkgs.stdenv.mkDerivation rec {
   # This is an aggregate runtime layout; avoid stripping to prevent hook errors
   dontStrip = true;
 
-  # Skip wrapQtApps: wrapper renames binary to .LogosBasecamp-wrapped; macOS Dock uses executable filename
-  # We create a custom launcher that execs the binary (keeps process name "LogosBasecamp")
+  # Skip wrapQtApps: we create our own wrapper for dev builds (hidden binary + shell launcher)
+  # and portable builds don't need wrapping (nix-bundle-dir handles Qt paths)
   dontWrapQtApps = true;
 
   # Additional environment variables for Qt and RPATH cleanup
@@ -115,7 +115,7 @@ pkgs.stdenv.mkDerivation rec {
           patchelf --remove-rpath "$1" 2>/dev/null || true
         fi
         # Set proper RPATH for the main binary
-        if echo "$1" | grep -q "/LogosBasecamp$"; then
+        if echo "$1" | grep -qE "/\.?LogosBasecamp$"; then
           echo "Setting RPATH for $1"
           patchelf --set-rpath "$out/lib" "$1" 2>/dev/null || true
         fi
@@ -187,10 +187,33 @@ pkgs.stdenv.mkDerivation rec {
     # Create output directories
     mkdir -p $out/bin $out/lib $out/modules $out/plugins
 
-    # Install our app binary (real binary, so Qt hook can wrap it)
+    # Install app binary
     if [ -f "build/LogosBasecamp" ]; then
-      cp build/LogosBasecamp "$out/bin/LogosBasecamp"
-      echo "Installed LogosBasecamp binary"
+      ${if portable then ''
+        # Portable: install binary directly (nix-bundle-dir handles Qt paths)
+        cp build/LogosBasecamp "$out/bin/LogosBasecamp"
+      '' else ''
+        # Dev: hide real binary, create wrapper that sets Qt env vars
+        cp build/LogosBasecamp "$out/bin/.LogosBasecamp"
+
+        cat > $out/bin/LogosBasecamp << 'WRAPPER_EOF'
+#!/bin/sh
+BINDIR="$(cd "$(dirname "$0")" && pwd)"
+APPDIR="$(cd "$BINDIR/.." && pwd)"
+WRAPPER_EOF
+        echo "export QT_PLUGIN_PATH=\"${qtPluginPath}\"" >> $out/bin/LogosBasecamp
+        echo "export QML2_IMPORT_PATH=\"${qmlImportPath}\"" >> $out/bin/LogosBasecamp
+        echo "export DYLD_LIBRARY_PATH=\"${qtLibPath}:\$DYLD_LIBRARY_PATH\"" >> $out/bin/LogosBasecamp
+        echo "export LD_LIBRARY_PATH=\"${qtLibPath}:\$LD_LIBRARY_PATH\"" >> $out/bin/LogosBasecamp
+        cat >> $out/bin/LogosBasecamp << 'WRAPPER_EOF'
+if [ "$(uname)" = "Linux" ]; then
+  export XDG_DATA_DIRS="$APPDIR/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"
+fi
+exec "$BINDIR/.LogosBasecamp" "$@"
+WRAPPER_EOF
+        chmod +x $out/bin/LogosBasecamp
+      ''}
+      echo "Installed LogosBasecamp"
     fi
 
     # Install ui-host binary from logos-view-module-runtime (process-isolated UI plugins)
@@ -252,21 +275,6 @@ pkgs.stdenv.mkDerivation rec {
       cp ${src}/app/icons/logos.png $out/share/icons/hicolor/256x256/apps/logos-basecamp.png
     fi
 
-    # Create launcher script (sets Qt env, execs binary - process name stays "LogosBasecamp" for Dock)
-    cat > $out/bin/logos-basecamp << 'EOF'
-#!/bin/sh
-EOF
-    echo "export QT_PLUGIN_PATH=\"${qtPluginPath}\"" >> $out/bin/logos-basecamp
-    echo "export QML2_IMPORT_PATH=\"${qmlImportPath}\"" >> $out/bin/logos-basecamp
-    echo "export DYLD_LIBRARY_PATH=\"${qtLibPath}:\$DYLD_LIBRARY_PATH\"" >> $out/bin/logos-basecamp
-    echo "export LD_LIBRARY_PATH=\"${qtLibPath}:\$LD_LIBRARY_PATH\"" >> $out/bin/logos-basecamp
-    echo 'APPDIR="$(cd "$(dirname "$0")/.." && pwd)"' >> $out/bin/logos-basecamp
-    echo 'if [ "$(uname)" = "Linux" ]; then' >> $out/bin/logos-basecamp
-    echo '  export XDG_DATA_DIRS="$APPDIR/share''${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}"' >> $out/bin/logos-basecamp
-    echo 'fi' >> $out/bin/logos-basecamp
-    echo 'exec "$(dirname "$0")/LogosBasecamp" "$@"' >> $out/bin/logos-basecamp
-    chmod +x $out/bin/logos-basecamp
-
     # Create a README for reference
     cat > $out/README.txt <<EOF
 Logos App - Build Information
@@ -276,7 +284,7 @@ cpp-sdk: ${logosSdk}
 logos-design-system: ${logosDesignSystem}
 
 Runtime Layout:
-- Binary: $out/bin/LogosBasecamp
+- Entry point: $out/bin/LogosBasecamp
 - Libraries: $out/lib
 - Embedded modules: $out/modules (pre-installed at build time)
 - Embedded plugins: $out/plugins (pre-installed at build time)

--- a/nix/integration-test.nix
+++ b/nix/integration-test.nix
@@ -3,7 +3,7 @@
 # and runs UI tests (click buttons, verify text, etc.).
 #
 # Requires Node.js for the test runner and the Qt offscreen platform plugin.
-{ pkgs, src, appPkg, logosQtMcp, appBin ? "${appPkg}/bin/logos-basecamp", timeoutSec ? 120 }:
+{ pkgs, src, appPkg, logosQtMcp, appBin ? "${appPkg}/bin/LogosBasecamp", timeoutSec ? 120 }:
 
 pkgs.runCommand "logos-basecamp-integration-test" {
   nativeBuildInputs = [ pkgs.coreutils pkgs.nodejs ]

--- a/nix/smoke-test.nix
+++ b/nix/smoke-test.nix
@@ -9,10 +9,10 @@
 # If the app crashes it exits immediately — the timeout is only ever waited out
 # on the happy path (app stays alive and healthy).
 #
-# The logos-basecamp launcher script (bin/logos-basecamp) already bakes in the correct
-# QT_PLUGIN_PATH and LD_LIBRARY_PATH at build time, so we only need to add
-# the offscreen platform plugin and GL stubs on Linux.
-{ pkgs, appPkg, appBin ? "${appPkg}/bin/logos-basecamp", timeoutSec ? 5 }:
+# The LogosBasecamp launcher (bin/LogosBasecamp) bakes in the correct
+# QT_PLUGIN_PATH and LD_LIBRARY_PATH at build time for dev builds.
+# We only need to add the offscreen platform plugin and GL stubs on Linux.
+{ pkgs, appPkg, appBin ? "${appPkg}/bin/LogosBasecamp", timeoutSec ? 5 }:
 
 pkgs.runCommand "logos-basecamp-smoke-test" {
   nativeBuildInputs = [ pkgs.coreutils ]

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -41,10 +41,7 @@ echo "================================================"
 echo ""
 
 # Run the app from the nix result
-# Use logos-basecamp launcher (sets Qt env, execs LogosBasecamp binary - Dock shows "LogosBasecamp")
-if [ -f "./result/bin/logos-basecamp" ]; then
-    ./result/bin/logos-basecamp "$@"
-elif [ -f "./result/bin/LogosBasecamp" ]; then
+if [ -f "./result/bin/LogosBasecamp" ]; then
     ./result/bin/LogosBasecamp "$@"
 else
     echo "Error: Application binary not found in ./result/bin/"


### PR DESCRIPTION
now both dev and portable builds launch using `./bin/LogosBasecamp`

The `./bin/logos-basecamp` script doesn't exist anymore