### PR TITLE
write console output to files

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -125,6 +125,8 @@ set(PROJECT_SOURCES
     main.cpp
     window.h
     window.cpp
+    utils/LogRedirector.h
+    utils/LogRedirector.cpp
     macos/trafficLightsTitleBar.h
     macos/trafficLightsTitleBar.cpp
     macos/macWindowStyle.h

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -3,6 +3,7 @@
 #include "token_manager.h"
 #include "logos_mode.h"
 #include "LogosBasecampPaths.h"
+#include "LogRedirector.h"
 #ifdef ENABLE_QML_INSPECTOR
 #include "inspectorserver.h"
 #endif
@@ -57,6 +58,13 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
     app.setOrganizationName("Logos");
     app.setApplicationName("LogosBasecamp");
+
+    // Redirect stdout/stderr to a rotating per-session log file under
+    // <baseDirectory>/logs. Must happen after setOrganizationName/setApplicationName
+    // so baseDirectory() resolves to the right location. Terminal output is
+    // preserved by mirroring to the original stdout.
+    LogosBasecampLog::LogRedirector::instance().start(
+        LogosBasecampPaths::logsDirectory());
 
     // Set up module directories for logos core.
     // 1. Embedded modules directory (pre-installed at build time, read-only)
@@ -174,6 +182,9 @@ int main(int argc, char *argv[])
 
     // Cleanup logos core (plugins, modules, etc.)
     logos_core_cleanup();
+
+    // Flush final output, restore original stdout/stderr, and close the log file.
+    LogosBasecampLog::LogRedirector::instance().stop();
 
     return result;
 }

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -63,8 +63,11 @@ int main(int argc, char *argv[])
     // <baseDirectory>/logs. Must happen after setOrganizationName/setApplicationName
     // so baseDirectory() resolves to the right location. Terminal output is
     // preserved by mirroring to the original stdout.
-    LogosBasecampLog::LogRedirector::instance().start(
-        LogosBasecampPaths::logsDirectory());
+    const QString logsDir = LogosBasecampPaths::logsDirectory();
+    if (!LogosBasecampLog::LogRedirector::instance().start(logsDir)) {
+        qWarning() << "Failed to start log redirection; continuing without file logs."
+                   << "Logs directory:" << logsDir;
+    }
 
     // Set up module directories for logos core.
     // 1. Embedded modules directory (pre-installed at build time, read-only)

