### PR TITLE
fix: defer unloadUiModule and sidebar launch to prevent derefWindow c…

### DIFF
--- a/src/MainContainer.cpp
+++ b/src/MainContainer.cpp
@@ -51,11 +51,22 @@ MainContainer::MainContainer(LogosAPI* logosAPI, QWidget* parent)
     connect(m_mdiView, &MdiView::pluginWindowClosed,
             m_backend, &MainUIBackend::onPluginWindowClosed);
 
-    // Connect to QML signals from SidebarPanel
+    // Connect to QML signals from SidebarPanel.
+    //
+    // launchUIModule uses QueuedConnection — the signal is emitted from a
+    // SidebarAppDelegate.onClicked handler inside a Repeater delegate.
+    // onAppLauncherClicked calls setCurrentVisibleApp which synchronously
+    // emits launcherAppsChanged, causing both sidebar Repeaters to reset
+    // their models. If the connection were direct the Repeater would call
+    // setParentItem(nullptr) on the clicked delegate while its click handler
+    // is still on the call stack, leading to a null deref in
+    // QQuickItemPrivate::derefWindow. Queuing the call lets the click handler
+    // return before any Repeater model update fires.
     QObject* sidebarRoot = m_sidebarWidget->rootObject();
     if (sidebarRoot) {
         connect(sidebarRoot, SIGNAL(launchUIModule(QString)),
-                m_backend, SLOT(onAppLauncherClicked(QString)));
+                m_backend, SLOT(onAppLauncherClicked(QString)),
+                Qt::QueuedConnection);
         connect(sidebarRoot, SIGNAL(updateLauncherIndex(int)),
                 m_backend, SLOT(setCurrentActiveSectionIndex(int)));
     }

--- a/src/UIPluginManager.cpp
+++ b/src/UIPluginManager.cpp
@@ -214,6 +214,32 @@ QStringList UIPluginManager::loadingModules() const
 
 void UIPluginManager::unloadUiModule(const QString& moduleName)
 {
+    if (m_shuttingDown) {
+        // Shutdown path: run synchronously — no QML signal handler is on
+        // the stack and we need the teardown to complete before Qt child
+        // destruction continues. The cascade guard below skips when
+        // m_shuttingDown is true, so this goes straight to teardown.
+        unloadUiModuleImpl(moduleName);
+        return;
+    }
+
+    // Normal path: defer the whole body — same rationale as loadCoreModule /
+    // unloadCoreModule. This slot is invoked from a QML Button.onClicked handler
+    // inside a Repeater delegate (e.g. UiModulesTab "Unload Plugin" button).
+    // Emitting uiModulesChanged() synchronously causes Repeater.setModel to fire,
+    // which calls clear() → setParentItem(nullptr) on every delegate, including
+    // the button that was just clicked. QQuickItemPrivate::derefWindow then
+    // crashes trying to walk that button's child tree while the window pointer
+    // on one of its children is already null.
+    // Deferring via QueuedConnection lets the click handler fully unwind first;
+    // by the time the lambda runs the Repeater delegate tree is stable again.
+    QMetaObject::invokeMethod(this, [this, moduleName]{
+        unloadUiModuleImpl(moduleName);
+    }, Qt::QueuedConnection);
+}
+
+void UIPluginManager::unloadUiModuleImpl(const QString& moduleName)
+{
     qDebug() << "Unloading UI module:" << moduleName;
 
     bool isQml = m_qmlPluginWidgets.contains(moduleName);
@@ -513,11 +539,11 @@ void UIPluginManager::confirmUnloadCascade(const QString& moduleName)
         }
 
         // The UI widget for the target itself still needs to be unloaded.
-        // Re-enter the normal path — m_pendingUnload is inactive, so the
-        // guard won't re-trigger. unloadUiModule itself defers to the next
-        // tick internally too, which is fine: the widget teardown just
-        // lands one more tick later.
-        unloadUiModule(moduleName);
+        // We're already inside a QueuedConnection lambda so the original
+        // click handler has returned — call the impl directly instead of
+        // scheduling another async hop. m_pendingUnload is inactive so the
+        // cascade guard in unloadUiModuleImpl won't re-trigger.
+        unloadUiModuleImpl(moduleName);
 
         // Stats may have shifted; the deferred-emit block that followed
         // below handles the QML-notification side.

--- a/src/UIPluginManager.h
+++ b/src/UIPluginManager.h
@@ -174,6 +174,11 @@ private:
     QStringList loadedCorePlugins() const;
     QStringList loadedDependentsOf(const QString& name) const;
 
+    // Synchronous unload implementation — called directly from the shutdown
+    // path and from the QueuedConnection lambda in unloadUiModule. Never call
+    // this from a live QML signal handler; use unloadUiModule() instead.
+    void unloadUiModuleImpl(const QString& moduleName);
+
     // Wiring
     LogosAPI*          m_logosAPI;          // not owned
     CoreModuleManager* m_coreModuleManager; // not owned (sibling Qt child)


### PR DESCRIPTION
…rash

When a QML Button inside a Repeater delegate calls backend.unloadUiModule() or root.launchUIModule(), the backend emits uiModulesChanged / launcherAppsChanged synchronously. This causes QQuickRepeater::setModel to fire, which calls clear() → setParentItem(nullptr) on every delegate including the one whose click handler is still on the call stack. QQuickItemPrivate::derefWindow then crashes trying to walk the button's child item tree while the window pointer on one of those children is null (SIGSEGV, EXC_BAD_ACCESS at 0x0).

Two fixes:

1. UIPluginManager::unloadUiModule — extract body into unloadUiModuleImpl and wrap the normal (non-shutdown) path in QMetaObject::invokeMethod with Qt::QueuedConnection, matching the existing pattern in loadCoreModule / unloadCoreModule. confirmUnloadCascade already defers via QueuedConnection so its internal call is updated to call unloadUiModuleImpl directly.

2. MainContainer — change the SidebarPanel.launchUIModule → onAppLauncherClicked connection from AutoConnection to QueuedConnection. setCurrentVisibleApp inside onAppLauncherClicked emits launcherAppsChanged synchronously, which resets both sidebar Repeaters while the clicked SidebarAppDelegate's onClicked is on the call stack.