### PR TITLE
fix: the colors for app grid to be used to match dark theme and keep …

### DIFF
--- a/src/Basecamp/AppManager/AddApplicationDialog.qml
+++ b/src/Basecamp/AppManager/AddApplicationDialog.qml
@@ -67,14 +67,9 @@ Dialog {
             if (raw.indexOf("://") < 0) return ""
             return raw
         }
-        readonly property bool   hasIcon: d.targetIcon.length > 0
         readonly property string packageColor: root.metadata.color || ""
-        readonly property color  tileColor:
-            d.packageColor.length > 0 ? d.packageColor
-                                      : AppColors.colorForApp(d.targetName)
 
         readonly property int tileSize: 64
-        readonly property int monogramSize: Math.round(d.tileSize * 0.375)
 
         readonly property bool   installed:        root.metadata.isInstalled === true
         readonly property string installedVersion: root.metadata.installedVersion || ""
@@ -308,30 +303,14 @@ Dialog {
                 anchors.centerIn: parent
                 spacing: Theme.spacing.small
 
-                Rectangle {
+                AppTile {
                     Layout.alignment: Qt.AlignHCenter
-                    Layout.preferredWidth: d.tileSize
-                    Layout.preferredHeight: d.tileSize
-                    color: d.tileColor
-                    radius: Theme.spacing.radiusMedium
-
-                    LogosIcon {
-                        anchors.centerIn: parent
-                        source: d.targetIcon
-                        color: Theme.palette.text
-                        brightness: 1.0
-                        width: 32
-                        height: 32
-                        visible: d.hasIcon
-                    }
-                    LogosText {
-                        anchors.centerIn: parent
-                        visible: !d.hasIcon
-                        text: (d.targetDisplayName || "?").substring(0, 2).toUpperCase()
-                        font.pixelSize: d.monogramSize
-                        font.weight: Theme.typography.weightBold
-                        color: Theme.palette.text
-                    }
+                    appName: d.targetName
+                    monogramLabel: d.targetDisplayName
+                    packageColor: d.packageColor
+                    iconSource: d.targetIcon
+                    tileSize: d.tileSize
+                    iconSize: 32
                 }
 
                 LogosText {

--- a/src/Basecamp/AppManager/AppColors.qml
+++ b/src/Basecamp/AppManager/AppColors.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 import QtQuick
+import Logos.Theme
 
 QtObject {
     function hash32(key) {
@@ -14,13 +15,28 @@ QtObject {
         return h
     }
 
+    // Muted accent for dark-theme app tiles (single solid fill).
     function colorForApp(appKey) {
-        if (!appKey) return "#404040"
+        if (!appKey) return Theme.palette.surfaceRaised
         var h = hash32(appKey)
-        // Golden-ratio hue: maximally spreads similar hashes around the wheel.
         var hue = ((h / 4294967296) * 0.618033988749895) % 1
-        var sat   = 0.68
-        var light = 0.48
+        var sat   = 0.38
+        var light = 0.22
         return Qt.hsla(hue, sat, light, 1.0)
+    }
+
+    function accentForDarkTheme(color) {
+        var c = Qt.color(color)
+        var hue = c.hsvHue
+        if (hue < 0)
+            hue = (hash32(color) / 4294967296) % 1
+        var sat = Math.max(0.30, Math.min(c.hsvSaturation > 0 ? c.hsvSaturation : 0.38, 0.50))
+        return Qt.hsva(hue, sat, 0.28, 1.0)
+    }
+
+    function tileColor(packageColor, appKey) {
+        if (packageColor && packageColor.length > 0)
+            return accentForDarkTheme(packageColor)
+        return colorForApp(appKey)
     }
 }

--- a/src/Basecamp/AppManager/AppGridDelegate.qml
+++ b/src/Basecamp/AppManager/AppGridDelegate.qml
@@ -36,18 +36,11 @@ ItemDelegate {
         readonly property string displayName:   root.appData ? (root.appData.displayName || root.appData.name || "") : ""
         readonly property string iconUrl:      root.appData ? (root.appData.iconUrl || "") : ""
         readonly property string repositoryUrl: root.appData ? (root.appData.repositoryUrl || "") : ""
-        readonly property string monogram:      (d.nameText || "?").substring(0, 2).toUpperCase()
-        readonly property bool   hasIcon:       d.iconUrl.length > 0
-
         readonly property string packageColor: root.appData ? (root.appData.color || "") : ""
-        readonly property color  tileColor:
-            d.packageColor.length > 0 ? d.packageColor
-                                      : AppColors.colorForApp(d.nameText)
         readonly property real tileOpacity:
             (d.isInstalled || root.hovered) ? 1.0 : 0.55
 
         readonly property int tileSize: 80
-        readonly property int monogramSize: Math.round(d.tileSize * 0.375)
     }
 
     background: Item {}
@@ -67,35 +60,23 @@ ItemDelegate {
             anchors.horizontalCenter: parent.horizontalCenter
             spacing: Theme.spacing.medium
 
-            Rectangle {
+            Item {
                 id: tile
                 Layout.preferredWidth: d.tileSize
                 Layout.preferredHeight: d.tileSize
                 Layout.alignment: Qt.AlignHCenter
-                radius: Theme.spacing.radiusXlarge
-                color: d.tileColor
-                border.color: root.hovered ? Theme.palette.border : "transparent"
-                border.width: 1
-                opacity: d.tileOpacity
-                Behavior on opacity { NumberAnimation { duration: 150 } }
 
-                LogosIcon {
-                    anchors.centerIn: parent
-                    source: d.iconUrl
-                    color: Theme.palette.text
-                    brightness: 1.0
-                    width: 40
-                    height: 40
-                    visible: d.hasIcon
-                }
-
-                LogosText {
-                    anchors.centerIn: parent
-                    text: d.monogram
-                    font.pixelSize: d.monogramSize
-                    font.weight: Theme.typography.weightBold
-                    color: Theme.palette.text
-                    visible: !d.hasIcon
+                AppTile {
+                    anchors.fill: parent
+                    appName: d.nameText
+                    packageColor: d.packageColor
+                    iconSource: d.iconUrl
+                    tileSize: d.tileSize
+                    iconSize: 40
+                    radius: Theme.spacing.radiusXlarge
+                    borderOnHover: true
+                    borderEmphasized: root.hovered
+                    dimOpacity: d.tileOpacity
                 }
 
                 LogosBadge {

--- a/src/Basecamp/AppManager/AppListDelegate.qml
+++ b/src/Basecamp/AppManager/AppListDelegate.qml
@@ -36,18 +36,11 @@ ItemDelegate {
         readonly property string iconUrl:      root.appData ? (root.appData.iconUrl || "") : ""
         readonly property string description:   root.appData ? (root.appData.description || "") : ""
         readonly property string repositoryUrl: root.appData ? (root.appData.repositoryUrl || "") : ""
-        readonly property string monogram:      (d.nameText || "?").substring(0, 2).toUpperCase()
-        readonly property bool   hasIcon:       d.iconUrl.length > 0
-
         readonly property string packageColor: root.appData ? (root.appData.color || "") : ""
-        readonly property color  tileColor:
-            d.packageColor.length > 0 ? d.packageColor
-                                      : AppColors.colorForApp(d.nameText)
         readonly property real tileOpacity:
             (d.isInstalled || root.hovered) ? 1.0 : 0.55
 
         readonly property int tileSize: 40
-        readonly property int monogramSize: Math.round(d.tileSize * 0.375)
     }
 
     padding: 0
@@ -72,33 +65,16 @@ ItemDelegate {
         anchors.rightMargin: Theme.spacing.medium
         spacing: Theme.spacing.medium
 
-        Rectangle {
+        AppTile {
             Layout.preferredWidth: d.tileSize
             Layout.preferredHeight: d.tileSize
             Layout.alignment: Qt.AlignVCenter
-            radius: Theme.spacing.radiusMedium
-            color: d.tileColor
-            opacity: d.tileOpacity
-            Behavior on opacity { NumberAnimation { duration: 150 } }
-
-            LogosIcon {
-                anchors.centerIn: parent
-                source: d.iconUrl
-                color: Theme.palette.text
-                brightness: 1.0
-                width: 24
-                height: 24
-                visible: d.hasIcon
-            }
-
-            LogosText {
-                anchors.centerIn: parent
-                text: d.monogram
-                font.pixelSize: d.monogramSize
-                font.weight: Theme.typography.weightBold
-                color: Theme.palette.text
-                visible: !d.hasIcon
-            }
+            appName: d.nameText
+            packageColor: d.packageColor
+            iconSource: d.iconUrl
+            tileSize: d.tileSize
+            iconSize: 24
+            dimOpacity: d.tileOpacity
         }
 
         // Name + (optional) description.

--- a/src/Basecamp/AppManager/AppTile.qml
+++ b/src/Basecamp/AppManager/AppTile.qml
@@ -1,0 +1,63 @@
+import QtQuick
+import QtQuick.Controls
+import Logos.Theme
+import Logos.Controls
+
+// Shared app tile: dark muted background, package icon or monogram.
+Control {
+    id: root
+
+    property string appName: ""
+    property string monogramLabel: ""
+    property string packageColor: ""
+    property url iconSource: ""
+    property real dimOpacity: 1.0
+
+    property int tileSize: 40
+    property int iconSize: 0
+    property int radius: Theme.spacing.radiusMedium
+    property bool borderOnHover: false
+    // Parent delegate hover (Control.hovered is FINAL and only tracks this item).
+    property bool borderEmphasized: false
+
+    readonly property int effectiveIconSize:
+        iconSize > 0 ? iconSize : Math.round(tileSize * 0.5)
+    readonly property string monogram:
+        ((monogramLabel || appName) || "?").substring(0, 2).toUpperCase()
+    readonly property bool hasIcon: iconSource.toString().length > 0
+
+    implicitWidth: tileSize
+    implicitHeight: tileSize
+    padding: 0
+    opacity: dimOpacity
+    Behavior on opacity { NumberAnimation { duration: 150 } }
+
+    background: Rectangle {
+        radius: root.radius
+        color: AppColors.tileColor(root.packageColor, root.appName)
+        border.width: 1
+        border.color: root.borderOnHover && root.borderEmphasized
+                      ? Theme.palette.border
+                      : Theme.palette.borderSubtle
+    }
+
+    contentItem: Item {
+        LogosIcon {
+            anchors.centerIn: parent
+            width: root.effectiveIconSize
+            height: root.effectiveIconSize
+            source: root.iconSource
+            color: Theme.palette.text
+            visible: root.hasIcon
+        }
+
+        LogosText {
+            anchors.centerIn: parent
+            text: root.monogram
+            font.pixelSize: Math.round(root.tileSize * 0.375)
+            font.weight: Theme.typography.weightBold
+            color: Theme.palette.text
+            visible: !root.hasIcon
+        }
+    }
+}

--- a/src/Basecamp/Sidebar/SidebarAppDelegate.qml
+++ b/src/Basecamp/Sidebar/SidebarAppDelegate.qml
@@ -21,16 +21,8 @@ AbstractButton {
         id: d
 
         readonly property string nameText: root.text || ""
-        readonly property string monogram: (d.nameText || "?").substring(0, 2).toUpperCase()
-        readonly property color tileColor: AppColors.colorForApp(d.nameText)
-        readonly property real uninstalledTileAlpha: 0.55
-        readonly property color tileBackgroundColor:
-            root.loaded ? d.tileColor
-                        : Theme.colors.getColor(d.tileColor, d.uninstalledTileAlpha)
-
         readonly property int tileSize: 38
         readonly property int iconSize: 19
-        readonly property int monogramSize: Math.round(d.tileSize * 0.375)
     }
 
     onHoveredChanged: {
@@ -54,36 +46,15 @@ AbstractButton {
     }
 
     contentItem: Item {
-        Rectangle {
+        AppTile {
             id: tile
             anchors.centerIn: parent
-            width: d.tileSize
-            height: d.tileSize
-            radius: Theme.spacing.radiusMedium
-            color: d.tileBackgroundColor
-
-            LogosIcon {
-                id: appIcon
-                anchors.centerIn: parent
-                source: root.icon.source
-                color: Theme.palette.text
-                brightness: 1.0
-                width: d.iconSize
-                height: d.iconSize
-                visible: !root.loading
-                         && !!root.icon.source
-                         && appIcon.imageItem.status !== Image.Null
-                         && appIcon.imageItem.status !== Image.Error
-            }
-
-            LogosText {
-                anchors.centerIn: parent
-                text: d.monogram
-                font.pixelSize: d.monogramSize
-                font.weight: Theme.typography.weightBold
-                color: Theme.palette.text
-                visible: !root.loading && !appIcon.visible
-            }
+            appName: d.nameText
+            iconSource: root.icon.source
+            tileSize: d.tileSize
+            iconSize: d.iconSize
+            dimOpacity: root.loaded ? 1.0 : 0.55
+            visible: !root.loading
         }
 
         Item {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,6 +246,7 @@ qt_add_qml_module(basecamp_appmanager_qml
         Basecamp/AppManager/PackageRowDelegate.qml
         Basecamp/AppManager/AddApplicationDialog.qml
         Basecamp/AppManager/AppColors.qml
+        Basecamp/AppManager/AppTile.qml
 )
 
 qt_add_qml_module(basecamp_settings_qml


### PR DESCRIPTION
…app icons as they are delivered

<img width="1056" height="787" alt="image" src="https://github.com/user-attachments/assets/75935d73-f8c2-4b6a-8a73-ab9aa8c24671" />


fixes #233 