### PR TITLE
rework new ui qml load code into PluginLoader

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -891,11 +891,11 @@
         "process-stats": "process-stats"
       },
       "locked": {
-        "lastModified": 1775764743,
-        "narHash": "sha256-nPWoaPLoeE+pjPg9fP5sc5038ZenbePlD6Hl0/Q4Rpc=",
+        "lastModified": 1776084938,
+        "narHash": "sha256-0UL6tG6mK00HN99fm9CLJu3JA9ay2ry6dgeHfyApiWo=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "522c56b4fafb4ef30615231ef6616316a104b935",
+        "rev": "b293e9d70a04983778ef2ef3ef42596f76f41161",
         "type": "github"
       },
       "original": {

--- a/src/MainUIBackend.cpp
+++ b/src/MainUIBackend.cpp
@@ -22,12 +22,9 @@
 #include <QPointer>
 #include <QFileDialog>
 #include <memory>
-#include <LogosQmlBridge.h>
 #include <ViewModuleHost.h>
 #include "logos_sdk.h"
 #include "token_manager.h"
-#include "restricted/DenyAllNAMFactory.h"
-#include "restricted/RestrictedUrlInterceptor.h"
 
 extern "C" {
     char* logos_core_get_module_stats();
@@ -200,7 +197,19 @@ void MainUIBackend::loadUiModule(const QString& moduleName)
     }
 
     if (isQmlPlugin(moduleName)) {
-        loadQmlUiModule(moduleName, m_uiPluginMetadata.value(moduleName));
+        const QVariantMap& meta = m_uiPluginMetadata.value(moduleName);
+
+        PluginLoadRequest request;
+        request.name = moduleName;
+        request.type = UIPluginType::UiQml;
+        request.installDir = meta.value("installDir").toString();
+        request.qmlViewPath = resolveQmlViewPath(meta);
+        request.iconPath = getPluginIconPath(moduleName, true);
+        if (hasBackendPlugin(moduleName))
+            request.mainFilePath = meta.value("mainFilePath").toString();
+        request.coreDependencies = meta.value("dependencies").toList();
+
+        m_pluginLoader->load(request);
         return;
     }
 
@@ -208,12 +217,15 @@ void MainUIBackend::loadUiModule(const QString& moduleName)
 }
 
 void MainUIBackend::onPluginLoaded(const QString& name, QWidget* widget,
-                                   IComponent* component, bool isQml)
+                                   IComponent* component, UIPluginType type,
+                                   ViewModuleHost* viewHost)
 {
     if (component)
         m_loadedUiModules[name] = component;
-    if (isQml)
+    if (type != UIPluginType::Legacy)
         m_qmlPluginWidgets[name] = qobject_cast<QQuickWidget*>(widget);
+    if (viewHost)
+        m_viewModuleHosts[name] = viewHost;
     m_uiModuleWidgets[name] = widget;
     m_loadedApps.insert(name);
 
@@ -232,10 +244,7 @@ void MainUIBackend::onPluginLoadFailed(const QString& name, const QString& error
 
 QStringList MainUIBackend::loadingModules() const
 {
-    QStringList loading = m_pluginLoader->loadingPlugins();
-    for (const QString& name : m_loadingQmlModules)
-        loading.append(name);
-    return loading;
+    return m_pluginLoader->loadingPlugins();
 }
 
 void MainUIBackend::unloadUiModule(const QString& moduleName)
@@ -555,86 +564,6 @@ QString MainUIBackend::resolveQmlViewPath(const QVariantMap& meta) const
     return QDir(installDir).filePath(viewField);
 }
 
-void MainUIBackend::loadQmlUiModule(const QString& moduleName, const QVariantMap& meta)
-{
-    if (m_loadingQmlModules.contains(moduleName)) {
-        qDebug() << "ui_qml module" << moduleName << "is already loading";
-        return;
-    }
-
-    const QString installDir = meta.value("installDir").toString();
-    const QString qmlViewPath = resolveQmlViewPath(meta);
-    if (qmlViewPath.isEmpty() || !QFile::exists(qmlViewPath)) {
-        qWarning() << "ui_qml module QML file not found:" << qmlViewPath;
-        return;
-    }
-
-    m_loadingQmlModules.insert(moduleName);
-    emit loadingModulesChanged();
-
-    LogosQmlBridge* bridge = new LogosQmlBridge(m_logosAPI, this);
-    if (!hasBackendPlugin(moduleName)) {
-        loadQmlView(moduleName, installDir, qmlViewPath, bridge, nullptr);
-        return;
-    }
-
-    const QString pluginSoPath = meta.value("mainFilePath").toString();
-    auto* viewHost = new ViewModuleHost(this);
-    if (!viewHost->spawn(moduleName, pluginSoPath)) {
-        qWarning() << "Failed to spawn ui-host for ui_qml module" << moduleName;
-        delete viewHost;
-        delete bridge;
-        m_loadingQmlModules.remove(moduleName);
-        emit loadingModulesChanged();
-        return;
-    }
-
-    auto onHostReady = [this, moduleName, installDir, qmlViewPath,
-                        pluginSoPath, bridge, viewHost]() {
-        bridge->setViewModuleSocket(moduleName, viewHost->socketName());
-
-        const QString base = QFileInfo(pluginSoPath).absolutePath()
-            + QStringLiteral("/") + moduleName
-            + QStringLiteral("_replica_factory");
-        for (const QString& suffix : { QStringLiteral(".dylib"),
-                                       QStringLiteral(".so"),
-                                       QStringLiteral(".dll") }) {
-            const QString factoryPath = base + suffix;
-            if (QFile::exists(factoryPath)) {
-                bridge->setViewReplicaPlugin(moduleName, factoryPath);
-                break;
-            }
-        }
-        loadQmlView(moduleName, installDir, qmlViewPath, bridge, viewHost);
-    };
-
-    auto* timeout = new QTimer(this);
-    timeout->setSingleShot(true);
-    auto readyConn = std::make_shared<QMetaObject::Connection>();
-    auto timeoutConn = std::make_shared<QMetaObject::Connection>();
-    *readyConn = connect(viewHost, &ViewModuleHost::ready, this,
-        [timeout, readyConn, timeoutConn, onHostReady]() {
-            QObject::disconnect(*readyConn);
-            QObject::disconnect(*timeoutConn);
-            timeout->stop();
-            timeout->deleteLater();
-            onHostReady();
-        });
-    *timeoutConn = connect(timeout, &QTimer::timeout, this,
-        [this, moduleName, viewHost, bridge, timeout, readyConn, timeoutConn]() {
-            QObject::disconnect(*readyConn);
-            QObject::disconnect(*timeoutConn);
-            timeout->deleteLater();
-            qWarning() << "Timeout waiting for ui-host ready signal for" << moduleName;
-            viewHost->stop();
-            viewHost->deleteLater();
-            delete bridge;
-            m_loadingQmlModules.remove(moduleName);
-            emit loadingModulesChanged();
-        });
-    timeout->start(30000);
-}
-
 void MainUIBackend::loadLegacyUiModule(const QString& moduleName)
 {
     if (m_pluginLoader->isLoading(moduleName)) {
@@ -644,7 +573,7 @@ void MainUIBackend::loadLegacyUiModule(const QString& moduleName)
 
     PluginLoadRequest request;
     request.name = moduleName;
-    request.isQml = false;
+    request.type = UIPluginType::Legacy;
     request.pluginPath = getPluginPath(moduleName);
     request.iconPath = getPluginIconPath(moduleName, true);
     if (m_uiPluginMetadata.contains(moduleName)) {
@@ -652,65 +581,6 @@ void MainUIBackend::loadLegacyUiModule(const QString& moduleName)
     }
 
     m_pluginLoader->load(request);
-}
-
-void MainUIBackend::loadQmlView(const QString& moduleName,
-                                const QString& installDir,
-                                const QString& qmlViewPath,
-                                LogosQmlBridge* bridge,
-                                ViewModuleHost* viewHost)
-{
-    QQuickWidget* qmlWidget = new QQuickWidget;
-    qmlWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
-    if (QQmlEngine* engine = qmlWidget->engine()) {
-        // Start with Qt's default import/plugin paths so standard Qt QML
-        // modules (QtRemoteObjects, QtQuick.Controls, etc.) remain available.
-        // The sandbox restricts network + filesystem, not Qt APIs.
-        QStringList importPaths = engine->importPathList();
-        importPaths.prepend(installDir);
-        engine->setImportPathList(importPaths);
-
-        // Restrict native plugin search to Qt system paths + the plugin's own
-        // directory so ui_qml views cannot load arbitrary C++ plugins.
-        QStringList pluginPaths = engine->pluginPathList();
-        pluginPaths.prepend(installDir);
-        engine->setPluginPathList(pluginPaths);
-
-        engine->setNetworkAccessManagerFactory(new DenyAllNAMFactory());
-        QStringList allowedRoots; allowedRoots << installDir;
-        engine->addUrlInterceptor(new RestrictedUrlInterceptor(allowedRoots));
-        engine->setBaseUrl(QUrl::fromLocalFile(installDir + "/"));
-    }
-
-    // Reparent the bridge under the widget so its lifetime tracks it.
-    bridge->setParent(qmlWidget);
-    qmlWidget->rootContext()->setContextProperty("logos", bridge);
-    qmlWidget->setSource(QUrl::fromLocalFile(qmlViewPath));
-    qmlWidget->setWindowIcon(QIcon(getPluginIconPath(moduleName, true)));
-
-    if (qmlWidget->status() == QQuickWidget::Error) {
-        qWarning() << "Failed to load ui_qml view" << moduleName;
-        const auto errors = qmlWidget->errors();
-        for (const QQmlError& error : errors) qWarning() << error.toString();
-        qmlWidget->deleteLater();
-        if (viewHost) { viewHost->stop(); delete viewHost; }
-        m_loadingQmlModules.remove(moduleName);
-        emit loadingModulesChanged();
-        return;
-    }
-
-    if (viewHost) m_viewModuleHosts[moduleName] = viewHost;
-    m_qmlPluginWidgets[moduleName] = qmlWidget;
-    m_uiModuleWidgets[moduleName] = qmlWidget;
-    m_loadedApps.insert(moduleName);
-    m_loadingQmlModules.remove(moduleName);
-
-    emit loadingModulesChanged();
-    emit uiModulesChanged();
-    emit launcherAppsChanged();
-    emit pluginWindowRequested(qmlWidget, moduleName);
-    emit navigateToApps();
-    qDebug() << "Successfully loaded ui_qml module:" << moduleName;
 }
 
 bool MainUIBackend::hasBackendPlugin(const QString& name) const

--- a/src/MainUIBackend.h
+++ b/src/MainUIBackend.h
@@ -14,7 +14,7 @@
 class QQuickWidget;
 class PluginLoader;
 class ViewModuleHost;
-class LogosQmlBridge;
+enum class UIPluginType;
 
 class MainUIBackend : public QObject {
     Q_OBJECT
@@ -94,7 +94,8 @@ signals:
 
 private slots:
     void onPluginLoaded(const QString& name, QWidget* widget,
-                        IComponent* component, bool isQml);
+                        IComponent* component, UIPluginType type,
+                        ViewModuleHost* viewHost);
     void onPluginLoadFailed(const QString& name, const QString& error);
 
 private:
@@ -102,21 +103,12 @@ private:
     void subscribeToPackageInstallationEvents();
     void fetchUiPluginMetadata();
     QStringList findAvailableUiPlugins() const;
-    void loadQmlUiModule(const QString& moduleName, const QVariantMap& meta);
     void loadLegacyUiModule(const QString& moduleName);
     QString resolveQmlViewPath(const QVariantMap& meta) const;
     QString getPluginPath(const QString& name) const;
     QString getPluginType(const QString& name) const;
     bool isQmlPlugin(const QString& name) const;
     bool hasBackendPlugin(const QString& name) const;
-    // Load a ui_qml module's QML view in-process via QQuickWidget. The bridge
-    // is reparented under the widget. viewHost is non-null when there is a
-    // backend ui-host whose lifetime should be tied to the widget.
-    void loadQmlView(const QString& moduleName,
-                     const QString& installDir,
-                     const QString& qmlViewPath,
-                     LogosQmlBridge* bridge,
-                     ViewModuleHost* viewHost);
     void updateModuleStats();
     QString getPluginIconPath(const QString& pluginName, bool forWidgetIcon = false) const;
     
@@ -150,6 +142,4 @@ private:
     // View module hosts (process-isolated UI plugins)
     QMap<QString, ViewModuleHost*> m_viewModuleHosts;
 
-    // Tracks ui_qml modules currently being loaded (prevents double-loading)
-    QSet<QString> m_loadingQmlModules;
 };

--- a/src/PluginLoader.cpp
+++ b/src/PluginLoader.cpp
@@ -23,6 +23,7 @@
 #include "logos_api.h"
 #include "restricted/DenyAllNAMFactory.h"
 #include "restricted/RestrictedUrlInterceptor.h"
+#include <ViewModuleHost.h>
 
 extern "C" {
     int logos_core_load_plugin_with_dependencies(const char* plugin_name);
@@ -105,14 +106,17 @@ void PluginLoader::loadCoreDependencies(const PluginLoadRequest& request)
 
 void PluginLoader::continueLoad(const PluginLoadRequest& request)
 {
-    if (request.isQml) {
-        loadQmlPluginAsync(request);
-    } else {
+    switch (request.type) {
+    case UIPluginType::UiQml:
+        loadUiQmlModule(request);
+        break;
+    case UIPluginType::Legacy:
         loadCppPluginAsync(request);
+        break;
     }
 }
 
-// ---------- C++ plugin path ----------
+// ---------- Legacy ui plugin path ----------
 
 void PluginLoader::loadCppPluginAsync(const PluginLoadRequest& request)
 {
@@ -173,60 +177,125 @@ void PluginLoader::finishCppPluginLoad(const PluginLoadRequest& request)
         widget->setWindowIcon(QIcon(request.iconPath));
 
     setLoading(request.name, false);
-    emit pluginLoaded(request.name, widget, component, false);
+    emit pluginLoaded(request.name, widget, component, UIPluginType::Legacy, nullptr);
 }
 
-// ---------- QML plugin path ----------
+// ---------- ui_qml module path ----------
 
-void PluginLoader::loadQmlPluginAsync(const PluginLoadRequest& request)
+void PluginLoader::loadUiQmlModule(const PluginLoadRequest& request)
 {
-    if (!QFile::exists(request.qmlFilePath)) {
-        qWarning() << "QML file not found for plugin" << request.name << ":" << request.qmlFilePath;
+    if (request.qmlViewPath.isEmpty() || !QFile::exists(request.qmlViewPath)) {
+        qWarning() << "ui_qml module QML file not found:" << request.qmlViewPath;
         setLoading(request.name, false);
         emit pluginLoadFailed(request.name,
-            QStringLiteral("QML file not found: ") + request.qmlFilePath);
+            QStringLiteral("QML view file not found: ") + request.qmlViewPath);
         return;
     }
 
-    auto* qmlWidget = new QQuickWidget;
-    qmlWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    auto* bridge = new LogosQmlBridge(m_logosAPI, this);
 
-    QQmlEngine* engine = qmlWidget->engine();
-    if (engine) {
-        QStringList importPaths;
-        importPaths << QStringLiteral("qrc:/qt-project.org/imports");
-        importPaths << QStringLiteral("qrc:/qt/qml");
-        importPaths << request.pluginPath;
-        QString appLibPath = QDir(
-            QCoreApplication::applicationDirPath() + QStringLiteral("/../lib")).absolutePath();
-        if (QDir(appLibPath).exists())
-            importPaths << appLibPath;
-        engine->setImportPathList(importPaths);
-
-        engine->setPluginPathList({});
-
-        engine->setNetworkAccessManagerFactory(new DenyAllNAMFactory());
-        QStringList allowedRoots;
-        allowedRoots << request.pluginPath;
-        engine->addUrlInterceptor(new RestrictedUrlInterceptor(allowedRoots));
-        engine->setBaseUrl(QUrl::fromLocalFile(request.pluginPath + QStringLiteral("/")));
+    if (request.mainFilePath.isEmpty()) {
+        loadQmlView(request, bridge, nullptr);
+        return;
     }
 
-    // Use QQmlComponent::Asynchronous to compile QML in a background thread.
-    // The engine caches compiled types, so the later setSource() will be fast.
-    QUrl sourceUrl = QUrl::fromLocalFile(request.qmlFilePath);
-    auto* preloader = new QQmlComponent(engine, sourceUrl, QQmlComponent::Asynchronous);
+    // Has a backend plugin — spawn a ViewModuleHost process.
+    auto* viewHost = new ViewModuleHost(this);
+    if (!viewHost->spawn(request.name, request.mainFilePath)) {
+        qWarning() << "Failed to spawn ui-host for ui_qml module" << request.name;
+        delete viewHost;
+        delete bridge;
+        setLoading(request.name, false);
+        emit pluginLoadFailed(request.name,
+            QStringLiteral("Failed to spawn ui-host for ") + request.name);
+        return;
+    }
 
-    auto finishOrCleanup = [this, preloader, qmlWidget, request](QQmlComponent::Status status) {
+    auto onHostReady = [this, request, bridge, viewHost]() {
+        bridge->setViewModuleSocket(request.name, viewHost->socketName());
+
+        const QString base = QFileInfo(request.mainFilePath).absolutePath()
+            + QStringLiteral("/") + request.name
+            + QStringLiteral("_replica_factory");
+        for (const QString& suffix : { QStringLiteral(".dylib"),
+                                       QStringLiteral(".so"),
+                                       QStringLiteral(".dll") }) {
+            const QString factoryPath = base + suffix;
+            if (QFile::exists(factoryPath)) {
+                bridge->setViewReplicaPlugin(request.name, factoryPath);
+                break;
+            }
+        }
+        loadQmlView(request, bridge, viewHost);
+    };
+
+    auto* timeout = new QTimer(this);
+    timeout->setSingleShot(true);
+    auto readyConn = std::make_shared<QMetaObject::Connection>();
+    auto timeoutConn = std::make_shared<QMetaObject::Connection>();
+    *readyConn = connect(viewHost, &ViewModuleHost::ready, this,
+        [timeout, readyConn, timeoutConn, onHostReady]() {
+            QObject::disconnect(*readyConn);
+            QObject::disconnect(*timeoutConn);
+            timeout->stop();
+            timeout->deleteLater();
+            onHostReady();
+        });
+    *timeoutConn = connect(timeout, &QTimer::timeout, this,
+        [this, request, viewHost, bridge, timeout, readyConn, timeoutConn]() {
+            QObject::disconnect(*readyConn);
+            QObject::disconnect(*timeoutConn);
+            timeout->deleteLater();
+            qWarning() << "Timeout waiting for ui-host ready signal for" << request.name;
+            viewHost->stop();
+            viewHost->deleteLater();
+            delete bridge;
+            setLoading(request.name, false);
+            emit pluginLoadFailed(request.name,
+                QStringLiteral("Timeout waiting for ui-host for ") + request.name);
+        });
+    timeout->start(30000);
+}
+
+void PluginLoader::loadQmlView(const PluginLoadRequest& request,
+                               LogosQmlBridge* bridge,
+                               ViewModuleHost* viewHost)
+{
+    auto* qmlWidget = new QQuickWidget;
+    qmlWidget->setResizeMode(QQuickWidget::SizeRootObjectToView);
+    if (QQmlEngine* engine = qmlWidget->engine()) {
+        QStringList importPaths = engine->importPathList();
+        importPaths.prepend(request.installDir);
+        engine->setImportPathList(importPaths);
+
+        QStringList pluginPaths = engine->pluginPathList();
+        pluginPaths.prepend(request.installDir);
+        engine->setPluginPathList(pluginPaths);
+
+        engine->setNetworkAccessManagerFactory(new DenyAllNAMFactory());
+        QStringList allowedRoots; allowedRoots << request.installDir;
+        engine->addUrlInterceptor(new RestrictedUrlInterceptor(allowedRoots));
+        engine->setBaseUrl(QUrl::fromLocalFile(request.installDir + "/"));
+    }
+
+    // Async pre-compile: the engine caches compiled types so setSource() is fast.
+    QUrl sourceUrl = QUrl::fromLocalFile(request.qmlViewPath);
+    auto* preloader = new QQmlComponent(qmlWidget->engine(), sourceUrl,
+                                        QQmlComponent::Asynchronous);
+
+    auto finishOrCleanup = [this, preloader, qmlWidget, request, bridge,
+                            viewHost](QQmlComponent::Status status) {
         preloader->deleteLater();
         if (status == QQmlComponent::Ready) {
-            finishQmlPluginLoad(qmlWidget, request);
+            finishUiQmlLoad(qmlWidget, request, bridge, viewHost);
         } else {
             QString errors;
             for (const auto& e : preloader->errors())
                 errors += e.toString() + QStringLiteral("\n");
-            qWarning() << "Failed to compile QML plugin" << request.name << ":" << errors;
+            qWarning() << "Failed to compile ui_qml view" << request.name << ":" << errors;
             qmlWidget->deleteLater();
+            delete bridge;
+            if (viewHost) { viewHost->stop(); delete viewHost; }
             setLoading(request.name, false);
             emit pluginLoadFailed(request.name, errors);
         }
@@ -239,26 +308,30 @@ void PluginLoader::loadQmlPluginAsync(const PluginLoadRequest& request)
     }
 }
 
-void PluginLoader::finishQmlPluginLoad(QQuickWidget* qmlWidget, const PluginLoadRequest& request)
+void PluginLoader::finishUiQmlLoad(QQuickWidget* qmlWidget,
+                                   const PluginLoadRequest& request,
+                                   LogosQmlBridge* bridge,
+                                   ViewModuleHost* viewHost)
 {
-    auto* bridge = new LogosQmlBridge(m_logosAPI, qmlWidget);
+    bridge->setParent(qmlWidget);
     qmlWidget->rootContext()->setContextProperty("logos", bridge);
-    qmlWidget->setSource(QUrl::fromLocalFile(request.qmlFilePath));
+    qmlWidget->setSource(QUrl::fromLocalFile(request.qmlViewPath));
 
     if (!request.iconPath.isEmpty())
         qmlWidget->setWindowIcon(QIcon(request.iconPath));
 
     if (qmlWidget->status() == QQuickWidget::Error) {
-        QString errors;
-        for (const QQmlError& e : qmlWidget->errors())
-            errors += e.toString() + QStringLiteral("\n");
-        qWarning() << "Failed to load QML plugin" << request.name << ":" << errors;
+        qWarning() << "Failed to load ui_qml view" << request.name;
+        const auto errors = qmlWidget->errors();
+        for (const QQmlError& error : errors) qWarning() << error.toString();
         qmlWidget->deleteLater();
+        if (viewHost) { viewHost->stop(); delete viewHost; }
         setLoading(request.name, false);
-        emit pluginLoadFailed(request.name, errors);
+        emit pluginLoadFailed(request.name,
+            QStringLiteral("Failed to load QML view for ") + request.name);
         return;
     }
 
     setLoading(request.name, false);
-    emit pluginLoaded(request.name, qmlWidget, nullptr, true);
+    emit pluginLoaded(request.name, qmlWidget, nullptr, UIPluginType::UiQml, viewHost);
 }

--- a/src/PluginLoader.h
+++ b/src/PluginLoader.h
@@ -10,14 +10,25 @@ class LogosAPI;
 class IComponent;
 class QWidget;
 class QQuickWidget;
+class ViewModuleHost;
+class LogosQmlBridge;
+
+enum class UIPluginType {
+    Legacy,
+    UiQml
+};
 
 struct PluginLoadRequest {
     QString name;
+    UIPluginType type = UIPluginType::Legacy;
     QString pluginPath;
-    QString qmlFilePath;
-    bool isQml = false;
     QString iconPath;
     QVariantList coreDependencies;
+
+    // ui_qml module fields
+    QString installDir;      // Module install directory (import paths root)
+    QString qmlViewPath;     // Resolved QML view entry point
+    QString mainFilePath;    // Backend plugin .so/.dylib path (empty if QML-only)
 };
 
 class PluginLoader : public QObject {
@@ -33,7 +44,8 @@ public:
 
 signals:
     void pluginLoaded(const QString& name, QWidget* widget,
-                      IComponent* component, bool isQml);
+                      IComponent* component, UIPluginType type,
+                      ViewModuleHost* viewHost);
     void pluginLoadFailed(const QString& name, const QString& error);
     void loadingChanged();
 
@@ -41,10 +53,20 @@ private:
     void startLoad(const PluginLoadRequest& request);
     void loadCoreDependencies(const PluginLoadRequest& request);
     void continueLoad(const PluginLoadRequest& request);
+
+    // legacy ui module loading
     void loadCppPluginAsync(const PluginLoadRequest& request);
-    void loadQmlPluginAsync(const PluginLoadRequest& request);
     void finishCppPluginLoad(const PluginLoadRequest& request);
-    void finishQmlPluginLoad(QQuickWidget* widget, const PluginLoadRequest& request);
+
+    // ui_qml module loading
+    void loadUiQmlModule(const PluginLoadRequest& request);
+    void loadQmlView(const PluginLoadRequest& request,
+                     LogosQmlBridge* bridge,
+                     ViewModuleHost* viewHost);
+    void finishUiQmlLoad(QQuickWidget* qmlWidget,
+                         const PluginLoadRequest& request,
+                         LogosQmlBridge* bridge,
+                         ViewModuleHost* viewHost);
 
     void setLoading(const QString& name, bool loading);
 


### PR DESCRIPTION
Move the new `ui_qml` plugin loading flow into PluginLoader.

This also fixes a bug where `ui_qml` plugins didn't load the core module dependencies.