--- a/app/utils/LogRedirector.cpp
+++ b/app/utils/LogRedirector.cpp
@@ -1,0 +1,201 @@
+#include "LogRedirector.h"
+
+#include <QDateTime>
+#include <QDir>
+
+#include <cerrno>
+#include <cstdio>
+
+#if !defined(Q_OS_WIN)
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
+
+namespace LogosBasecampLog {
+
+LogRedirector& LogRedirector::instance()
+{
+    static LogRedirector s;
+    return s;
+}
+
+LogRedirector::~LogRedirector()
+{
+    stop();
+}
+
+#if defined(Q_OS_WIN)
+
+bool LogRedirector::start(const QString&, int) { return false; }
+void LogRedirector::stop() {}
+void LogRedirector::readerLoop() {}
+void LogRedirector::openNewFile() {}
+
+#else
+
+bool LogRedirector::start(const QString& logsDir, int maxLinesPerFile)
+{
+    if (m_started)
+        return true;
+    if (maxLinesPerFile <= 0)
+        maxLinesPerFile = 10000;
+
+    m_logsDir = logsDir;
+    m_maxLinesPerFile = maxLinesPerFile;
+
+    if (!QDir().mkpath(m_logsDir))
+        return false;
+
+    m_sessionStamp = QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss");
+    m_rotationIndex = 0;
+    m_linesInCurrentFile = 0;
+
+    openNewFile();
+    if (!m_currentFile || !m_currentFile->isOpen())
+        return false;
+
+    m_originalStdout = ::dup(fileno(stdout));
+    m_originalStderr = ::dup(fileno(stderr));
+
+    int fds[2];
+    if (::pipe(fds) != 0)
+        return false;
+
+    std::fflush(stdout);
+    std::fflush(stderr);
+
+    if (::dup2(fds[1], fileno(stdout)) == -1 ||
+        ::dup2(fds[1], fileno(stderr)) == -1) {
+        ::close(fds[0]);
+        ::close(fds[1]);
+        return false;
+    }
+
+    // Line-buffer so each line is forwarded through the pipe promptly, even
+    // when stdout is not attached to a terminal.
+    std::setvbuf(stdout, nullptr, _IOLBF, 0);
+    std::setvbuf(stderr, nullptr, _IOLBF, 0);
+
+    ::close(fds[1]);
+    m_readFd = fds[0];
+
+    m_running = true;
+    m_readerThread = std::thread(&LogRedirector::readerLoop, this);
+    m_started = true;
+    return true;
+}
+
+void LogRedirector::stop()
+{
+    if (!m_started)
+        return;
+    m_running = false;
+
+    std::fflush(stdout);
+    std::fflush(stderr);
+
+    // Restoring via dup2 closes the previous target fd, i.e. the pipe's
+    // write end held by stdout/stderr. Once both are restored, the reader
+    // thread sees EOF on the read end and exits.
+    if (m_originalStdout >= 0) {
+        ::dup2(m_originalStdout, fileno(stdout));
+        ::close(m_originalStdout);
+        m_originalStdout = -1;
+    }
+    if (m_originalStderr >= 0) {
+        ::dup2(m_originalStderr, fileno(stderr));
+        ::close(m_originalStderr);
+        m_originalStderr = -1;
+    }
+
+    if (m_readerThread.joinable())
+        m_readerThread.join();
+
+    if (m_readFd >= 0) {
+        ::close(m_readFd);
+        m_readFd = -1;
+    }
+    if (m_currentFile) {
+        m_currentFile->flush();
+        m_currentFile->close();
+        m_currentFile.reset();
+    }
+    m_started = false;
+}
+
+void LogRedirector::openNewFile()
+{
+    QString name;
+    if (m_rotationIndex == 0) {
+        name = QStringLiteral("basecamp_%1.log").arg(m_sessionStamp);
+    } else {
+        name = QStringLiteral("basecamp_%1.%2.log")
+                   .arg(m_sessionStamp)
+                   .arg(m_rotationIndex, 3, 10, QChar('0'));
+    }
+
+    auto f = std::make_unique<QFile>(m_logsDir + QStringLiteral("/") + name);
+    if (!f->open(QIODevice::WriteOnly | QIODevice::Append | QIODevice::Text)) {
+        m_currentFile.reset();
+        return;
+    }
+    m_currentFile = std::move(f);
+    m_linesInCurrentFile = 0;
+    ++m_rotationIndex;
+}
+
+void LogRedirector::readerLoop()
+{
+    char buf[4096];
+    while (true) {
+        ssize_t n = ::read(m_readFd, buf, sizeof(buf));
+        if (n < 0) {
+            if (errno == EINTR)
+                continue;
+            break;
+        }
+        if (n == 0)
+            break; // EOF: all writers (stdout/stderr replacements) are gone.
+
+        // Mirror to the original stdout so an attached terminal keeps seeing
+        // output. Failures here are ignored (e.g. stdout was /dev/null).
+        if (m_originalStdout >= 0) {
+            ssize_t off = 0;
+            while (off < n) {
+                ssize_t w = ::write(m_originalStdout, buf + off, n - off);
+                if (w < 0) {
+                    if (errno == EINTR)
+                        continue;
+                    break;
+                }
+                off += w;
+            }
+        }
+
+        if (!m_currentFile)
+            continue;
+
+        ssize_t start = 0;
+        for (ssize_t i = 0; i < n; ++i) {
+            if (buf[i] != '\n')
+                continue;
+            m_currentFile->write(buf + start, i - start + 1);
+            ++m_linesInCurrentFile;
+            start = i + 1;
+            if (m_linesInCurrentFile >= m_maxLinesPerFile) {
+                m_currentFile->flush();
+                m_currentFile->close();
+                openNewFile();
+                if (!m_currentFile)
+                    return; // Rotation failed; stop writing to files.
+            }
+        }
+        if (start < n && m_currentFile)
+            m_currentFile->write(buf + start, n - start);
+        m_currentFile->flush();
+    }
+}
+
+#endif // Q_OS_WIN
+
+} // namespace LogosBasecampLog

