### PR TITLE
fix: show version badge for all builds — bake pre-release sha into buildVersion

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,11 +40,14 @@
       # changes or is overridden via a path input.
       revOf = input: input.rev or input.dirtyRev or "dirty";
       buildInfo = {
-        # VERSION is only present on release branches; absent = empty string
-        # (Dashboard hides the version line when empty).
+        # VERSION is only present on release branches. On master (pre-release
+        # CI builds) there is no VERSION file, so fall back to a
+        # "pre-release-{sha7}" string derived from self.rev — available on
+        # every clean CI checkout. Dirty local builds lack self.rev and get
+        # an empty string, which hides the badge (intentional for dev).
         version = if builtins.pathExists ./VERSION
           then nixpkgs.lib.removeSuffix "\n" (builtins.readFile ./VERSION)
-          else "";
+          else if (self ? rev) then "pre-release-${builtins.substring 0 7 self.rev}" else "";
         commits = [
           { name = "logos-basecamp"; commit = revOf self; }
           { name = "logos-nix"; commit = revOf logos-nix; }

--- a/src/qml/panels/SidebarPanel.qml
+++ b/src/qml/panels/SidebarPanel.qml
@@ -61,12 +61,12 @@ Control {
             source: "qrc:/icons/basecamp.png"
         }
 
-        // Pre-release version badge — only shown for builds whose version
-        // string carries a pre-release suffix (-rc, -alpha, -beta, -dev).
-        // Stable releases show nothing. Keeps screenshots and bug reports
-        // self-documenting without cluttering the production UI.
+        // Version badge — shown for any build whose version string is
+        // non-empty (pre-release CI builds, RCs, and stable releases alike).
+        // Keeps screenshots and bug reports self-documenting. Hidden only for
+        // dirty local dev builds where no version is baked in.
         Text {
-            visible: /(-rc|-alpha|-beta|-dev)/i.test(backend.buildVersion)
+            visible: backend.buildVersion.length > 0
             text: backend.buildVersion
             color: "#4B5563"
             font.pixelSize: 10


### PR DESCRIPTION
Fixes #203.

## What was broken

PR #188 added a version badge beneath the sidebar logo, but it has been hidden in every pre-release build since the merge.

`SidebarPanel.qml` tested `backend.buildVersion` against `/-rc|-alpha|-beta|-dev/i`, but `buildVersion` is always `""` on master — `flake.nix` only reads the `VERSION` file, which exists only on `release/*` branches. The regex was never reached.

## Changes

**`flake.nix`** — fall back to `pre-release-{sha7}` from `self.rev` when no `VERSION` file is present. `self.rev` is defined on every clean CI checkout; absent on dirty local builds, which intentionally show nothing:

```nix
else if (self ? rev) then "pre-release-${builtins.substring 0 7 self.rev}" else "";
```

**`src/qml/panels/SidebarPanel.qml`** — replace the suffix regex with a plain non-empty check, consistent with `DashboardView.qml`. Until 1.0, every build (stable, RC, pre-release) benefits from being identifiable at a glance:

```qml
visible: backend.buildVersion.length > 0
```

## Result

| Build | `buildVersion` | Badge |
|---|---|---|
| `pre-release-2576ef8-269` (master CI) | `pre-release-2576ef8` | ✓ shown |
| `0.1.2-RC3` (release branch) | `0.1.2-RC3` | ✓ shown |
| `0.1.2` (stable release) | `0.1.2` | ✓ shown |
| dirty local dev build | `""` | ✗ hidden |