### PR TITLE
Replace per-module Methods screen with an Interface screen (methods + events)

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -40,7 +40,7 @@ logos-basecamp/
 │   │   │   ├── DashboardView.qml         # Dashboard screen
 │   │   │   ├── ModulesView.qml           # Modules management screen
 │   │   │   ├── CoreModulesView.qml       # Core modules list
-│   │   │   ├── PluginMethodsView.qml     # Method inspection
+│   │   │   ├── PluginInterfaceView.qml   # Interface inspection (methods + events)
 │   │   │   └── SettingsView.qml          # Settings screen
 │   │   ├── controls/                     # Reusable QML controls
 │   │   │   ├── SidebarIconButton.qml

--- a/src/CoreModuleManager.cpp
+++ b/src/CoreModuleManager.cpp
@@ -120,6 +120,27 @@ QString CoreModuleManager::getMethods(const QString& moduleName)
     return "[]";
 }
 
+QString CoreModuleManager::getEvents(const QString& moduleName)
+{
+    if (!m_logosAPI) {
+        return "[]";
+    }
+
+    LogosAPIClient* client = m_logosAPI->getClient(moduleName);
+    if (!client || !client->isConnected()) {
+        return "[]";
+    }
+
+    QVariant result = client->invokeRemoteMethod(moduleName, "getPluginEvents");
+    if (result.canConvert<QJsonArray>()) {
+        QJsonArray events = result.toJsonArray();
+        QJsonDocument doc(events);
+        return doc.toJson(QJsonDocument::Compact);
+    }
+
+    return "[]";
+}
+
 QString CoreModuleManager::callMethod(const QString& moduleName,
                                       const QString& methodName,
                                       const QString& argsJson)

--- a/src/CoreModuleManager.h
+++ b/src/CoreModuleManager.h
@@ -63,6 +63,7 @@ public:
     // JSON on failure rather than throwing. Module not being connected is a
     // normal transient state, not an error.
     Q_INVOKABLE QString getMethods(const QString& moduleName);
+    Q_INVOKABLE QString getEvents(const QString& moduleName);
     Q_INVOKABLE QString callMethod(const QString& moduleName,
                                    const QString& methodName,
                                    const QString& argsJson);

--- a/src/CoreModuleManager.h
+++ b/src/CoreModuleManager.h
@@ -59,9 +59,9 @@ public:
     // PackageManager after install/uninstall events reshape the known set.
     Q_INVOKABLE void refresh();
 
