### PR TITLE
Add CoreModulesView.openMethods(name) for UI automation

### DIFF
--- a/src/qml/views/CoreModulesView.qml
+++ b/src/qml/views/CoreModulesView.qml
@@ -6,9 +6,18 @@ import panels
 
 Item {
     id: root
+    objectName: "coreModulesView"
 
     property string selectedPlugin: ""
     property bool showingMethods: false
+
+    // Open a specific module's Methods screen by name. Equivalent to clicking
+    // that module's "View Methods" button — exposed for UI automation/tests,
+    // which can't disambiguate the per-row buttons by their identical label.
+    function openMethods(name) {
+        selectedPlugin = name;
+        showingMethods = true;
+    }
 
     onVisibleChanged: {
         if (visible) {


### PR DESCRIPTION
## What

Adds an `objectName` ("coreModulesView") and an `openMethods(name)` function to `CoreModulesView` that opens a module's Methods screen by name — equivalent to clicking its "View Methods" button.

## Why

The per-row "View Methods" buttons all share one label, so UI automation can't disambiguate them by text. This hook lets the **logos-tutorial** doctest deterministically open `calc_module`'s Methods screen and assert that per-method `description`s (from `///` doc comments) render there — the GUI surface of the per-method documentation feature (coordinated branch `parse-method-comments-as-description` across logos-cpp-sdk #70, logos-module #14, logos-logoscore-cli #37, logos-module-builder #106, logos-tutorial #60).

## Verified

The Part 2 tutorial doctest (`tutorial-qml-ui-app`) now opens `calc_module`'s Methods screen via `openMethods` and asserts the descriptions render (incl. `factorial`'s multi-line doc) — **56 passed, 0 failed** with `--release-for logos-basecamp=parse-method-comments-as-description`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)