--- a/app/utils/LogRedirector.cpp
+++ b/app/utils/LogRedirector.cpp
@@ -50,16 +50,33 @@ bool LogRedirector::start(const QString& logsDir, int maxLinesPerFile)
     m_rotationIndex = 0;
     m_linesInCurrentFile = 0;
 
+    auto cleanup = [this]() {
+        if (m_originalStdout >= 0) { ::close(m_originalStdout); m_originalStdout = -1; }
+        if (m_originalStderr >= 0) { ::close(m_originalStderr); m_originalStderr = -1; }
+        if (m_currentFile) {
+            m_currentFile->close();
+            m_currentFile.reset();
+        }
+    };
+
     openNewFile();
-    if (!m_currentFile || !m_currentFile->isOpen())
+    if (!m_currentFile || !m_currentFile->isOpen()) {
+        cleanup();
         return false;
+    }
 
     m_originalStdout = ::dup(fileno(stdout));
     m_originalStderr = ::dup(fileno(stderr));
+    if (m_originalStdout < 0 || m_originalStderr < 0) {
+        cleanup();
+        return false;
+    }
 
     int fds[2];
-    if (::pipe(fds) != 0)
+    if (::pipe(fds) != 0) {
+        cleanup();
         return false;
+    }
 
     std::fflush(stdout);
     std::fflush(stderr);
@@ -68,6 +85,7 @@ bool LogRedirector::start(const QString& logsDir, int maxLinesPerFile)
         ::dup2(fds[1], fileno(stderr)) == -1) {
         ::close(fds[0]);
         ::close(fds[1]);
+        cleanup();
         return false;
     }
 
@@ -96,20 +114,20 @@ void LogRedirector::stop()
 
     // Restoring via dup2 closes the previous target fd, i.e. the pipe's
     // write end held by stdout/stderr. Once both are restored, the reader
-    // thread sees EOF on the read end and exits.
-    if (m_originalStdout >= 0) {
+    // thread sees EOF on the read end and exits. Keep the duplicated
+    // originals open until after the reader thread has finished, since
+    // readerLoop() may still be writing to m_originalStdout — closing it
+    // concurrently could race with fd-number reuse.
+    if (m_originalStdout >= 0)
         ::dup2(m_originalStdout, fileno(stdout));
-        ::close(m_originalStdout);
-        m_originalStdout = -1;
-    }
-    if (m_originalStderr >= 0) {
+    if (m_originalStderr >= 0)
         ::dup2(m_originalStderr, fileno(stderr));
-        ::close(m_originalStderr);
-        m_originalStderr = -1;
-    }
 
     if (m_readerThread.joinable())
         m_readerThread.join();
+
+    if (m_originalStdout >= 0) { ::close(m_originalStdout); m_originalStdout = -1; }
+    if (m_originalStderr >= 0) { ::close(m_originalStderr); m_originalStderr = -1; }
 
     if (m_readFd >= 0) {
         ::close(m_readFd);
@@ -192,8 +210,10 @@ void LogRedirector::readerLoop()
         }
         if (start < n && m_currentFile)
             m_currentFile->write(buf + start, n - start);
-        m_currentFile->flush();
     }
+
+    if (m_currentFile)
+        m_currentFile->flush();
 }
 
 #endif // Q_OS_WIN