-    // Introspection — serialised to JSON for QML. Both return "[]" / error
-    // JSON on failure rather than throwing. Module not being connected is a
-    // normal transient state, not an error.
+    // Introspection — serialised to JSON for QML. getMethods/getEvents return
+    // "[]" and callMethod returns error JSON on failure rather than throwing.
+    // Module not being connected is a normal transient state, not an error.
     Q_INVOKABLE QString getMethods(const QString& moduleName);
     Q_INVOKABLE QString getEvents(const QString& moduleName);
     Q_INVOKABLE QString callMethod(const QString& moduleName,

--- a/src/MainUIBackend.cpp
+++ b/src/MainUIBackend.cpp
@@ -240,6 +240,7 @@ void MainUIBackend::cancelPendingAction(const QString& n) {
 
 void    MainUIBackend::refreshCoreModules()                         { m_coreModuleManager->refresh(); }
 QString MainUIBackend::getCoreModuleMethods(const QString& n)       { return m_coreModuleManager->getMethods(n); }
+QString MainUIBackend::getCoreModuleEvents(const QString& n)        { return m_coreModuleManager->getEvents(n); }
 QString MainUIBackend::callCoreModuleMethod(const QString& n,
                                              const QString& m,
                                              const QString& a)      { return m_coreModuleManager->callMethod(n, m, a); }

--- a/src/MainUIBackend.h
+++ b/src/MainUIBackend.h
@@ -144,6 +144,7 @@ public slots:
     void unloadCoreModule(const QString& moduleName);
     Q_INVOKABLE void refreshCoreModules();
     Q_INVOKABLE QString getCoreModuleMethods(const QString& moduleName);
+    Q_INVOKABLE QString getCoreModuleEvents(const QString& moduleName);
     Q_INVOKABLE QString callCoreModuleMethod(const QString& moduleName, const QString& methodName, const QString& argsJson);
 
     // UI Modules refresh — forwarded to UIPluginManager which in turn asks

--- a/src/main_ui_resources.qrc
+++ b/src/main_ui_resources.qrc
@@ -24,7 +24,7 @@
         <file>qml/views/ModulesView.qml</file>
         <file>qml/panels/UiModulesTab.qml</file>
         <file>qml/views/CoreModulesView.qml</file>
-        <file>qml/views/PluginMethodsView.qml</file>
+        <file>qml/views/PluginInterfaceView.qml</file>
         <file>qml/views/SettingsView.qml</file>
         <file>qml/views/qmldir</file>
     </qresource>

--- a/src/qml/views/CoreModulesView.qml
+++ b/src/qml/views/CoreModulesView.qml
@@ -9,14 +9,15 @@ Item {
     objectName: "coreModulesView"
 
     property string selectedPlugin: ""
-    property bool showingMethods: false
+    property bool showingInterface: false
 
-    // Open a specific module's Methods screen by name. Equivalent to clicking
-    // that module's "View Methods" button — exposed for UI automation/tests,
-    // which can't disambiguate the per-row buttons by their identical label.
-    function openMethods(name) {
+    // Open a specific module's Interface screen (methods + events) by name.
+    // Equivalent to clicking that module's "Interface" button — exposed for UI
+    // automation/tests, which can't disambiguate the per-row buttons by their
+    // identical label.
+    function openInterface(name) {
         selectedPlugin = name;
-        showingMethods = true;
+        showingInterface = true;
     }
 
     onVisibleChanged: {
@@ -31,7 +32,7 @@ Item {
 
     StackLayout {
         anchors.fill: parent
-        currentIndex: root.showingMethods ? 1 : 0
+        currentIndex: root.showingInterface ? 1 : 0
 
         // Plugin list view
         ColumnLayout {
@@ -180,9 +181,9 @@ Item {
                                     }
                                 }
 
-                                // View Methods button (only for loaded)
+                                // Interface button (methods + events; only for loaded)
                                 Button {
-                                    text: "View Methods"
+                                    text: "Interface"
                                     visible: modelData.isLoaded
 
                                     contentItem: LogosText {
@@ -202,7 +203,7 @@ Item {
 
                                     onClicked: {
                                         root.selectedPlugin = modelData.name
-                                        root.showingMethods = true
+                                        root.showingInterface = true
                                     }
                                 }
 
@@ -250,10 +251,10 @@ Item {
             }
         }
 
-        // Methods view
-        PluginMethodsView {
+        // Interface view (methods + events)
+        PluginInterfaceView {
             pluginName: root.selectedPlugin
-            onBackClicked: root.showingMethods = false
+            onBackClicked: root.showingInterface = false
         }
     }
 }

--- a/src/qml/views/PluginInterfaceView.qml
+++ b/src/qml/views/PluginInterfaceView.qml
@@ -25,6 +25,10 @@ Item {
             } catch (e) {
                 methods = []
             }
+        } else {
+            // Cleared/reset: don't leave a previous plugin's data on screen.
+            methods = []
+            resultText = ""
         }
     }
 
@@ -36,6 +40,8 @@ Item {
             } catch (e) {
                 events = []
             }
+        } else {
+            events = []
         }
     }
 
@@ -93,12 +99,18 @@ Item {
                 spacing: 16
 
                 ScrollView {
+                    id: interfaceScroll
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     clip: true
 
                     ColumnLayout {
-                        width: parent.width
+                        // See CoreModulesView/UiModulesTab — bind to the
+                        // ScrollView's `availableWidth`, not `parent.width`,
+                        // which inside a Qt 6 ScrollView resolves against the
+                        // internal Flickable contentItem and can transiently
+                        // collapse to 0 during Repeater reflow.
+                        width: interfaceScroll.availableWidth
                         spacing: 8
 
                         // ── Methods ──

--- a/src/qml/views/PluginInterfaceView.qml
+++ b/src/qml/views/PluginInterfaceView.qml
@@ -9,13 +9,14 @@ Item {
     
     property string pluginName: ""
     property var methods: []
+    property var events: []
     property string resultText: ""
-    
+
     signal backClicked()
-    
-    Component.onCompleted: loadMethods()
-    onPluginNameChanged: loadMethods()
-    
+
+    Component.onCompleted: { loadMethods(); loadEvents() }
+    onPluginNameChanged: { loadMethods(); loadEvents() }
+
     function loadMethods() {
         if (pluginName.length > 0) {
             let methodsJson = backend.getCoreModuleMethods(pluginName)
@@ -23,6 +24,17 @@ Item {
                 methods = JSON.parse(methodsJson)
             } catch (e) {
                 methods = []
+            }
+        }
+    }
+
+    function loadEvents() {
+        if (pluginName.length > 0) {
+            let eventsJson = backend.getCoreModuleEvents(pluginName)
+            try {
+                events = JSON.parse(eventsJson)
+            } catch (e) {
+                events = []
             }
         }
     }
@@ -57,7 +69,7 @@ Item {
             }
 
             LogosText {
-                text: "Methods: " + root.pluginName
+                text: "Interface: " + root.pluginName
                 font.pixelSize: 20
                 font.weight: Font.Bold
                 color: "#ffffff"
@@ -88,6 +100,15 @@ Item {
                     ColumnLayout {
                         width: parent.width
                         spacing: 8
+
+                        // ── Methods ──
+                        LogosText {
+                            text: "Methods"
+                            font.pixelSize: Theme.typography.secondaryText
+                            font.weight: Font.Bold
+                            color: "#a0a0a0"
+                            visible: root.methods.length > 0
+                        }
 
                         Repeater {
                             model: root.methods
@@ -167,6 +188,64 @@ Item {
                             Layout.alignment: Qt.AlignHCenter
                             Layout.topMargin: 40
                             visible: root.methods.length === 0
+                        }
+
+                        // ── Events ──
+                        LogosText {
+                            text: "Events"
+                            font.pixelSize: Theme.typography.secondaryText
+                            font.weight: Font.Bold
+                            color: "#a0a0a0"
+                            Layout.topMargin: 12
+                            visible: root.events.length > 0
+                        }
+
+                        Repeater {
+                            model: root.events
+
+                            Rectangle {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: eventColumn.implicitHeight + 24
+                                color: "#363636"
+                                radius: 6
+
+                                ColumnLayout {
+                                    id: eventColumn
+                                    anchors.fill: parent
+                                    anchors.margins: 12
+                                    spacing: 8
+
+                                    RowLayout {
+                                        Layout.fillWidth: true
+                                        spacing: 12
+
+                                        LogosText {
+                                            text: modelData.name || modelData
+                                            font.weight: Font.Bold
+                                            // Amber to distinguish events from the blue methods.
+                                            color: "#E2A04A"
+                                        }
+
+                                        LogosText {
+                                            text: modelData.signature || ""
+                                            font.pixelSize: Theme.typography.secondaryText
+                                            color: "#808080"
+                                            visible: modelData.signature !== undefined
+                                        }
+
+                                        Item { Layout.fillWidth: true }
+                                    }
+
+                                    LogosText {
+                                        text: modelData.description || ""
+                                        font.pixelSize: Theme.typography.secondaryText
+                                        color: "#a0a0a0"
+                                        wrapMode: Text.Wrap
+                                        Layout.fillWidth: true
+                                        visible: modelData.description !== undefined && modelData.description.length > 0
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/qml/views/qmldir
+++ b/src/qml/views/qmldir
@@ -4,5 +4,5 @@ DashboardView 1.0 DashboardView.qml
 ModulesView 1.0 ModulesView.qml
 CoreModulesView 1.0 CoreModulesView.qml
 OverlayDialogs 1.0 OverlayDialogs.qml
-PluginMethodsView 1.0 PluginMethodsView.qml
+PluginInterfaceView 1.0 PluginInterfaceView.qml
 SettingsView 1.0 SettingsView.qml


### PR DESCRIPTION
## What

A module exposes two halves of its API — **methods** you call and **events** you subscribe to. The per-module screen now shows both. Part of the per-event documentation feature (see logos-cpp-sdk#71).

The per-row **"View Methods"** button becomes **"Interface"**, and `PluginMethodsView` is renamed to `PluginInterfaceView`: a **Methods** section (unchanged, with **Call**) and a new **Events** section below it (event name in amber, signature, and the event's description; no Call button — events are fire-and-forget).

## Changes

- **`CoreModuleManager.{h,cpp}`** — `getEvents(name)` → `invokeRemoteMethod(name, "getPluginEvents")`, mirroring `getMethods`.
- **`MainUIBackend.{h,cpp}`** — `getCoreModuleEvents(name)` delegates to it.
- **`CoreModulesView.qml`** — "Interface" button; `openInterface()` / `showingInterface` (kept `objectName: "coreModulesView"` for UI automation).
- **`PluginMethodsView.qml` → `PluginInterfaceView.qml`** — loads methods + events, renders both sections.
- **`main_ui_resources.qrc` / `qmldir`** — track the rename.
- **docs** — project.md view description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)