### PR TITLE
add Wayland platform plugin support on Linux

### DIFF
--- a/nix/app.nix
+++ b/nix/app.nix
@@ -19,8 +19,8 @@ pkgs.stdenv.mkDerivation rec {
     pkgs.qt6.qtdeclarative
   ] ++ (
     if pkgs.stdenv.isLinux then
-      # Linux: WebKitGTK as backend
-      [ webkitgtk ]
+      # Linux: WebKitGTK as backend + Wayland platform plugin
+      [ webkitgtk pkgs.qt6.qtwayland ]
     else
       []
   );
@@ -56,9 +56,16 @@ pkgs.stdenv.mkDerivation rec {
       pkgs.xorg.libXi
       pkgs.xorg.libXfixes
       pkgs.xorg.libxcb
+      pkgs.qt6.qtwayland
     ]
   );
-  qtPluginPath = "${pkgs.qt6.qtbase}/lib/qt-6/plugins:${pkgs.qt6.qtwebview}/lib/qt-6/plugins:${pkgs.qt6.qtsvg}/lib/qt-6/plugins";
+  qtPluginPath = pkgs.lib.concatStringsSep ":" ([
+    "${pkgs.qt6.qtbase}/lib/qt-6/plugins"
+    "${pkgs.qt6.qtwebview}/lib/qt-6/plugins"
+    "${pkgs.qt6.qtsvg}/lib/qt-6/plugins"
+  ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+    "${pkgs.qt6.qtwayland}/lib/qt-6/plugins"
+  ]);
   qmlImportPath = "${placeholder "out"}/lib:${pkgs.qt6.qtdeclarative}/lib/qt-6/qml:${pkgs.qt6.qtwebview}/lib/qt-6/qml:${pkgs.qt6.qtsvg}/lib/qt-6/qml";
 
   preConfigure = ''

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -13,6 +13,11 @@ export QML2_IMPORT_PATH="$QML_UI/qml:$QML_UI:$QML2_IMPORT_PATH"
 export QML_DISABLE_DISK_CACHE=1
 export QML_NO_CACHE=1
 
+# If running on Wayland and QT_QPA_PLATFORM is not set explicitly, use wayland
+if [ -S "/run/user/$(id -u)/wayland-0" ] && [ -z "$QT_QPA_PLATFORM" ]; then
+    export QT_QPA_PLATFORM=wayland
+fi
+
 # Add design system to import path if available
 if [ -n "$LOGOS_DESIGN_SYSTEM_ROOT" ]; then
     # Use design system from environment variable (typically from nix shell)


### PR DESCRIPTION
## Summary

Adds the Qt Wayland platform plugin so the app runs natively on Wayland compositors instead of falling back to XWayland.

## Changes

- **`nix/app.nix`**: adds `qt6.qtwayland` as a build and runtime dependency on Linux, and includes its plugin directory in `QT_PLUGIN_PATH`
- **`run-dev.sh`**: auto-detects a running Wayland compositor via the `wayland-0` socket and sets `QT_QPA_PLATFORM=wayland` if not already set explicitly

## Notes

To force X11/XWayland in dev mode: `QT_QPA_PLATFORM=xcb ./run-dev.sh`
