### PR TITLE
Add cross-version compatibility doctests for accounts and chat

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -1,7 +1,6 @@
 name: basecamp Doc-Tests
 
 # Runs the executable basecamp doc-tests end-to-end via the shared doctest CLI.
-# Both specs drive the SAME Modules-view walk; they differ only in what they build:
 #   basecamp-modules.test.yaml — builds THIS commit's development app
 #       (inspector-enabled #app), launches the dev binary headless, and drives its
 #       Modules view: it opens the UI Modules tab to see the installed apps (UI
@@ -11,7 +10,14 @@ name: basecamp Doc-Tests
 #   basecamp-modules-bundle.test.yaml — the bundle twin: builds THIS commit as the
 #       real portable bundle (inspector-enabled #bin-bundle-dir-inspector) and runs
 #       the identical Modules-view walk against it.
-# Both run back-to-back into one --report HTML (a dropdown switches between them).
+#   basecamp-crossversion-accounts.test.yaml / -chat.test.yaml — cross-version
+#       compatibility: build one component fresh from source (#install-portable),
+#       download the latest released counterpart from the package manager, assemble
+#       both into a user-dir, launch the portable bundle against it, and drive the
+#       app (accounts: create mnemonics; chat: confirm the Waku node initializes) —
+#       in both directions (fresh module + released UI, and fresh UI + released
+#       module). These need network at runtime and exercise the live ecosystem.
+# All specs run into one --report HTML (a dropdown switches between them).
 #
 # ──────────────────────────────────────────────────────────────────────────────
 # One-time setup required for the clickable report links to work:
@@ -118,13 +124,20 @@ jobs:
           # report is complete. The job still fails (non-zero exit) if any step
           # failed; this only changes whether we stop early.
           #
-          # Both specs build this commit and drive the same Modules-view walk —
-          # one against the dev app (#app), one against the portable bundle
-          # (#bin-bundle-dir-inspector). Passing both to one `run` puts them in a
-          # single --report HTML (a dropdown switches between them).
+          # All specs build this commit; passing them to one `run` puts them in a
+          # single --report HTML (a dropdown switches between them):
+          #   basecamp-modules / basecamp-modules-bundle — the Modules-view walk
+          #     against the dev app (#app) and the portable bundle.
+          #   basecamp-crossversion-accounts / -chat — cross-version compatibility:
+          #     a freshly-built component (#install-portable) driven against the
+          #     latest released counterpart downloaded from the package manager,
+          #     in both directions. These need network at runtime (catalog
+          #     download + chat's Waku node) and exercise the live ecosystem.
           nix run github:logos-co/logos-doctest -- run \
             doctests/basecamp-modules.test.yaml \
             doctests/basecamp-modules-bundle.test.yaml \
+            doctests/basecamp-crossversion-accounts.test.yaml \
+            doctests/basecamp-crossversion-chat.test.yaml \
             --verbose \
             --continue-on-fail \
             --release-for logos-basecamp=${{ steps.commit.outputs.sha }} \
@@ -152,7 +165,7 @@ jobs:
 
       - name: Verify markdown generation
         run: |
-          for spec in basecamp-modules basecamp-modules-bundle; do
+          for spec in basecamp-modules basecamp-modules-bundle basecamp-crossversion-accounts basecamp-crossversion-chat; do
             nix run github:logos-co/logos-doctest -- generate \
               "doctests/${spec}.test.yaml" \
               --release-for logos-basecamp=${{ steps.commit.outputs.sha }} \