--- a/app/utils/LogRedirector.h
+++ b/app/utils/LogRedirector.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <QString>
+#include <QFile>
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace LogosBasecampLog {
+
+// Captures the process stdout/stderr into rotating log files under a given
+// directory. One file per session (named basecamp_YYYYMMDD_HHMMSS.log); when
+// the current file hits maxLinesPerFile, a suffixed rotation file is opened
+// (basecamp_YYYYMMDD_HHMMSS.001.log, .002.log, ...).
+//
+// Implementation: replaces stdout/stderr with the write-end of a pipe via
+// dup2(); a background reader thread reads from the pipe, writes to the
+// current log file (counting newlines for rotation) and mirrors bytes to the
+// original stdout so a terminal attached at launch still sees output.
+//
+// POSIX-only (macOS/Linux). On other platforms start() is a no-op.
+class LogRedirector
+{
+public:
+    static LogRedirector& instance();
+
+    // Start capture. Safe to call once; subsequent calls are no-ops.
+    // Returns false if redirection could not be set up.
+    bool start(const QString& logsDir, int maxLinesPerFile = 10000);
+
+    // Flush, restore original stdout/stderr, join reader thread, close files.
+    void stop();
+
+    LogRedirector(const LogRedirector&) = delete;
+    LogRedirector& operator=(const LogRedirector&) = delete;
+
+private:
+    LogRedirector() = default;
+    ~LogRedirector();
+
+    void readerLoop();
+    void openNewFile();
+
+    QString m_logsDir;
+    QString m_sessionStamp;
+    int m_maxLinesPerFile = 10000;
+    int m_rotationIndex = 0;
+    int m_linesInCurrentFile = 0;
+
+    std::unique_ptr<QFile> m_currentFile;
+
+    int m_readFd = -1;
+    int m_originalStdout = -1;
+    int m_originalStderr = -1;
+
+    std::thread m_readerThread;
+    std::atomic<bool> m_running{false};
+    bool m_started = false;
+};
+
+} // namespace LogosBasecampLog

--- a/app/utils/LogosBasecampPaths.h
+++ b/app/utils/LogosBasecampPaths.h
@@ -63,6 +63,12 @@ inline QString moduleDataDirectory()
     return baseDirectory() + "/module_data";
 }
 
