### PR TITLE
Rename Logos App to Logos Basecamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The app currently supports:
 2. Participating in consensus (chain-following and proposing blocks)
 3. Making and receiving transfers
 
-You can run the Blockchain App through the Logos App, or standalone by building and running the app from source, instructions [here](https://github.com/logos-blockchain/logos-blockchain-ui?tab=readme-ov-file#how-to-build).
+You can run the Blockchain App through Logos Basecamp, or standalone by building and running the app from source, instructions [here](https://github.com/logos-blockchain/logos-blockchain-ui?tab=readme-ov-file#how-to-build).
 
 ### LEZ Wallet
 
@@ -113,11 +113,11 @@ The wallet currently supports:
 3. Public to Public transfers
 4. Private to Private transfers
 
-You can run the LEZ Wallet through Logos App, or standalone by building and running from source, see instructions [here](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui?tab=readme-ov-file#how-to-build).
+You can run the LEZ Wallet through Logos Basecamp, or standalone by building and running from source, see instructions [here](https://github.com/logos-blockchain/logos-execution-zone-wallet-ui?tab=readme-ov-file#how-to-build).
 
 ### Storage
 
-The Logos Storage App allows you to publish, download, and share files with other Logos users. You can run it both in standalone mode, or as part of the main Logos App.
+The Logos Storage App allows you to publish, download, and share files with other Logos users. You can run it both in standalone mode, or as part of the main Logos Basecamp.
 
 Sharing files requires direct connection across nodes, so you will need to set up your router to allow NAT traversal either via UPnP, or manual port forwarding. The app will help you figure out if your NAT traversal is working with a reachability check.
 
@@ -125,7 +125,7 @@ Check [the app's README file](https://github.com/logos-co/logos-storage-ui) for 
 
 ### Chat
 
-The Logos Chat App lets you send and receive private 1:1 messages, where messages are transferred over Logos Delivery, the decentralised transport layer. You can run it both in standalone mode, or as part of the main Logos App.
+The Logos Chat App lets you send and receive private 1:1 messages, where messages are transferred over Logos Delivery, the decentralised transport layer. You can run it both in standalone mode, or as part of the main Logos Basecamp.
 
 In the current testnet demo, the app supports:
 - Creating and sharing your intro bundle (a contact identifier others can use to reach you)
@@ -145,7 +145,7 @@ This demonstrates two core primitives working end-to-end:
 
 Your chat client will first discover the necessary addresses and keys for a pool of mix nodes (using the [capability discovery API](https://lip.logos.co/ift-ts/raw/extended-kad-disco.html#api-specification)) and then proceed to route every published message through this libp2p [mix overlay network](https://lip.logos.co/ift-ts/raw/mix.html).
 
-You can run Mix Demo Chat inside the Logos App.
+You can run Mix Demo Chat inside Logos Basecamp.
 On loading, the UI will show the following:
 - Status is shown as *Ready*
 - LP Peer count increasing over time before stabilising

--- a/app/Readme.md
+++ b/app/Readme.md
@@ -1,4 +1,4 @@
-# Logos App
+# Logos Basecamp
 
 ## Building the Application
 

--- a/app/macos/Info.plist.in
+++ b/app/macos/Info.plist.in
@@ -5,7 +5,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleDisplayName</key>
-    <string>Logos App</string>
+    <string>Logos Basecamp</string>
     <key>CFBundleExecutable</key>
     <string>LogosBasecamp</string>
     <key>CFBundleIconFile</key>
@@ -15,7 +15,7 @@
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>Logos App</string>
+    <string>Logos Basecamp</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>

--- a/app/window.cpp
+++ b/app/window.cpp
@@ -117,7 +117,7 @@ void Window::setupUi()
     }
 
     // Set window title and size
-    setWindowTitle("Logos App");
+    setWindowTitle("Logos Basecamp");
     resize(1024, 768);
 
 #ifdef Q_OS_MAC
@@ -198,7 +198,7 @@ void Window::createTrayIcon()
     // Create tray icon
     m_trayIcon = new QSystemTrayIcon(this);
     setIcon();
-    m_trayIcon->setToolTip("Logos App");
+    m_trayIcon->setToolTip("Logos Basecamp");
 
     // Create context menu
     m_trayIconMenu = new QMenu(this);
@@ -261,7 +261,7 @@ void Window::closeEvent(QCloseEvent *event)
         // Show a message to inform the user
         if (m_trayIcon->supportsMessages()) {
             m_trayIcon->showMessage(
-                tr("Logos App"),
+                tr("Logos Basecamp"),
                 tr("The application will continue to run in the system tray. "
                    "Click the tray icon to restore the window."),
                 QSystemTrayIcon::Information,

--- a/assets/logos-basecamp.desktop
+++ b/assets/logos-basecamp.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Logos App
+Name=Logos Basecamp
 Exec=LogosBasecamp
 Icon=logos-basecamp
 Categories=Utility;

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Logos App - Qt application with UI plugins";
+  description = "Logos Basecamp - Qt application with UI plugins";
 
   inputs = {
     logos-nix.url = "github:logos-co/logos-nix";
@@ -321,7 +321,7 @@
             export LOGOS_PACKAGE_MANAGER_MODULE_SRC="${logosPackageManagerModuleSrc}"
             export LOGOS_CAPABILITY_MODULE_SRC="${logosCapabilityModuleSrc}"
             
-            echo "Logos App development environment"
+            echo "Logos Basecamp development environment"
             echo ""
             echo "Nix packages (host builds):"
             echo "  LOGOS_CPP_SDK_ROOT: $LOGOS_CPP_SDK_ROOT"

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -298,7 +298,7 @@ WRAPPER_EOF
 
     # Create a README for reference
     cat > $out/README.txt <<EOF
-Logos App - Build Information
+Logos Basecamp - Build Information
 ==================================
 liblogos: ${logosLiblogos}
 cpp-sdk: ${logosSdk}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -45,7 +45,7 @@
   
   # Metadata
   meta = with pkgs.lib; {
-    description = "Logos App - Qt application with UI plugins";
+    description = "Logos Basecamp - Qt application with UI plugins";
     platforms = platforms.unix;
   };
 }

--- a/run-dev.sh
+++ b/run-dev.sh
@@ -35,7 +35,7 @@ fi
 
 # Print the paths being used
 echo "================================================"
-echo "Starting Logos App in DEVELOPMENT mode"
+echo "Starting Logos Basecamp in DEVELOPMENT mode"
 echo "================================================"
 echo "QML_UI path: $QML_UI"
 echo ""


### PR DESCRIPTION
The title still says "Logos App", so did a couple of case insensitive find/replaces:
1. `the Logos \w*App\b` to `Logos Basecamp`
2. `Logos \w*App\b` to `Logos Basecamp`

This has NOT been comprehensively tested, consider it a serving suggestion 👨‍🍳

fixes #196 