--- a/doctests/basecamp-crossversion-accounts.test.yaml
+++ b/doctests/basecamp-crossversion-accounts.test.yaml
@@ -1,0 +1,325 @@
+name: "Cross-version check: freshly-built accounts against the latest released counterpart"
+output: basecamp-crossversion-accounts.md
+release: ""
+
+intro: |
+  [`logos-basecamp`](https://github.com/logos-co/logos-basecamp) hosts modules and
+  their UI plugins that ship **independently** through the package manager: the
+  `accounts_module` (core runtime) and `accounts_ui` (the QML app) are built,
+  released, and downloaded as separate `.lgx` packages. Because they evolve on
+  their own cadence, the risk is **cross-version drift** — a change to the module
+  that subtly breaks the released UI, or vice-versa.
+
+  The existing basecamp doc-tests only ever exercise the modules and plugins
+  **baked into a single build**, so that drift ships green. This doc-test closes
+  that gap for the **accounts** pair. It builds **one** side fresh from source,
+  downloads the **other** side as the latest released package from the package
+  manager, drops both into a basecamp user-dir, launches the portable basecamp
+  bundle against it, and drives the real Accounts app — in **both** directions:
+
+  - **Variant A:** freshly-built **`accounts_module`** + latest-downloaded **`accounts_ui`**
+  - **Variant B:** freshly-built **`accounts_ui`** + latest-downloaded **`accounts_module`**
+
+  Everything is **portable**. A freshly-built component can only coexist in the
+  same process as a downloaded catalog package if both — and the host — are the
+  portable variant (the dev `#app` / `#install` outputs rpath into `/nix/store`
+  and will not load alongside a portable package). So the host is the portable
+  bundle (`#bin-bundle-dir-inspector`, the inspector-enabled twin of the shippable
+  `#bin-bundle-dir`), the fresh side is built with `#install-portable`, and the
+  downloaded side is the catalog's portable `.lgx`. This is exactly the real
+  install scenario: a portable bundle with portable packages installed into it.
+
+  basecamp discovers extra modules/plugins from a **user-dir** passed via
+  `--user-dir`: anything under `<user-dir>/modules/<name>/` and
+  `<user-dir>/plugins/<name>/` is picked up at launch on top of the bundle's
+  baked-in set. We assemble that dir on disk from the fresh build + the download
+  (the in-app package manager is **not** driven here — its catalog refresh stalls
+  headless), then open the Accounts app from the sidebar and create a couple of
+  mnemonics. A green run is real evidence that this commit's source build of one
+  accounts component still interoperates with the last released version of the
+  other.
+
+what_you_build: "The portable basecamp bundle (inspector-enabled `#bin-bundle-dir-inspector`), plus a freshly-built portable `accounts_module`/`accounts_ui`, combined in a user-dir with the latest released counterpart downloaded from the package manager, and driven through the Accounts app."
+
+what_you_learn:
+  - How `accounts_module` and `accounts_ui` ship as separate packages and why cross-version compatibility needs its own test
+  - Why fresh-built and downloaded packages must both be the portable variant to coexist in one process
+  - How to build a component portably (`#install-portable`) into a `modules/<name>/` or `plugins/<name>/` layout
+  - How to download the latest released package with `lgpd` and install it with `lgpm`
+  - How basecamp's `--user-dir` discovers extra modules and UI plugins at launch
+  - How to drive the Accounts app headless with logos-qt-mcp (open the app, create mnemonics) and capture screenshots
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+
+    Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+  - "**A Linux or macOS machine.** The app runs headless via `QT_QPA_PLATFORM=offscreen`, so no display is required."
+  - "**Network access.** Unlike the other basecamp doc-tests, this one downloads the latest released package from the package manager catalog, so it needs internet access."
+
+sections:
+  - title: "How the cross-version check works"
+    text: |
+      The accounts feature is two packages that ship separately:
+
+      ```
+      accounts_module   core runtime plugin   -> modules/accounts_module/
+      accounts_ui       QML app (depends on accounts_module) -> plugins/accounts_ui/
+      ```
+
+      To catch drift between them, each variant of this doc-test pins one side to
+      **today's source** and the other to the **latest release**:
+
+      ```
+      Variant A : fresh accounts_module   + downloaded accounts_ui
+      Variant B : fresh accounts_ui       + downloaded accounts_module
+      ```
+
+      Both are assembled into a basecamp **user-dir** (`modules/` + `plugins/`),
+      and the **portable** bundle is launched with `--user-dir` pointed at it. The
+      Accounts app then loads the freshly-built piece next to the released piece in
+      one process — which only works because everything is the portable variant.
+
+  - title: "Build the qt-mcp test driver"
+    step: true
+    text: |
+      [`logos-qt-mcp`](https://github.com/logos-co/logos-qt-mcp) is the harness the
+      doc-test uses to connect to the bundle's QML inspector and drive it. Build it
+      once and link it as `./result-mcp`.
+    steps:
+      - title: "Build logos-qt-mcp"
+        run: 'nix build "${QT_MCP_FLAKE:-github:logos-co/logos-qt-mcp}" -o result-mcp'
+        code_block: "nix build 'github:logos-co/logos-qt-mcp' -o result-mcp"
+        check_file: "result-mcp"
+
+  - title: "Build the package-manager CLIs"
+    step: true
+    text: |
+      The download/install of the released counterpart is driven by the package
+      manager's CLIs: `lgpd` (downloader) fetches the latest `.lgx` from the
+      catalog, and `lgpm` (manager) installs it into the user-dir. We build them
+      from their flakes — `lgpm` from the **portable** CLI (`#cli-portable`), so it
+      selects the catalog's portable platform variant rather than a `-dev` one.
+    steps:
+      - title: "Build lgpd (package downloader)"
+        run: "nix build 'github:logos-co/logos-package-downloader#cli' -o result-lgpd"
+        check_file: "result-lgpd/bin/lgpd"
+      - title: "Build lgpm (package manager, portable)"
+        run: "nix build 'github:logos-co/logos-package-manager#cli-portable' -o result-lgpm"
+        check_file: "result-lgpm/bin/lgpm"
+
+  - title: "Build the basecamp bundle"
+    step: true
+    text: |
+      Build **this** basecamp commit's portable bundle and link it as
+      `./result-bundle`. This is the self-contained `#bin-bundle-dir` you ship; to
+      automate the UI we build its inspector-enabled twin
+      (`#bin-bundle-dir-inspector`) — identical except the QML inspector is
+      compiled in. The bundle is the **host** the fresh + downloaded portable
+      packages load into.
+
+      > The `{release}` in the URL pins the build to this commit (the doc-test
+      > runner expands it; locally that is this checkout's `HEAD`, see `run.sh`).
+    steps:
+      - title: "Build the bundle"
+        run: "nix build 'github:logos-co/logos-basecamp{release}#bin-bundle-dir-inspector' -o result-bundle"
+        code_block: |
+          # From inside the clone this is simply: nix build '.#bin-bundle-dir'
+          nix build 'github:logos-co/logos-basecamp{release}#bin-bundle-dir' -o result-bundle
+        check_file: "result-bundle/bin/LogosBasecamp"
+
+  - title: "Variant A — fresh accounts_module + latest accounts_ui"
+    step: true
+    text: |
+      Build `accounts_module` fresh from source as a **portable** install, download
+      the latest released `accounts_ui` from the package manager, and assemble both
+      into the user-dir `./testdata/acc-A`.
+    steps:
+      - title: "Build the fresh accounts_module (portable)"
+        text: |
+          `#install-portable` produces the same `modules/<name>/` layout basecamp
+          loads from a user-dir — a portable plugin plus its metadata.
+        run: "nix build 'github:logos-co/logos-accounts-module#install-portable' -o result-accA-mod"
+        check_file: "result-accA-mod/modules/accounts_module"
+
+      - title: "Download the latest released accounts_ui"
+        text: |
+          `lgpd` fetches the latest `accounts_ui` `.lgx` from the package manager
+          catalog into `./dl-accA`.
+        run: "rm -rf dl-accA && mkdir -p dl-accA && ./result-lgpd/bin/lgpd download accounts_ui -o dl-accA && ls dl-accA"
+        expect_contains:
+          - "accounts_ui"
+
+      - title: "Assemble the user-dir"
+        text: |
+          Copy the freshly-built module into the user-dir's `modules/`, and install
+          the downloaded UI `.lgx` into its `plugins/` with `lgpm`.
+        run: |
+          chmod -R u+w testdata/acc-A 2>/dev/null || true
+          rm -rf testdata/acc-A
+          mkdir -p testdata/acc-A/modules testdata/acc-A/plugins
+          cp -r result-accA-mod/modules/accounts_module testdata/acc-A/modules/
+          chmod -R u+w testdata/acc-A
+          ./result-lgpm/bin/lgpm --modules-dir testdata/acc-A/modules --ui-plugins-dir testdata/acc-A/plugins install --file dl-accA/*.lgx
+          echo "--- modules ---"; ls testdata/acc-A/modules
+          echo "--- plugins ---"; ls testdata/acc-A/plugins
+        expect_contains:
+          - "accounts_module"
+          - "accounts_ui"
+
+      - title: "Launch the bundle and create mnemonics"
+        text: |
+          Launch the portable bundle against `./testdata/acc-A`, open the Accounts
+          app from the sidebar, and create a couple of random mnemonics — each a
+          round-trip from the freshly-built `accounts_module` through the released
+          `accounts_ui`.
+        ui_test:
+          launch: "./result-bundle/bin/LogosBasecamp --user-dir ./testdata/acc-A"
+          qt_mcp: "result-mcp"
+          launch_timeout: 300
+          tests:
+            - name: "App window opens with the sidebar visible"
+              action: wait_for
+              texts: ["Applications", "Settings"]
+              timeout: 60000
+              text: "The bundle launches headless against the assembled user-dir."
+              screenshot: "xver-accA-launch.png"
+
+            - name: "The accounts app appears in the sidebar"
+              action: wait_for
+              texts: ["accounts_ui"]
+              timeout: 30000
+
+            - name: "Open the Accounts app"
+              action: click
+              target: "accounts_ui"
+
+            - name: "Accounts Manager loads"
+              action: wait_for
+              texts: ["Accounts Manager", "Create Random Mnemonic"]
+              timeout: 30000
+              text: "Clicking the sidebar icon loads `accounts_ui` and auto-loads its `accounts_module` dependency."
+              screenshot: "xver-accA-open.png"
+
+            - name: "Create the first mnemonic"
+              action: click
+              target: "Create Random Mnemonic"
+
+            - name: "First mnemonic is created"
+              action: wait_for
+              texts: ["Status: Mnemonic created successfully"]
+              timeout: 30000
+              text: "The released UI calls the freshly-built module's `createRandomMnemonic` and reports success."
+              screenshot: "xver-accA-mnemonic1.png"
+
+            - name: "Create a second mnemonic"
+              action: click
+              target: "Create Random Mnemonic"
+
+            - name: "Second mnemonic is created"
+              action: wait_for
+              texts: ["Status: Mnemonic created successfully"]
+              timeout: 30000
+              screenshot: "xver-accA-mnemonic2.png"
+        post_text: |
+          A green Variant A means today's `accounts_module` source still serves the
+          latest released `accounts_ui`.
+
+  - title: "Variant B — fresh accounts_ui + latest accounts_module"
+    step: true
+    text: |
+      The mirror image: build `accounts_ui` fresh from source as a **portable**
+      install, download the latest released `accounts_module`, and assemble both
+      into `./testdata/acc-B`.
+    steps:
+      - title: "Build the fresh accounts_ui (portable)"
+        text: |
+          For a QML UI, `#install-portable` produces a `plugins/<name>/` layout with
+          the plugin, its `qml/` view, and metadata.
+        run: "nix build 'github:logos-co/logos-accounts-ui#install-portable' -o result-accB-ui"
+        check_file: "result-accB-ui/plugins/accounts_ui"
+
+      - title: "Download the latest released accounts_module"
+        run: "rm -rf dl-accB && mkdir -p dl-accB && ./result-lgpd/bin/lgpd download accounts_module -o dl-accB && ls dl-accB"
+        expect_contains:
+          - "accounts_module"
+
+      - title: "Assemble the user-dir"
+        text: |
+          Copy the freshly-built UI into the user-dir's `plugins/`, and install the
+          downloaded module `.lgx` into its `modules/` with `lgpm`. (We copy only
+          the `accounts_ui` plugin dir, so the fresh side is exactly the UI and the
+          module comes from the download.)
+        run: |
+          chmod -R u+w testdata/acc-B 2>/dev/null || true
+          rm -rf testdata/acc-B
+          mkdir -p testdata/acc-B/modules testdata/acc-B/plugins
+          cp -r result-accB-ui/plugins/accounts_ui testdata/acc-B/plugins/
+          chmod -R u+w testdata/acc-B
+          ./result-lgpm/bin/lgpm --modules-dir testdata/acc-B/modules --ui-plugins-dir testdata/acc-B/plugins install --file dl-accB/*.lgx
+          echo "--- modules ---"; ls testdata/acc-B/modules
+          echo "--- plugins ---"; ls testdata/acc-B/plugins
+        expect_contains:
+          - "accounts_module"
+          - "accounts_ui"
+
+      - title: "Launch the bundle and create mnemonics"
+        text: |
+          Same drive as Variant A, against `./testdata/acc-B`: this time the
+          freshly-built `accounts_ui` is calling the latest released
+          `accounts_module`.
+        ui_test:
+          launch: "./result-bundle/bin/LogosBasecamp --user-dir ./testdata/acc-B"
+          qt_mcp: "result-mcp"
+          launch_timeout: 300
+          tests:
+            - name: "App window opens with the sidebar visible"
+              action: wait_for
+              texts: ["Applications", "Settings"]
+              timeout: 60000
+              screenshot: "xver-accB-launch.png"
+
+            - name: "The accounts app appears in the sidebar"
+              action: wait_for
+              texts: ["accounts_ui"]
+              timeout: 30000
+
+            - name: "Open the Accounts app"
+              action: click
+              target: "accounts_ui"
+
+            - name: "Accounts Manager loads"
+              action: wait_for
+              texts: ["Accounts Manager", "Create Random Mnemonic"]
+              timeout: 30000
+              text: "The freshly-built `accounts_ui` loads and auto-loads the released `accounts_module`."
+              screenshot: "xver-accB-open.png"
+
+            - name: "Create the first mnemonic"
+              action: click
+              target: "Create Random Mnemonic"
+
+            - name: "First mnemonic is created"
+              action: wait_for
+              texts: ["Status: Mnemonic created successfully"]
+              timeout: 30000
+              screenshot: "xver-accB-mnemonic1.png"
+
+            - name: "Create a second mnemonic"
+              action: click
+              target: "Create Random Mnemonic"
+
+            - name: "Second mnemonic is created"
+              action: wait_for
+              texts: ["Status: Mnemonic created successfully"]
+              timeout: 30000
+              screenshot: "xver-accB-mnemonic2.png"
+        post_text: |
+          A green Variant B means today's `accounts_ui` source still works against
+          the last released `accounts_module`. Together with Variant A, the accounts
+          pair is verified in both directions.

--- a/doctests/basecamp-crossversion-chat.test.yaml
+++ b/doctests/basecamp-crossversion-chat.test.yaml
@@ -1,0 +1,312 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# SCOPE — chat cross-version check is currently "init + screenshot".
+#
+# This spec verifies, in both directions, that a freshly-built chat component
+# loads and initializes inside basecamp alongside the latest released
+# counterpart: it opens the chat app and waits for the chat node to come up
+# (status "Connected"), capturing a screenshot. `chat_module` starts a real Waku
+# node by default, so reaching "Connected" depends on the run environment having
+# working network/peer discovery.
+#
+# DEFERRED (not yet driven here): the full messaging flow — click "Get Intro
+# Bundle", start a new conversation from a bundle, and send/receive messages. It
+# is left as a commented WIP block in the "Variant A" launch step below. Driving
+# it needs (a) capturing the generated intro bundle out of the bundle dialog and
+# re-injecting it into the new-conversation dialog via the runner's set_text
+# action, and (b) a reliably-connected node (its own e2e tests use a dedicated
+# nwaku bootstrap). Keep the messaging steps commented until both are addressed,
+# so the spec stays green. (Mirrors the WIP approach in
+# basecamp-modules-bundle.test.yaml.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: "Cross-version check: freshly-built chat against the latest released counterpart"
+output: basecamp-crossversion-chat.md
+release: ""
+
+intro: |
+  > **⚠️ Partial coverage.** This chat cross-version check currently goes as far
+  > as **opening the chat app and confirming it initializes** (the chat node comes
+  > up and the UI reaches **Connected**), capturing a screenshot. The full
+  > messaging flow — get intro bundle → start a conversation → send messages — is
+  > a documented follow-up (see the WIP block in the spec). `chat_module` runs a
+  > real Waku node, so reaching **Connected** depends on the run environment's
+  > network.
+
+  [`logos-basecamp`](https://github.com/logos-co/logos-basecamp) hosts the
+  `chat_module` (core runtime, which runs a real Waku node) and `chat_ui` (the QML
+  app) as **separate** packages that ship independently through the package
+  manager. As with accounts, they can drift apart, so this doc-test checks a
+  freshly-built side against the latest released counterpart in **both**
+  directions:
+
+  - **Variant A:** freshly-built **`chat_module`** + latest-downloaded **`chat_ui`**
+  - **Variant B:** freshly-built **`chat_ui`** + latest-downloaded **`chat_module`**
+
+  Everything is **portable**: a freshly-built component can only coexist with a
+  downloaded catalog package in one process if both — and the host — are the
+  portable variant. So the host is the portable bundle
+  (`#bin-bundle-dir-inspector`, the inspector-enabled twin of the shippable
+  `#bin-bundle-dir`), the fresh side is built with `#install-portable`, and the
+  downloaded side is the catalog's portable `.lgx`.
+
+  Both sides are assembled into a basecamp **user-dir** (discovered via
+  `--user-dir`: `<user-dir>/modules/<name>/` + `<user-dir>/plugins/<name>/`), the
+  portable bundle is launched against it, the chat app is opened from the sidebar,
+  and we wait for it to initialize. A green run is evidence that this commit's
+  source build of one chat component still loads and initializes next to the last
+  released version of the other.
+
+what_you_build: "The portable basecamp bundle (inspector-enabled `#bin-bundle-dir-inspector`), plus a freshly-built portable `chat_module`/`chat_ui`, combined in a user-dir with the latest released counterpart downloaded from the package manager, and driven to confirm the chat app initializes."
+
+what_you_learn:
+  - How `chat_module` and `chat_ui` ship as separate packages and why cross-version compatibility needs its own test
+  - Why fresh-built and downloaded packages must both be the portable variant to coexist in one process
+  - How to build a component portably (`#install-portable`) and download its counterpart with `lgpd`/`lgpm`
+  - How basecamp's `--user-dir` discovers extra modules and UI plugins at launch
+  - How to confirm the chat app initializes (the Waku node comes up and the UI reaches "Connected") headless with logos-qt-mcp
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+
+    Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+  - "**A Linux or macOS machine.** The app runs headless via `QT_QPA_PLATFORM=offscreen`, so no display is required."
+  - "**Network access.** This doc-test downloads the latest released package from the package manager catalog, and `chat_module` starts a real Waku node — both need internet access."
+
+sections:
+  - title: "How the cross-version check works"
+    text: |
+      The chat feature is two packages that ship separately:
+
+      ```
+      chat_module   core runtime plugin (runs a real Waku node) -> modules/chat_module/
+      chat_ui       QML app (depends on chat_module)            -> plugins/chat_ui/
+      ```
+
+      Each variant pins one side to **today's source** and the other to the
+      **latest release**:
+
+      ```
+      Variant A : fresh chat_module + downloaded chat_ui
+      Variant B : fresh chat_ui     + downloaded chat_module
+      ```
+
+      Both are assembled into a basecamp **user-dir**, and the **portable** bundle
+      is launched with `--user-dir` pointed at it — so the freshly-built piece
+      initializes next to the released piece in one process.
+
+  - title: "Build the qt-mcp test driver"
+    step: true
+    text: |
+      [`logos-qt-mcp`](https://github.com/logos-co/logos-qt-mcp) is the harness the
+      doc-test uses to connect to the bundle's QML inspector and drive it. Build it
+      once and link it as `./result-mcp`.
+    steps:
+      - title: "Build logos-qt-mcp"
+        run: 'nix build "${QT_MCP_FLAKE:-github:logos-co/logos-qt-mcp}" -o result-mcp'
+        code_block: "nix build 'github:logos-co/logos-qt-mcp' -o result-mcp"
+        check_file: "result-mcp"
+
+  - title: "Build the package-manager CLIs"
+    step: true
+    text: |
+      `lgpd` (downloader) fetches the latest `.lgx` from the catalog, and `lgpm`
+      (manager) installs it into the user-dir. We build them from their flakes —
+      `lgpm` from the **portable** CLI (`#cli-portable`), so it selects the
+      catalog's portable platform variant rather than a `-dev` one.
+    steps:
+      - title: "Build lgpd (package downloader)"
+        run: "nix build 'github:logos-co/logos-package-downloader#cli' -o result-lgpd"
+        check_file: "result-lgpd/bin/lgpd"
+      - title: "Build lgpm (package manager, portable)"
+        run: "nix build 'github:logos-co/logos-package-manager#cli-portable' -o result-lgpm"
+        check_file: "result-lgpm/bin/lgpm"
+
+  - title: "Build the basecamp bundle"
+    step: true
+    text: |
+      Build **this** basecamp commit's portable bundle and link it as
+      `./result-bundle` — the inspector-enabled twin (`#bin-bundle-dir-inspector`)
+      of the shippable `#bin-bundle-dir`, the host the fresh + downloaded portable
+      packages load into.
+    steps:
+      - title: "Build the bundle"
+        run: "nix build 'github:logos-co/logos-basecamp{release}#bin-bundle-dir-inspector' -o result-bundle"
+        code_block: |
+          # From inside the clone this is simply: nix build '.#bin-bundle-dir'
+          nix build 'github:logos-co/logos-basecamp{release}#bin-bundle-dir' -o result-bundle
+        check_file: "result-bundle/bin/LogosBasecamp"
+
+  - title: "Variant A — fresh chat_module + latest chat_ui"
+    step: true
+    text: |
+      Build `chat_module` fresh from source as a **portable** install, download the
+      latest released `chat_ui`, and assemble both into `./testdata/chat-A`.
+    steps:
+      - title: "Build the fresh chat_module (portable)"
+        run: "nix build 'github:logos-co/logos-chat-module#install-portable' -o result-chatA-mod"
+        check_file: "result-chatA-mod/modules/chat_module"
+
+      - title: "Download the latest released chat_ui"
+        run: "rm -rf dl-chatA && mkdir -p dl-chatA && ./result-lgpd/bin/lgpd download chat_ui -o dl-chatA && ls dl-chatA"
+        expect_contains:
+          - "chat_ui"
+
+      - title: "Assemble the user-dir"
+        run: |
+          chmod -R u+w testdata/chat-A 2>/dev/null || true
+          rm -rf testdata/chat-A
+          mkdir -p testdata/chat-A/modules testdata/chat-A/plugins
+          cp -r result-chatA-mod/modules/chat_module testdata/chat-A/modules/
+          chmod -R u+w testdata/chat-A
+          ./result-lgpm/bin/lgpm --modules-dir testdata/chat-A/modules --ui-plugins-dir testdata/chat-A/plugins install --file dl-chatA/*.lgx
+          echo "--- modules ---"; ls testdata/chat-A/modules
+          echo "--- plugins ---"; ls testdata/chat-A/plugins
+        expect_contains:
+          - "chat_module"
+          - "chat_ui"
+
+      - title: "Launch the bundle and confirm chat initializes"
+        text: |
+          Launch the portable bundle against `./testdata/chat-A`, open the chat app
+          from the sidebar, and wait for the chat node to come up — the released
+          `chat_ui` initializing the freshly-built `chat_module`'s Waku node.
+        ui_test:
+          launch: "./result-bundle/bin/LogosBasecamp --user-dir ./testdata/chat-A"
+          qt_mcp: "result-mcp"
+          launch_timeout: 300
+          tests:
+            - name: "App window opens with the sidebar visible"
+              action: wait_for
+              texts: ["Applications", "Settings"]
+              timeout: 60000
+              screenshot: "xver-chatA-launch.png"
+
+            - name: "The chat app appears in the sidebar"
+              action: wait_for
+              texts: ["chat_ui"]
+              timeout: 30000
+
+            - name: "Open the chat app"
+              action: click
+              target: "chat_ui"
+
+            - name: "Chat view renders"
+              action: wait_for
+              texts: ["Get Intro Bundle"]
+              timeout: 30000
+              text: "Clicking the sidebar icon loads `chat_ui` and auto-loads its `chat_module` dependency."
+              screenshot: "xver-chatA-open.png"
+
+            - name: "Chat node initializes (Connected)"
+              action: wait_for
+              texts: ["Connected"]
+              timeout: 120000
+              text: "The chat node starts its Waku node and the UI reaches **Connected** — the freshly-built module initialized cleanly under the released UI."
+              screenshot: "xver-chatA-connected.png"
+
+            # ── DEFERRED WIP: full messaging flow ───────────────────────────────
+            # Once we can (a) capture the generated intro bundle out of the bundle
+            # dialog and (b) rely on a connected node, drive the rest here:
+            #
+            #   - { action: click,    target: "Get Intro Bundle" }
+            #   - { action: wait_for, texts: ["My Bundle", "Share this bundle"], timeout: 30000 }
+            #     # bundle text lives in the `bundleDisplay` TextArea (ChatView.qml:725);
+            #     # capture it, then close the dialog.
+            #   - { action: click,    target: "+ new" }
+            #   - { action: set_text, find_by: "objectName", find_value: "<bundleInput>", value: "<captured-bundle>" }
+            #   - { action: set_text, find_by: "objectName", find_value: "<introMsgInput>", value: "Hello!" }
+            #   - { action: click,    target: "Create" }
+            #   - { action: wait_for, texts: ["No messages yet", "Conversation active"], timeout: 60000 }
+            #   - { action: set_text, find_by: "objectName", find_value: "<msgInput>", value: "first message" }
+            #   - { action: click,    target: ">>" }
+            #   - { action: wait_for, texts: ["first message"], timeout: 60000, screenshot: "xver-chatA-message.png" }
+            #
+            # NOTE: bundleInput/introMsgInput/msgInput in ChatView.qml currently
+            # carry QML `id`s but not `objectName`s; set_text matches by property
+            # (default findByProperty), so those elements would need stable
+            # objectNames added to be targetable. Track that as part of enabling
+            # this flow.
+            # ────────────────────────────────────────────────────────────────────
+        post_text: |
+          A green Variant A means today's `chat_module` source initializes cleanly
+          under the latest released `chat_ui`.
+
+  - title: "Variant B — fresh chat_ui + latest chat_module"
+    step: true
+    text: |
+      The mirror image: build `chat_ui` fresh from source as a **portable**
+      install, download the latest released `chat_module`, and assemble both into
+      `./testdata/chat-B`.
+    steps:
+      - title: "Build the fresh chat_ui (portable)"
+        run: "nix build 'github:logos-co/logos-chat-ui#install-portable' -o result-chatB-ui"
+        check_file: "result-chatB-ui/plugins/chat_ui"
+
+      - title: "Download the latest released chat_module"
+        run: "rm -rf dl-chatB && mkdir -p dl-chatB && ./result-lgpd/bin/lgpd download chat_module -o dl-chatB && ls dl-chatB"
+        expect_contains:
+          - "chat_module"
+
+      - title: "Assemble the user-dir"
+        text: |
+          Copy only the freshly-built `chat_ui` plugin dir into the user-dir's
+          `plugins/`, and install the downloaded module `.lgx` into its `modules/`.
+        run: |
+          chmod -R u+w testdata/chat-B 2>/dev/null || true
+          rm -rf testdata/chat-B
+          mkdir -p testdata/chat-B/modules testdata/chat-B/plugins
+          cp -r result-chatB-ui/plugins/chat_ui testdata/chat-B/plugins/
+          chmod -R u+w testdata/chat-B
+          ./result-lgpm/bin/lgpm --modules-dir testdata/chat-B/modules --ui-plugins-dir testdata/chat-B/plugins install --file dl-chatB/*.lgx
+          echo "--- modules ---"; ls testdata/chat-B/modules
+          echo "--- plugins ---"; ls testdata/chat-B/plugins
+        expect_contains:
+          - "chat_module"
+          - "chat_ui"
+
+      - title: "Launch the bundle and confirm chat initializes"
+        text: |
+          Same drive as Variant A, against `./testdata/chat-B`: the freshly-built
+          `chat_ui` initializing the latest released `chat_module`'s Waku node.
+        ui_test:
+          launch: "./result-bundle/bin/LogosBasecamp --user-dir ./testdata/chat-B"
+          qt_mcp: "result-mcp"
+          launch_timeout: 300
+          tests:
+            - name: "App window opens with the sidebar visible"
+              action: wait_for
+              texts: ["Applications", "Settings"]
+              timeout: 60000
+              screenshot: "xver-chatB-launch.png"
+
+            - name: "The chat app appears in the sidebar"
+              action: wait_for
+              texts: ["chat_ui"]
+              timeout: 30000
+
+            - name: "Open the chat app"
+              action: click
+              target: "chat_ui"
+
+            - name: "Chat view renders"
+              action: wait_for
+              texts: ["Get Intro Bundle"]
+              timeout: 30000
+              screenshot: "xver-chatB-open.png"
+
+            - name: "Chat node initializes (Connected)"
+              action: wait_for
+              texts: ["Connected"]
+              timeout: 120000
+              text: "The freshly-built `chat_ui` brings up the released `chat_module`'s Waku node and reaches **Connected**."
+              screenshot: "xver-chatB-connected.png"
+        post_text: |
+          A green Variant B means today's `chat_ui` source initializes the last
+          released `chat_module` cleanly. Together with Variant A, the chat pair is
+          verified (init scope) in both directions.


### PR DESCRIPTION
## What

Two new `logos-doctest` specs in `doctests/` that verify a **freshly-built** component still interoperates with the **latest released** counterpart from the package manager — in both directions:

- **Variant A:** fresh **module** + latest-downloaded **UI**
- **Variant B:** fresh **UI** + latest-downloaded **module**

**accounts** (`basecamp-crossversion-accounts.test.yaml`) — opens the Accounts app and clicks *Create Random Mnemonic* a couple of times, asserting `Status: Mnemonic created successfully`.

**chat** (`basecamp-crossversion-chat.test.yaml`) — opens the chat app and confirms the chat node initializes (reaches **Connected**). The full get-bundle → new-conversation → send-message flow is left as a documented WIP block.

## How

Everything is **portable** so the fresh build and the downloaded catalog package coexist in one process:

- host = `#bin-bundle-dir-inspector`
- fresh side = `#install-portable`
- `lgpm` = `#cli-portable` (the dev `lgpm` only tries `-dev` variants the catalog doesn't publish)

Each scenario builds the fresh side, downloads the counterpart with `lgpd`, installs it with `lgpm`, assembles a `modules/` + `plugins/` user-dir, and launches the bundle with `--user-dir` pointed at it, driving the UI via logos-qt-mcp.

## Notes

- Both specs auto-run via `doctests/run.sh` (it globs `*.test.yaml`); no run.sh change needed.
- Unlike the existing basecamp doctests, these **need network at runtime** (catalog download + chat's Waku node) — the prerequisites say so.
- Verified locally end-to-end: **12/12 green** for each spec.
- While developing, the chat check caught a real cross-version gap (the released `chat_module` lacked `initChat` that the latest `chat_ui` calls); after a `chat_module` re-release both directions pass — exactly the drift this test exists to surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