+// Directory for app log files (stdout/stderr capture, rotated per session).
+inline QString logsDirectory()
+{
+    return baseDirectory() + "/logs";
+}
+
 // Embedded directories — read-only, pre-installed at build time alongside the binary.
 inline QString embeddedModulesDirectory()
 {

--- a/flake.lock
+++ b/flake.lock
@@ -1496,11 +1496,11 @@
         "process-stats": "process-stats_3"
       },
       "locked": {
-        "lastModified": 1776379599,
-        "narHash": "sha256-F2udDQNt9LMsvVTJ+lEh7kFGWI1WYe1xUcReJAakdLY=",
+        "lastModified": 1776713240,
+        "narHash": "sha256-IZhem7N47dKOYcArZ5bC6A6/Ro72e9wHAyQ173TwHKM=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "e96b05b657a7871be85842e559c2635eef5c31a1",
+        "rev": "5c01d968ceb6561042d546623beed2ddda99ca5d",
         "type": "github"
       },
       "original": {
@@ -1705,11 +1705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776372591,
-        "narHash": "sha256-uuY3FvSbWF11DR7JO9jyMDV25fLJoxT9TpDW7l/BngM=",
+        "lastModified": 1776431480,
+        "narHash": "sha256-QMdoBJfwQzXemrGKiWPGY797DQ6aH/NuzK0T2SNP+ho=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "e14aaa89f9ef652daf201cfaf3d06817ac8a440e",
+        "rev": "1247e5c0cc8823a75412e82b2c1ff2409bb1eacd",
         "type": "github"
       },
       "original": {
@@ -11021,11 +11021,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776372380,
-        "narHash": "sha256-kleKGfcRgtIjeltogH0NCFrp5QwetlXsHJxOTllP13E=",
+        "lastModified": 1776431432,
+        "narHash": "sha256-eO1nnUS33OUkdU36I27OJ0wVcFxRFkJDVuRYT6WKzy8=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "5e122402898c1d896cc6b72db04c6277697a2f2f",
+        "rev": "09461edcaa1c617f813120124655c37f803e3a17",
         "type": "github"
       },
       "original": {
@@ -11394,11 +11394,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776372308,
+        "lastModified": 1776431382,
         "narHash": "sha256-21SqqdOuHBLUGcYxGvjtC4iKp+wLGEQOKn64qLVl/+0=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "5dc32e0131e9abf0a86c085119aa082d56486d9e",
+        "rev": "d611d697bf4ff48405d71f6ea29b8103d7969b22",
         "type": "github"
       },
       "original": {
@@ -11513,11 +11513,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776372308,
+        "lastModified": 1776431382,
         "narHash": "sha256-21SqqdOuHBLUGcYxGvjtC4iKp+wLGEQOKn64qLVl/+0=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "5dc32e0131e9abf0a86c085119aa082d56486d9e",
+        "rev": "d611d697bf4ff48405d71f6ea29b8103d7969b22",
         "type": "github"
       },
       "original": {
@@ -11951,11 +11951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776108405,
-        "narHash": "sha256-5EpWcHvJNBDGtVr2oLIRw0KxKObEDxqNMF5IXO6J1to=",
+        "lastModified": 1776458016,
+        "narHash": "sha256-yIFmtVps0SfxusidPT5s5pAJxTODWhWv69UwzDwEDGM=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "e42556310f52fd7080bd3af838c7102d231da17d",
+        "rev": "14111ea314b9f40aff3e4c54816e6ee9680d962f",
         "type": "github"
       },
       "original": {
@@ -13682,11 +13682,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776108083,
-        "narHash": "sha256-gGmOUYksc/Gnso7dHGQ1DoB9QKsBGjQ/WUIHKqBbvuM=",
+        "lastModified": 1776457964,
+        "narHash": "sha256-hSwyWA3ufUhrLy9cmuIbKl4s+mvZmcMqjD/pRx1d6sc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "0dc73e8ec027420c55f6d8d7236c6adb8d68a159",
+        "rev": "061a9a830afaf23bb85d13fac673a6bb97edb2e2",
         "type": "github"
       },
       "original": {
@@ -13705,11 +13705,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776108083,
-        "narHash": "sha256-gGmOUYksc/Gnso7dHGQ1DoB9QKsBGjQ/WUIHKqBbvuM=",
+        "lastModified": 1776457964,
+        "narHash": "sha256-hSwyWA3ufUhrLy9cmuIbKl4s+mvZmcMqjD/pRx1d6sc=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "0dc73e8ec027420c55f6d8d7236c6adb8d68a159",
+        "rev": "061a9a830afaf23bb85d13fac673a6bb97edb2e2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
logsDirectory() added under baseDirectory()/logs.

New LogRedirector (POSIX-only, no-op on Windows): replaces stdout/stderr with the write end of a pipe() via dup2(). 

A background thread reads from the pipe, counts newlines, writes to the current log file, and mirrors bytes to the original stdout so an attached terminal still sees output.

Files named basecamp_YYYYMMDD_HHMMSS.log; on hitting maxLinesPerFile (default 10000) it rotates to basecamp_YYYYMMDD_HHMMSS.001.log, .002.log, …

Wired in main.cpp:66 right after setOrganizationName/setApplicationName (so baseDirectory() resolves correctly), and stopped after logos_core_cleanup() to flush and restore fds.

std::cout, std::cerr, printf, Qt's default handler (qDebug/qInfo/qWarning), and any child process that inherits these fds all land in the log file.