### PR TITLE
ci: use attic for nix cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+  ATTIC_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+
 jobs:
   build-appimage:
     strategy:
@@ -26,11 +30,16 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
+            fallback = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: ryanccn/attic-action@v0.4.1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          inputs-from: "."
+          token: ${{ env.ATTIC_TOKEN }}
 
       - name: Build bin-appimage
         run: nix build .#bin-appimage
@@ -59,11 +68,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@main
-
-      - uses: cachix/cachix-action@v15
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
+            fallback = true
+
+      - uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          inputs-from: "."
+          token: ${{ env.ATTIC_TOKEN }}
 
       - name: Build bin-macos-app
         run: nix build .#bin-macos-app
@@ -100,11 +116,16 @@ jobs:
         with:
           extra_nix_config: |
             experimental-features = nix-command flakes
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
+            fallback = true
 
-      - uses: cachix/cachix-action@v15
+      - uses: ryanccn/attic-action@v0.4.1
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          inputs-from: "."
+          token: ${{ env.ATTIC_TOKEN }}
 
       - name: Integration test (UI tests)
         run: nix build .#integration-test -L
@@ -116,11 +137,18 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: DeterminateSystems/nix-installer-action@main
-
-      - uses: cachix/cachix-action@v15
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
+            fallback = true
+
+      - uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          inputs-from: "."
+          token: ${{ env.ATTIC_TOKEN }}
 
       - name: Integration test (UI tests)
         run: nix build .#integration-test-bundle -L

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -47,6 +47,10 @@ concurrency:
   group: doctests-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
+  ATTIC_TOKEN: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+
 jobs:
   doctests:
     name: basecamp doc-tests (${{ matrix.os }})
@@ -64,12 +68,19 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v15
         with:
-          name: logos-co
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          extra-conf: |
+            extra-substituters = https://cache.nix.logos.co/public
+            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
+            fallback = true
+
+      - name: Setup Attic cache
+        uses: ryanccn/attic-action@v0.4.1
+        with:
+          endpoint: ${{ secrets.ATTIC_ENDPOINT }}
+          cache: ${{ env.ATTIC_CACHE }}
+          inputs-from: "."
+          token: ${{ env.ATTIC_TOKEN }}
 
       # The portable bundle (#bin-bundle-dir) is relocatable: it carries the app
       # and its Qt runtime, but NOT host graphics libraries (you can't bundle a

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,11 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://cache.nix.logos.co/public" ];
+    extra-trusted-public-keys = [ "public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=" ];
+  };
+
   outputs = { self, nixpkgs, logos-nix, logos-cpp-sdk, logos-protocol, logos-qt-sdk, logos-module, logos-liblogos, logos-package-manager, logos-package-manager-module, logos-package-downloader-module, logos-capability-module, logos-package, logos-package-manager-ui, logos-design-system, logos-view-module-runtime, logos-qt-mcp, nix-bundle-logos-module-install, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];


### PR DESCRIPTION
## Summary

- swaps out cachix with our hosted nix cache thats running attic.
- sets up public cache in flake.nix