### PR TITLE
T3: example skin manifests for detached sidebar prototype

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -51,6 +51,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/interfaces)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/utils)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/macos)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/windowdecorations)
 # Auto-generated build info header (dropped in by nix/app.nix); absent in
 # non-nix builds — main.cpp guards the include with __has_include.
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/generated)
@@ -132,6 +133,8 @@ set(PROJECT_SOURCES
     utils/LogRedirector.cpp
     macos/trafficLightsTitleBar.h
     macos/trafficLightsTitleBar.cpp
+    windowdecorations/TrafficLightsTitleBar.h\
+    windowdecorations/TrafficLightsTitleBar.cpp
     macos/macWindowStyle.h
     interfaces/IComponent.h
     resources.qrc

--- a/app/windowdecorations/TrafficLightsTitleBar.cpp
+++ b/app/windowdecorations/TrafficLightsTitleBar.cpp
@@ -1,0 +1,263 @@
+#include "TrafficLightsTitleBar.h"
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QWindow>
+#include <QIcon>
+#include <QApplication>
+#include <QMainWindow>
+
+QPushButton* makeTrafficButton(const QString& colorHex, const QString& borderHex, int size, QWidget* parent) {
+    auto* btn = new QPushButton(parent);
+    btn->setFixedSize(size, size);
+    btn->setCursor(Qt::ArrowCursor);
+    btn->setFlat(true);
+    btn->setStyleSheet(
+        QString("QPushButton {"
+                "  background-color: %1;"
+                "  border: 0.5px solid %2;"
+                "  border-radius: %3px;"
+                "}"
+                "QPushButton:hover { background-color: %1; }"
+                "QPushButton:pressed { background-color: %1; }")
+            .arg(colorHex, borderHex)
+            .arg(size / 2));
+    return btn;
+}
+
+TrafficLightsTitleBar::TrafficLightsTitleBar(QWidget* parent) : QWidget(parent) {
+    setFixedHeight(kTitleBarHeight);
+    setCursor(Qt::ArrowCursor);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+    setAttribute(Qt::WA_TranslucentBackground);
+    setAttribute(Qt::WA_NoSystemBackground);
+    setAutoFillBackground(false);
+    
+    setMouseTracking(true);
+    setAttribute(Qt::WA_Hover);
+
+    auto* layout = new QHBoxLayout(this);
+    layout->setContentsMargins(kLeftMargin, kTopMargin, 0, 0);
+    layout->setSpacing(kButtonSpacing);
+
+    m_closeBtn = makeTrafficButton("#FF5F57", "#E0443E", kButtonSize, this);
+    layout->addWidget(m_closeBtn);
+
+    m_minBtn = makeTrafficButton("#FEBC2E", "#DE9E24", kButtonSize, this);
+    layout->addWidget(m_minBtn);
+
+    m_zoomBtn = makeTrafficButton("#28C840", "#1AAC37", kButtonSize, this);
+    layout->addWidget(m_zoomBtn);
+
+    layout->addStretch(1);
+
+    connect(m_closeBtn, &QPushButton::clicked, this, [this]() { window()->hide(); });
+    connect(m_minBtn, &QPushButton::clicked, this, [this]() { window()->showMinimized(); });
+    connect(m_zoomBtn, &QPushButton::clicked, this, [this]() {
+        QWidget* w = window();
+        if (w->windowState() & Qt::WindowFullScreen)
+            w->setWindowState(Qt::WindowNoState);
+        else
+            w->setWindowState(Qt::WindowFullScreen);
+    });
+
+    m_closeBtn->installEventFilter(this);
+    m_minBtn->installEventFilter(this);
+    m_zoomBtn->installEventFilter(this);
+}
+
+bool TrafficLightsTitleBar::isOverButton(const QPoint& pos) const {
+    if (m_closeBtn && m_closeBtn->isVisible() && m_closeBtn->geometry().contains(pos)) {
+        return true;
+    }
+    if (m_minBtn && m_minBtn->isVisible() && m_minBtn->geometry().contains(pos)) {
+        return true;
+    }
+    if (m_zoomBtn && m_zoomBtn->isVisible() && m_zoomBtn->geometry().contains(pos)) {
+        return true;
+    }
+    return false;
+}
+
+void TrafficLightsTitleBar::setButtonIcon(QPushButton* btn, const QString& iconPath) {
+    if (!btn) return;
+    const QSize iconSize(6, 6);
+    btn->setIcon(QIcon(iconPath));
+    btn->setIconSize(iconSize);
+}
+
+void TrafficLightsTitleBar::setAllButtonIcons() {
+    setButtonIcon(m_closeBtn, ":/icons/trafficlights/close.png");
+    setButtonIcon(m_minBtn, ":/icons/trafficlights/minimise.png");
+    setButtonIcon(m_zoomBtn, ":/icons/trafficlights/maximize.png");
+}
+
+void TrafficLightsTitleBar::clearAllButtonIcons() {
+    if (m_closeBtn) m_closeBtn->setIcon(QIcon());
+    if (m_minBtn) m_minBtn->setIcon(QIcon());
+    if (m_zoomBtn) m_zoomBtn->setIcon(QIcon());
+}
+
+void TrafficLightsTitleBar::leaveEvent(QEvent* e) {
+    QWidget::leaveEvent(e);
+    clearAllButtonIcons();
+}
+
+bool TrafficLightsTitleBar::eventFilter(QObject* watched, QEvent* event) {
+    if (event->type() == QEvent::Enter) {
+        if (watched == m_closeBtn || watched == m_minBtn || watched == m_zoomBtn) {
+            setAllButtonIcons();
+        }
+    } else if (event->type() == QEvent::Leave) {
+        if (watched == m_closeBtn || watched == m_minBtn || watched == m_zoomBtn) {
+            clearAllButtonIcons();
+        }
+    }
+    return QWidget::eventFilter(watched, event);
+}
+
+void TrafficLightsTitleBar::forwardEventToCentralWidget(QMouseEvent* e) {
+    QMainWindow* mainWindow = qobject_cast<QMainWindow*>(window());
+    if (!mainWindow) return;
+    
+    QWidget* centralWidget = mainWindow->centralWidget();
+    if (!centralWidget) return;
+    
+    // Map coordinates from title bar space to central widget space
+    QPoint globalPos = mapToGlobal(e->pos());
+    QPoint centralPos = centralWidget->mapFromGlobal(globalPos);
+    
+    // Check if the position is within central widget bounds
+    if (!centralWidget->rect().contains(centralPos)) return;
+    
+    // Find the actual child widget at this position
+    QWidget* targetWidget = centralWidget->childAt(centralPos);
+    if (!targetWidget) {
+        // No specific child at this position, send to central widget itself
+        targetWidget = centralWidget;
+    }
+    
+    // Map coordinates to target widget's space
+    QPoint targetPos = targetWidget->mapFromGlobal(globalPos);
+    
+    // Create a new event with mapped coordinates
+    QMouseEvent mappedEvent(
+        e->type(),
+        targetPos,
+        e->globalPosition(),
+        e->button(),
+        e->buttons(),
+        e->modifiers()
+    );
+    
+    // Send the event to the target widget
+    QApplication::sendEvent(targetWidget, &mappedEvent);
+}
+
+void TrafficLightsTitleBar::mousePressEvent(QMouseEvent* e) {
+    if (isOverButton(e->pos())) {
+        QWidget::mousePressEvent(e);
+        return;
+    }
+    
+    // Only handle left button for potential dragging
+    // Forward all other buttons (right-click, middle-click, etc.) to central widget
+    if (e->button() != Qt::LeftButton) {
+        forwardEventToCentralWidget(e);
+        e->ignore();
+        return;
+    }
+    
+    // Left button: prepare for potential drag
+    m_dragActive = false;
+    m_dragStartPos = e->pos();
+    e->accept();
+}
+
+void TrafficLightsTitleBar::mouseMoveEvent(QMouseEvent* e) {
+    if (isOverButton(e->pos())) {
+        QWidget::mouseMoveEvent(e);
+        return;
+    }
+    
+    // If left button is pressed and we haven't started dragging yet
+    if (!m_dragActive && (e->buttons() & Qt::LeftButton)) {
+        // Check if we've moved enough to start a drag
+        int distance = (e->pos() - m_dragStartPos).manhattanLength();
+        if (distance >= kDragThresholdPx) {
+            if (QWindow* w = window()->windowHandle()) {
+                w->startSystemMove();
+                m_dragActive = true;
+            }
+        }
+    } else if (!(e->buttons() & Qt::LeftButton)) {
+        // No left button - forward hover events to central widget
+        forwardEventToCentralWidget(e);
+    }
+    
+    QWidget::mouseMoveEvent(e);
+}
+
+void TrafficLightsTitleBar::mouseReleaseEvent(QMouseEvent* e) {
+    if (isOverButton(e->pos())) {
+        QWidget::mouseReleaseEvent(e);
+        return;
+    }
+    
+    // If this was a left button release and we never started dragging,
+    // it was a click - forward it to the central widget
+    if (e->button() == Qt::LeftButton) {
+        bool wasClick = !m_dragActive;
+        m_dragActive = false;
+        
+        if (wasClick) {
+            // This was a click, not a drag - forward the release to central widget
+            // Also synthesize a press event so the central widget gets a complete click
+            QMainWindow* mainWindow = qobject_cast<QMainWindow*>(window());
+            if (mainWindow) {
+                QWidget* centralWidget = mainWindow->centralWidget();
+                if (centralWidget) {
+                    QPoint globalPos = mapToGlobal(e->pos());
+                    QPoint centralPos = centralWidget->mapFromGlobal(globalPos);
+                    
+                    if (centralWidget->rect().contains(centralPos)) {
+                        // Find the actual child widget at this position
+                        QWidget* targetWidget = centralWidget->childAt(centralPos);
+                        if (!targetWidget) {
+                            targetWidget = centralWidget;
+                        }
+                        
+                        // Map coordinates to target widget's space
+                        QPoint targetPos = targetWidget->mapFromGlobal(globalPos);
+                        
+                        // Send press event
+                        QMouseEvent pressEvent(
+                            QEvent::MouseButtonPress,
+                            targetPos,
+                            e->globalPosition(),
+                            e->button(),
+                            e->button(),
+                            e->modifiers()
+                        );
+                        QApplication::sendEvent(targetWidget, &pressEvent);
+                        
+                        forwardEventToCentralWidget(e);
+                    }
+                }
+            }
+        }
+    } else {
+        // Non-left button release - forward to central widget
+        forwardEventToCentralWidget(e);
+    }
+}
+
+void TrafficLightsTitleBar::mouseDoubleClickEvent(QMouseEvent* e) {
+    if (isOverButton(e->pos())) {
+        QWidget::mouseDoubleClickEvent(e);
+        return;
+    }
+    
+    forwardEventToCentralWidget(e);
+    e->ignore();
+}

--- a/app/windowdecorations/TrafficLightsTitleBar.h
+++ b/app/windowdecorations/TrafficLightsTitleBar.h
@@ -1,0 +1,48 @@
+#ifndef WINDOWDECORATIONS_TRAFFICLIGHTSTITLEBAR_H
+#define WINDOWDECORATIONS_TRAFFICLIGHTSTITLEBAR_H
+
+#include <QWidget>
+#include <QPoint>
+#include <QEvent>
+
+class QPushButton;
+class QMouseEvent;
+
+class TrafficLightsTitleBar : public QWidget
+{
+    Q_OBJECT
+
+public:
+    static const int kTitleBarHeight = 28;
+    static const int kButtonSize = 12;
+    static const int kButtonSpacing = 6;
+    static const int kLeftMargin = 10;
+    static const int kTopMargin = 4;
+
+    explicit TrafficLightsTitleBar(QWidget* parent = nullptr);
+
+protected:
+    void mousePressEvent(QMouseEvent* e) override;
+    void mouseMoveEvent(QMouseEvent* e) override;
+    void mouseReleaseEvent(QMouseEvent* e) override;
+    void mouseDoubleClickEvent(QMouseEvent* e) override;
+    void leaveEvent(QEvent* e) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+private:
+    bool isOverButton(const QPoint& pos) const;
+    void forwardEventToCentralWidget(QMouseEvent* e);
+    void setButtonIcon(QPushButton* btn, const QString& iconPath);
+    void setAllButtonIcons();
+    void clearAllButtonIcons();
+
+    QPushButton* m_closeBtn = nullptr;
+    QPushButton* m_minBtn = nullptr;
+    QPushButton* m_zoomBtn = nullptr;
+
+    bool m_dragActive = false;
+    QPoint m_dragStartPos;
+    static const int kDragThresholdPx = 4;
+};
+
+#endif // WINDOWDECORATIONS_TRAFFICLIGHTSTITLEBAR_H

--- a/examples/skins/README.md
+++ b/examples/skins/README.md
@@ -1,0 +1,47 @@
+# Basecamp Skins — Example Manifests
+
+Example skin configuration files for testing the detached sidebar prototype.
+
+## Schema Reference
+
+Each skin is a JSON manifest with these top-level keys:
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `name` | string | yes | — | Human-readable skin name (logged at startup) |
+| `version` | string | yes | — | Semantic version of the skin format |
+| `window.frameless` | bool | no | `true` | Remove OS titlebar/decorations on Linux |
+| `window.titleBarHeight` | int | no | `32` | Height of custom TrafficLightsTitleBar in pixels |
+| `sidebar.detached` | bool | no | `false` | Render sidebar as separate floating window |
+| `sidebar.defaultWidth` | int | no | `60` | Sidebar width in pixels (both embedded and detached) |
+| `sidebar.defaultPosition.x` | int | no | `-76` | X position for detached sidebar (screen coords) |
+| `sidebar.defaultPosition.y` | int | no | `200` | Y position for detached sidebar (screen coords) |
+| `theme.background` | string | no | `"#171717"` | Main window background color (hex) |
+| `theme.surface` | string | no | `"#262626"` | Panel/card surface color (hex) |
+| `theme.border` | string | no | `"#434343"` | Border/divider color (hex) |
+
+## Missing Keys = Defaults
+
+SkinConfig parses the JSON and uses defaults for any missing keys. This means you can create a minimal skin:
+
+```json
+{
+  "name": "minimal",
+  "version": "0.1.0"
+}
+```
+
+This would give you a frameless window with embedded sidebar at default position, using default theme colors.
+
+## Creating New Skins
+
+1. Copy `default.json` or `detached-sidebar.json` as a starting point
+2. Modify the values you want to change
+3. Test with: `LogosBasecamp --skin /path/to/your-skin.json`
+4. Check console output for parse errors (logged via `qDebug()`)
+
+## Skin Design Tips
+
+- **Positioning**: The sidebar window uses screen coordinates. Position it relative to your main window size and desired offset from the left edge.
+- **Theme colors**: These are C++ layer colors (window chrome, MainContainer background). QML content views use `Logos.Theme` tokens separately — skin colors and QML themes are independent for now.
+- **Frameless on Linux**: When `frameless: true`, the TrafficLightsTitleBar renders close/minimize/fullscreen buttons. Make sure your sidebar doesn't overlap the title bar area (it won't when detached, since they're separate windows).

--- a/examples/skins/default.json
+++ b/examples/skins/default.json
@@ -1,0 +1,17 @@
+{
+  "name": "default",
+  "version": "0.1.0",
+  "window": {
+    "frameless": true,
+    "titleBarHeight": 32
+  },
+  "sidebar": {
+    "detached": false,
+    "defaultWidth": 60
+  },
+  "theme": {
+    "background": "#171717",
+    "surface": "#262626",
+    "border": "#434343"
+  }
+}

--- a/examples/skins/detached-sidebar.json
+++ b/examples/skins/detached-sidebar.json
@@ -1,0 +1,21 @@
+{
+  "name": "detached-sidebar",
+  "version": "0.1.0",
+  "window": {
+    "frameless": true,
+    "titleBarHeight": 32
+  },
+  "sidebar": {
+    "detached": true,
+    "defaultWidth": 60,
+    "defaultPosition": {
+      "x": -76,
+      "y": 200
+    }
+  },
+  "theme": {
+    "background": "#171717",
+    "surface": "#262626",
+    "border": "#434343"
+  }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,8 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../app/utils)
 
 set(SOURCES
+    SkinConfig.h\
+    SkinConfig.cpp
     main_ui_plugin.cpp
     MainContainer.cpp
     MainUIBackend.cpp

--- a/src/SkinConfig.cpp
+++ b/src/SkinConfig.cpp
@@ -1,0 +1,119 @@
+#include "SkinConfig.h"
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QDebug>
+#include <memory>
+
+std::unique_ptr<SkinConfig> SkinConfig::s_instance;
+
+SkinConfig::SkinConfig(QObject* parent)
+    : QObject(parent)
+{
+}
+
+SkinConfig::~SkinConfig() = default;
+
+bool SkinConfig::loadFromFile(const QString& path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning() << "[SkinConfig] Failed to open skin file:" << path
+                   << file.errorString();
+        return false;
+    }
+
+    QByteArray data = file.readAll();
+    file.close();
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(data, &parseError);
+    if (doc.isNull() || !doc.isObject()) {
+        qWarning() << "[SkinConfig] JSON parse error at line" << parseError.offset
+                   << ":" << parseError.errorString();
+        return false;
+    }
+
+    s_instance = std::make_unique<SkinConfig>();
+    if (!s_instance->parse(doc.object())) {
+        qWarning() << "[SkinConfig] Failed to parse skin manifest:" << path;
+        s_instance.reset();
+        return false;
+    }
+
+    qDebug() << "[SkinConfig] Loaded skin '" << s_instance->m_skinName
+             << "' from" << path;
+    return true;
+}
+
+SkinConfig* SkinConfig::instance()
+{
+    return s_instance.get();
+}
+
+bool SkinConfig::parse(const QJsonObject& root)
+{
+    // --- Meta (optional) ---
+    if (root.contains("name")) {
+        m_skinName = root["name"].toString();
+    }
+    if (root.contains("version")) {
+        m_version = root["version"].toString();
+    }
+
+    // --- Window ---
+    if (root.contains("window")) {
+        QJsonObject window = root["window"].toObject();
+        if (window.contains("frameless")) {
+            m_frameless = window["frameless"].toBool(true);
+        }
+    }
+
+    // --- Sidebar ---
+    if (root.contains("sidebar")) {
+        QJsonObject sidebar = root["sidebar"].toObject();
+        if (sidebar.contains("detached")) {
+            m_sidebarDetached = sidebar["detached"].toBool(false);
+        }
+        if (sidebar.contains("defaultPosition")) {
+            QJsonObject pos = sidebar["defaultPosition"].toObject();
+            if (pos.contains("x")) {
+                m_sidebarDefaultX = pos["x"].toInt(-76);
+            }
+            if (pos.contains("y")) {
+                m_sidebarDefaultY = pos["y"].toInt(200);
+            }
+        }
+    }
+
+    // --- Theme ---
+    if (root.contains("theme")) {
+        QJsonObject theme = root["theme"].toObject();
+        if (theme.contains("background")) {
+            m_themeBackground = theme["background"].toString(m_themeBackground);
+        }
+        if (theme.contains("surface")) {
+            m_themeSurface = theme["surface"].toString(m_themeSurface);
+        }
+        if (theme.contains("border")) {
+            m_themeBorder = theme["border"].toString(m_themeBorder);
+        }
+    }
+
+    return true;  // always succeeds — missing keys use defaults
+}
+
+// --- Property getters ---
+
+bool SkinConfig::isFrameless() const { return m_frameless; }
+
+bool SkinConfig::isSidebarDetached() const { return m_sidebarDetached; }
+int SkinConfig::sidebarDefaultX() const { return m_sidebarDefaultX; }
+int SkinConfig::sidebarDefaultY() const { return m_sidebarDefaultY; }
+
+QString SkinConfig::themeBackground() const { return m_themeBackground; }
+QString SkinConfig::themeSurface() const { return m_themeSurface; }
+QString SkinConfig::themeBorder() const { return m_themeBorder; }
+
+QString SkinConfig::skinName() const { return m_skinName; }

--- a/src/SkinConfig.h
+++ b/src/SkinConfig.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <memory>
+
+/**
+ * SkinConfig — parses a skin manifest JSON file and exposes structured
+ * settings to the rest of the app.
+ *
+ * Singleton: call SkinConfig::loadFromFile() at startup, then access via
+ * SkinConfig::instance(). Returns nullptr if no skin was loaded.
+ *
+ * All properties default to current Basecamp behavior (embedded sidebar,
+ * hardcoded colors) so an absent or partial config file is safe.
+ */
+class SkinConfig : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool frameless READ isFrameless CONSTANT)
+    Q_PROPERTY(bool sidebarDetached READ isSidebarDetached CONSTANT)
+    Q_PROPERTY(int sidebarDefaultX READ sidebarDefaultX CONSTANT)
+    Q_PROPERTY(int sidebarDefaultY READ sidebarDefaultY CONSTANT)
+    Q_PROPERTY(QString themeBackground READ themeBackground CONSTANT)
+    Q_PROPERTY(QString themeSurface READ themeSurface CONSTANT)
+    Q_PROPERTY(QString themeBorder READ themeBorder CONSTANT)
+    Q_PROPERTY(QString skinName READ skinName CONSTANT)
+
+public:
+    /** Load and parse a skin manifest from file. Returns true on success.
+     * After a successful call, instance() returns the config. */
+    static bool loadFromFile(const QString& path);
+
+    /** Return the loaded singleton instance, or nullptr if no skin was loaded. */
+    static SkinConfig* instance();
+
+    // --- Window ---
+    bool isFrameless() const;
+
+    // --- Sidebar ---
+    bool isSidebarDetached() const;
+    int sidebarDefaultX() const;
+    int sidebarDefaultY() const;
+
+    // --- Theme colors ---
+    QString themeBackground() const;
+    QString themeSurface() const;
+    QString themeBorder() const;
+
+    // --- Meta ---
+    QString skinName() const;
+
+private:
+    SkinConfig(QObject* parent = nullptr);
+    ~SkinConfig();
+    bool parse(const QJsonObject& root);
+
+    // Window
+    bool m_frameless = true;  // default: frameless (prototype always frameless)
+
+    // Sidebar
+    bool m_sidebarDetached = false;  // default: embedded (current behavior)
+    int m_sidebarDefaultX = -76;     // left of main window
+    int m_sidebarDefaultY = 200;     // offset down from top
+
+    // Theme colors — match current hardcoded values
+    QString m_themeBackground = "#171717";
+    QString m_themeSurface = "#262626";
+    QString m_themeBorder = "#434343";
+
+    // Meta
+    QString m_skinName;
+    QString m_version;
+
+    // Singleton
+    static std::unique_ptr<SkinConfig> s_instance;
+};


### PR DESCRIPTION
## T3 — Example Skin Manifests

Creates two example skin JSON files + README documenting the manifest schema.

### Files Created
- `examples/skins/detached-sidebar.json` — demonstrates floating sidebar feature
- `examples/skins/default.json` — frameless window with embedded sidebar (current behavior)  
- `examples/skins/README.md` — schema reference, defaults, and skin creation guide

### Schema Design Decisions
- All keys map 1:1 to SkinConfig properties from T2
- Missing keys gracefully fall back to defaults
- Added optional fields for future-proofing:
  - `window.titleBarHeight` — allows skins to customize title bar height
  - `sidebar.defaultWidth` — skin-declarable sidebar width (currently hardcoded to 60)

### Validation
- ✅ Both files are valid JSON
- ✅ Schema matches what SkinConfig (T2) expects to parse
- ✅ README documents all schema keys, defaults, and design tips

### Next Steps
These manifests can be tested with T5 (frameless window) and T7 (CLI integration).

---
**Note:** This PR targets `master`. When the `feat/skins-prototype` branch is pushed to logos-co/co/logos-basecamp, this should be rebased onto that branch.