### PR TITLE
chore: bump liblogos + package-manager modules (logos-protocol json-convert fix)

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -130,12 +130,15 @@ int main(int argc, char *argv[])
     logos_core_set_persistence_base_path(
         LogosBasecampPaths::moduleDataDirectory().toUtf8().constData());
 
-    // Restrict the package_manager / package_downloader modules to calls
-    // from package_manager_ui. Must be set before logos_core_start().
-    logos_core_set_access_policy(
-        "{\"version\":1,\"mode\":\"enforce\",\"restrictions\":{"
-        "\"package_manager\":{\"allowedCallers\":[\"package_manager_ui\"]},"
-        "\"package_downloader\":{\"allowedCallers\":[\"package_manager_ui\"]}}}");
+    // Access policy temporarily disabled (allow all): passing NULL clears any
+    // policy so no enforcement runs. The enforce mode's derived deny-by-default
+    // gates every ui_qml app's calls to its own backend module, because UI
+    // plugins are loaded out-of-process and aren't tracked as dependents in the
+    // core ModuleRegistry — so they're never in a module's derived allowed-caller
+    // set and get denied (e.g. accounts_ui -> accounts_module). Re-enable once the
+    // access policy is redesigned to account for ui_qml callers.
+    // (Must be set before logos_core_start().)
+    logos_core_set_access_policy(nullptr);
 
     // Start the core
     logos_core_start();

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "default-container": {
       "inputs": {
         "logos-container": "logos-container",
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_129",
         "nixpkgs": [
           "logos-liblogos",
           "default-container",
@@ -28,12 +28,21 @@
     "default-module-loader": {
       "inputs": {
         "logos-container": "logos-container_2",
-        "logos-cpp-sdk": "logos-cpp-sdk_14",
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
         "logos-module": "logos-module_17",
         "logos-module-loader": "logos-module-loader",
-        "logos-nix": "logos-nix_133",
-        "logos-protocol": "logos-protocol_3",
-        "logos-qt-sdk": "logos-qt-sdk_3",
+        "logos-nix": "logos-nix_134",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-liblogos",
+          "logos-qt-sdk"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -60,11 +69,11 @@
         "logos-module-builder": "logos-module-builder"
       },
       "locked": {
-        "lastModified": 1782156979,
-        "narHash": "sha256-3lXRf8hZBLyZr3CK8wEToSTcD4dIJ4mkqsOqisr9iwM=",
+        "lastModified": 1782404211,
+        "narHash": "sha256-TbBsnEqvddSw4zeyC+K7yUeSHIBLPYWhMpaR7TOD1oM=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e5373f252468b2b7999d96d4d248cbb5c3ccbdd4",
+        "rev": "62be3aaeb271daa8ac6c77223a728a2e83ce62ac",
         "type": "github"
       },
       "original": {
@@ -86,7 +95,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_24",
-        "logos-nix": "logos-nix_151",
+        "logos-nix": "logos-nix_150",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -115,9 +124,9 @@
     },
     "logos-capability-module_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-cpp-sdk": "logos-cpp-sdk_17",
         "logos-module": "logos-module_25",
-        "logos-nix": "logos-nix_156",
+        "logos-nix": "logos-nix_155",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -178,7 +187,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_30",
-        "logos-nix": "logos-nix_195",
+        "logos-nix": "logos-nix_194",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -208,9 +217,9 @@
     },
     "logos-capability-module_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-module": "logos-module_31",
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_199",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -245,11 +254,11 @@
         "logos-module-builder": "logos-module-builder_8"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -270,7 +279,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_42",
-        "logos-nix": "logos-nix_291",
+        "logos-nix": "logos-nix_290",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -298,9 +307,9 @@
     },
     "logos-capability-module_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-module": "logos-module_43",
-        "logos-nix": "logos-nix_296",
+        "logos-nix": "logos-nix_295",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -333,11 +342,11 @@
         "logos-module-builder": "logos-module-builder_9"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1781129198,
+        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
         "type": "github"
       },
       "original": {
@@ -359,7 +368,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_48",
-        "logos-nix": "logos-nix_335",
+        "logos-nix": "logos-nix_334",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -391,11 +400,11 @@
         "logos-module-builder": "logos-module-builder_2"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -406,9 +415,9 @@
     },
     "logos-capability-module_20": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-module": "logos-module_49",
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_339",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -442,11 +451,11 @@
         "logos-module-builder": "logos-module-builder_11"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -467,7 +476,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_424",
+        "logos-nix": "logos-nix_425",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -495,9 +504,9 @@
     },
     "logos-capability-module_23": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-module": "logos-module_59",
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_430",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -530,11 +539,11 @@
         "logos-module-builder": "logos-module-builder_12"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1781129198,
+        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
         "type": "github"
       },
       "original": {
@@ -556,7 +565,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_468",
+        "logos-nix": "logos-nix_469",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -585,9 +594,9 @@
     },
     "logos-capability-module_26": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_48",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
         "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_473",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -621,11 +630,11 @@
         "logos-module-builder": "logos-module-builder_14"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1780946924,
+        "narHash": "sha256-8wFILW1oMS1L77Ff4bcC/5W9dytNe6I1rhf5AHhQW2U=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "0013e7653eb1b23d5495e39f149259bd60dc1db4",
         "type": "github"
       },
       "original": {
@@ -646,7 +655,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_74",
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_555",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -674,9 +683,9 @@
     },
     "logos-capability-module_29": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_55",
+        "logos-cpp-sdk": "logos-cpp-sdk_54",
         "logos-module": "logos-module_75",
-        "logos-nix": "logos-nix_557",
+        "logos-nix": "logos-nix_560",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -747,11 +756,11 @@
         "logos-module-builder": "logos-module-builder_15"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1781129198,
+        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
         "type": "github"
       },
       "original": {
@@ -773,7 +782,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_80",
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_599",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -802,9 +811,9 @@
     },
     "logos-capability-module_32": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_60",
+        "logos-cpp-sdk": "logos-cpp-sdk_59",
         "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_601",
+        "logos-nix": "logos-nix_604",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -864,7 +873,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_675",
+        "logos-nix": "logos-nix_680",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -893,9 +902,9 @@
     },
     "logos-capability-module_35": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_67",
+        "logos-cpp-sdk": "logos-cpp-sdk_66",
         "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_685",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -956,7 +965,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_96",
-        "logos-nix": "logos-nix_719",
+        "logos-nix": "logos-nix_724",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -986,9 +995,9 @@
     },
     "logos-capability-module_38": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_72",
+        "logos-cpp-sdk": "logos-cpp-sdk_71",
         "logos-module": "logos-module_97",
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_729",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -1081,7 +1090,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_106",
-        "logos-nix": "logos-nix_803",
+        "logos-nix": "logos-nix_808",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1110,9 +1119,9 @@
     },
     "logos-capability-module_41": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_79",
+        "logos-cpp-sdk": "logos-cpp-sdk_78",
         "logos-module": "logos-module_107",
-        "logos-nix": "logos-nix_808",
+        "logos-nix": "logos-nix_813",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1173,7 +1182,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_112",
-        "logos-nix": "logos-nix_847",
+        "logos-nix": "logos-nix_852",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1203,9 +1212,9 @@
     },
     "logos-capability-module_44": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_84",
+        "logos-cpp-sdk": "logos-cpp-sdk_83",
         "logos-module": "logos-module_113",
-        "logos-nix": "logos-nix_852",
+        "logos-nix": "logos-nix_857",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1240,11 +1249,11 @@
         "logos-module-builder": "logos-module-builder_3"
       },
       "locked": {
-        "lastModified": 1778182598,
-        "narHash": "sha256-QoyirL/blmVM2cmXQwbR6rmHufQJ6vaJSCkNORu4qaA=",
+        "lastModified": 1781129198,
+        "narHash": "sha256-vnJCkDQlGKXStnXFGhATzY3dXwwQT4/nnljReFmAzQc=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "e675e9e3a98ee69bb303365c2c626f9237bc1ab5",
+        "rev": "5d438961e2defe72b76028150787d59e586eec8c",
         "type": "github"
       },
       "original": {
@@ -1364,7 +1373,7 @@
     },
     "logos-container": {
       "inputs": {
-        "logos-nix": "logos-nix_126",
+        "logos-nix": "logos-nix_128",
         "nixpkgs": [
           "logos-liblogos",
           "default-container",
@@ -1389,7 +1398,7 @@
     },
     "logos-container_2": {
       "inputs": {
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_130",
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -1414,7 +1423,7 @@
     },
     "logos-container_3": {
       "inputs": {
-        "logos-nix": "logos-nix_131",
+        "logos-nix": "logos-nix_132",
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -1440,7 +1449,7 @@
     },
     "logos-container_4": {
       "inputs": {
-        "logos-nix": "logos-nix_257",
+        "logos-nix": "logos-nix_256",
         "nixpkgs": [
           "logos-liblogos",
           "logos-container",
@@ -1464,7 +1473,7 @@
     },
     "logos-container_5": {
       "inputs": {
-        "logos-nix": "logos-nix_260",
+        "logos-nix": "logos-nix_259",
         "nixpkgs": [
           "logos-liblogos",
           "logos-module-loader",
@@ -1505,11 +1514,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897505,
-        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
+        "lastModified": 1782292503,
+        "narHash": "sha256-XKjPeGtv07xufTeUQJWST5vOznSVn1ykFQR3IxDbFto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
+        "rev": "31b9d2bf5f2b7542df50d07c1050b865b4b30de8",
         "type": "github"
       },
       "original": {
@@ -1552,6 +1561,13 @@
     "logos-cpp-sdk_11": {
       "inputs": {
         "logos-nix": "logos-nix_96",
+        "logos-protocol": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -1563,11 +1579,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -1585,6 +1601,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_5",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -1596,11 +1613,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
         "type": "github"
       },
       "original": {
@@ -1612,7 +1629,7 @@
     "logos-cpp-sdk_13": {
       "inputs": {
         "logos-lidl": "logos-lidl_4",
-        "logos-nix": "logos-nix_124",
+        "logos-nix": "logos-nix_126",
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -1638,38 +1655,7 @@
     },
     "logos-cpp-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_5",
-        "logos-nix": "logos-nix_129",
-        "logos-protocol": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781663756,
-        "narHash": "sha256-q1Q2MCax3L1RLfcS40sDStVipK6dhfiPHYk31YeGyUI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "182d850e722c820b3640a09541d7c469ef79f0e6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_15": {
-      "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_135",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1693,9 +1679,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_16": {
+    "logos-cpp-sdk_15": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_142",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1703,6 +1689,36 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_16": {
+      "inputs": {
+        "logos-nix": "logos-nix_151",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1724,37 +1740,7 @@
     },
     "logos-cpp-sdk_17": {
       "inputs": {
-        "logos-nix": "logos-nix_152",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_18": {
-      "inputs": {
-        "logos-nix": "logos-nix_154",
+        "logos-nix": "logos-nix_153",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1784,9 +1770,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_19": {
+    "logos-cpp-sdk_18": {
       "inputs": {
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_156",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1807,6 +1793,33 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_19": {
+      "inputs": {
+        "logos-nix": "logos-nix_184",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781027175,
+        "narHash": "sha256-NjODUctwKSIi3vMUSMgk6bxfW4fJM9vX5jndk8CfZJ4=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "bb6d87b6ec7a64814df48fbdb10cf5290ce4b724",
         "type": "github"
       },
       "original": {
@@ -1845,23 +1858,26 @@
     },
     "logos-cpp-sdk_20": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_186",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781027175,
-        "narHash": "sha256-NjODUctwKSIi3vMUSMgk6bxfW4fJM9vX5jndk8CfZJ4=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "bb6d87b6ec7a64814df48fbdb10cf5290ce4b724",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -1872,7 +1888,7 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-nix": "logos-nix_187",
+        "logos-nix": "logos-nix_195",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1881,6 +1897,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -1902,38 +1919,7 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_23": {
-      "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_197",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1964,9 +1950,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_24": {
+    "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_200",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -1996,9 +1982,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_25": {
+    "logos-cpp-sdk_24": {
       "inputs": {
-        "logos-nix": "logos-nix_229",
+        "logos-nix": "logos-nix_228",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -2024,7 +2010,7 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_26": {
+    "logos-cpp-sdk_25": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -2059,10 +2045,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_27": {
+    "logos-cpp-sdk_26": {
       "inputs": {
-        "logos-lidl": "logos-lidl_7",
-        "logos-nix": "logos-nix_258",
+        "logos-lidl": "logos-lidl_5",
+        "logos-nix": "logos-nix_257",
         "logos-protocol": [
           "logos-liblogos",
           "logos-protocol"
@@ -2088,10 +2074,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_28": {
+    "logos-cpp-sdk_27": {
       "inputs": {
-        "logos-lidl": "logos-lidl_9",
-        "logos-nix": "logos-nix_274",
+        "logos-lidl": "logos-lidl_7",
+        "logos-nix": "logos-nix_273",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2106,11 +2092,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897505,
-        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
+        "lastModified": 1782292503,
+        "narHash": "sha256-XKjPeGtv07xufTeUQJWST5vOznSVn1ykFQR3IxDbFto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
+        "rev": "31b9d2bf5f2b7542df50d07c1050b865b4b30de8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_28": {
+      "inputs": {
+        "logos-nix": "logos-nix_282",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2121,13 +2135,14 @@
     },
     "logos-cpp-sdk_29": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_291",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2178,36 +2193,7 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-        "logos-nix": "logos-nix_292",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_31": {
-      "inputs": {
-        "logos-nix": "logos-nix_294",
+        "logos-nix": "logos-nix_293",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2236,9 +2222,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_32": {
+    "logos-cpp-sdk_31": {
       "inputs": {
-        "logos-nix": "logos-nix_297",
+        "logos-nix": "logos-nix_296",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2266,9 +2252,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_33": {
+    "logos-cpp-sdk_32": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_324",
+        "logos-protocol": "logos-protocol_10",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2279,11 +2266,40 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_33": {
+      "inputs": {
+        "logos-nix": "logos-nix_326",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2294,7 +2310,7 @@
     },
     "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2302,6 +2318,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2323,37 +2340,7 @@
     },
     "logos-cpp-sdk_35": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_36": {
-      "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2383,9 +2370,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_37": {
+    "logos-cpp-sdk_36": {
       "inputs": {
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2414,9 +2401,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_38": {
+    "logos-cpp-sdk_37": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_368",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2428,11 +2422,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -2441,7 +2435,7 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_39": {
+    "logos-cpp-sdk_38": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -2450,6 +2444,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_13",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2461,11 +2456,42 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_39": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_10",
+        "logos-nix": "logos-nix_408",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782292503,
+        "narHash": "sha256-XKjPeGtv07xufTeUQJWST5vOznSVn1ykFQR3IxDbFto=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "31b9d2bf5f2b7542df50d07c1050b865b4b30de8",
         "type": "github"
       },
       "original": {
@@ -2507,15 +2533,12 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
-        "logos-lidl": "logos-lidl_12",
-        "logos-nix": "logos-nix_407",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
+        "logos-nix": "logos-nix_417",
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2523,11 +2546,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897505,
-        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2538,13 +2561,14 @@
     },
     "logos-cpp-sdk_41": {
       "inputs": {
-        "logos-nix": "logos-nix_416",
+        "logos-nix": "logos-nix_426",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2566,36 +2590,7 @@
     },
     "logos-cpp-sdk_42": {
       "inputs": {
-        "logos-nix": "logos-nix_425",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_43": {
-      "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_428",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2624,9 +2619,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_44": {
+    "logos-cpp-sdk_43": {
       "inputs": {
-        "logos-nix": "logos-nix_430",
+        "logos-nix": "logos-nix_431",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2654,9 +2649,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_45": {
+    "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_459",
+        "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2667,11 +2663,40 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_461",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2682,7 +2707,7 @@
     },
     "logos-cpp-sdk_46": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_470",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2690,6 +2715,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2711,37 +2737,7 @@
     },
     "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-nix": "logos-nix_469",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_471",
+        "logos-nix": "logos-nix_472",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2771,9 +2767,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_49": {
+    "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-nix": "logos-nix_474",
+        "logos-nix": "logos-nix_475",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2794,6 +2790,40 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_503",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -2834,23 +2864,30 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_20",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
         "type": "github"
       },
       "original": {
@@ -2861,41 +2898,8 @@
     },
     "logos-cpp-sdk_51": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_52": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_15",
-        "logos-nix": "logos-nix_535",
+        "logos-lidl": "logos-lidl_13",
+        "logos-nix": "logos-nix_538",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2910,11 +2914,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1781897505,
-        "narHash": "sha256-sRVgfo8VfWOXb3IH2JqZQAqBSfL0bYo3FrFSgS6yvqk=",
+        "lastModified": 1782292503,
+        "narHash": "sha256-XKjPeGtv07xufTeUQJWST5vOznSVn1ykFQR3IxDbFto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "aea29d37975aa0c32fdf37d7119830be905acf34",
+        "rev": "31b9d2bf5f2b7542df50d07c1050b865b4b30de8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_547",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -2925,13 +2957,14 @@
     },
     "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2953,36 +2986,7 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
-        "logos-nix": "logos-nix_553",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_555",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3011,9 +3015,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_56": {
+    "logos-cpp-sdk_55": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_561",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3041,9 +3045,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_57": {
+    "logos-cpp-sdk_56": {
       "inputs": {
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_589",
+        "logos-protocol": "logos-protocol_24",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3054,11 +3059,40 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_591",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -3069,7 +3103,7 @@
     },
     "logos-cpp-sdk_58": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
+        "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3077,6 +3111,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3098,63 +3133,7 @@
     },
     "logos-cpp-sdk_59": {
       "inputs": {
-        "logos-nix": "logos-nix_597",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_6": {
-      "inputs": {
-        "logos-nix": "logos-nix_52",
-        "nixpkgs": [
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_60": {
-      "inputs": {
-        "logos-nix": "logos-nix_599",
+        "logos-nix": "logos-nix_602",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3184,9 +3163,36 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_61": {
+    "logos-cpp-sdk_6": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_52",
+        "logos-protocol": "logos-protocol_2",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_60": {
+      "inputs": {
+        "logos-nix": "logos-nix_605",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3215,9 +3221,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_62": {
+    "logos-cpp-sdk_61": {
       "inputs": {
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_633",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3229,11 +3242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781304979,
+        "narHash": "sha256-uCCoJJRVCUUO6j03GO6/02+uuLd9GaAi/0dHaiW2bXs=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "f0fe8cbfeb1fe62d934b4abf8c300047a49420c9",
         "type": "github"
       },
       "original": {
@@ -3242,7 +3255,7 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_63": {
+    "logos-cpp-sdk_62": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -3251,6 +3264,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_27",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -3262,11 +3276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779716125,
-        "narHash": "sha256-PfpmvkXyDnQRW0dcnIthGKE17rm5bwm8KLbEqJcm9kM=",
+        "lastModified": 1781313016,
+        "narHash": "sha256-gbchE6ExNqonj5XXVURXahYaaML0qAtSV9wHHMjs+/E=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "rev": "87abcd804422cbd733c2e658ae2f42c20162115c",
         "type": "github"
       },
       "original": {
@@ -3275,10 +3289,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_64": {
+    "logos-cpp-sdk_63": {
       "inputs": {
-        "logos-lidl": "logos-lidl_18",
-        "logos-nix": "logos-nix_658",
+        "logos-lidl": "logos-lidl_16",
+        "logos-nix": "logos-nix_663",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3308,9 +3322,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_65": {
+    "logos-cpp-sdk_64": {
       "inputs": {
-        "logos-nix": "logos-nix_667",
+        "logos-nix": "logos-nix_672",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3318,6 +3332,36 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_65": {
+      "inputs": {
+        "logos-nix": "logos-nix_681",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3339,37 +3383,7 @@
     },
     "logos-cpp-sdk_66": {
       "inputs": {
-        "logos-nix": "logos-nix_676",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_683",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3399,9 +3413,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_68": {
+    "logos-cpp-sdk_67": {
       "inputs": {
-        "logos-nix": "logos-nix_681",
+        "logos-nix": "logos-nix_686",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3430,9 +3444,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_69": {
+    "logos-cpp-sdk_68": {
       "inputs": {
-        "logos-nix": "logos-nix_709",
+        "logos-nix": "logos-nix_714",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3449,6 +3463,36 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "d77c3dd616384addfcc8c5607860466850fdfcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_716",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -3488,7 +3532,7 @@
     },
     "logos-cpp-sdk_70": {
       "inputs": {
-        "logos-nix": "logos-nix_711",
+        "logos-nix": "logos-nix_725",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3497,6 +3541,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3518,38 +3563,7 @@
     },
     "logos-cpp-sdk_71": {
       "inputs": {
-        "logos-nix": "logos-nix_720",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_72": {
-      "inputs": {
-        "logos-nix": "logos-nix_722",
+        "logos-nix": "logos-nix_727",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3580,9 +3594,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_73": {
+    "logos-cpp-sdk_72": {
       "inputs": {
-        "logos-nix": "logos-nix_725",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3612,9 +3626,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_74": {
+    "logos-cpp-sdk_73": {
       "inputs": {
-        "logos-nix": "logos-nix_753",
+        "logos-nix": "logos-nix_758",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3640,7 +3654,7 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_75": {
+    "logos-cpp-sdk_74": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -3675,10 +3689,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_76": {
+    "logos-cpp-sdk_75": {
       "inputs": {
-        "logos-lidl": "logos-lidl_21",
-        "logos-nix": "logos-nix_786",
+        "logos-lidl": "logos-lidl_19",
+        "logos-nix": "logos-nix_791",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3708,9 +3722,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_77": {
+    "logos-cpp-sdk_76": {
       "inputs": {
-        "logos-nix": "logos-nix_795",
+        "logos-nix": "logos-nix_800",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3718,6 +3732,36 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_809",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3739,37 +3783,7 @@
     },
     "logos-cpp-sdk_78": {
       "inputs": {
-        "logos-nix": "logos-nix_804",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_79": {
-      "inputs": {
-        "logos-nix": "logos-nix_806",
+        "logos-nix": "logos-nix_811",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3791,6 +3805,37 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "4b66dac015e4b977d33cfae80a4c8e1d518679f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_79": {
+      "inputs": {
+        "logos-nix": "logos-nix_814",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
         "type": "github"
       },
       "original": {
@@ -3831,38 +3876,7 @@
     },
     "logos-cpp-sdk_80": {
       "inputs": {
-        "logos-nix": "logos-nix_809",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_81": {
-      "inputs": {
-        "logos-nix": "logos-nix_837",
+        "logos-nix": "logos-nix_842",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3887,9 +3901,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_82": {
+    "logos-cpp-sdk_81": {
       "inputs": {
-        "logos-nix": "logos-nix_839",
+        "logos-nix": "logos-nix_844",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3898,6 +3912,37 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778167634,
+        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_82": {
+      "inputs": {
+        "logos-nix": "logos-nix_853",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3919,38 +3964,7 @@
     },
     "logos-cpp-sdk_83": {
       "inputs": {
-        "logos-nix": "logos-nix_848",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778167634,
-        "narHash": "sha256-gbBYvyEDxBHF8iACAE/dFcljBkIUTWr1rP3gBLj62JI=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "25c88f4d48fa95ea4437194bcf60bd8d0cf84a74",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_84": {
-      "inputs": {
-        "logos-nix": "logos-nix_850",
+        "logos-nix": "logos-nix_855",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3981,9 +3995,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_85": {
+    "logos-cpp-sdk_84": {
       "inputs": {
-        "logos-nix": "logos-nix_853",
+        "logos-nix": "logos-nix_858",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4013,9 +4027,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_86": {
+    "logos-cpp-sdk_85": {
       "inputs": {
-        "logos-nix": "logos-nix_881",
+        "logos-nix": "logos-nix_886",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4041,7 +4055,7 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_87": {
+    "logos-cpp-sdk_86": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -4139,7 +4153,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_336",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -4169,7 +4183,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4198,7 +4212,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_459",
+        "logos-nix": "logos-nix_460",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4209,11 +4223,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778224414,
-        "narHash": "sha256-QSSCCE4eKGiIS5PqHDfk9Lj4VFmeCh18khbFWrGxvvc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "6176f0d7a5dfeb64a7f0f98e7ca2bf71a4804772",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -4224,7 +4238,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_470",
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4254,7 +4268,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_554",
+        "logos-nix": "logos-nix_557",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4283,7 +4297,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_590",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4294,11 +4308,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778224414,
-        "narHash": "sha256-QSSCCE4eKGiIS5PqHDfk9Lj4VFmeCh18khbFWrGxvvc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "6176f0d7a5dfeb64a7f0f98e7ca2bf71a4804772",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -4309,7 +4323,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_601",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4339,7 +4353,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_682",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4369,7 +4383,7 @@
     },
     "logos-design-system_18": {
       "inputs": {
-        "logos-nix": "logos-nix_710",
+        "logos-nix": "logos-nix_715",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4396,7 +4410,7 @@
     },
     "logos-design-system_19": {
       "inputs": {
-        "logos-nix": "logos-nix_721",
+        "logos-nix": "logos-nix_726",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4438,11 +4452,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778224414,
-        "narHash": "sha256-QSSCCE4eKGiIS5PqHDfk9Lj4VFmeCh18khbFWrGxvvc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "6176f0d7a5dfeb64a7f0f98e7ca2bf71a4804772",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -4453,7 +4467,7 @@
     },
     "logos-design-system_20": {
       "inputs": {
-        "logos-nix": "logos-nix_805",
+        "logos-nix": "logos-nix_810",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4483,7 +4497,7 @@
     },
     "logos-design-system_21": {
       "inputs": {
-        "logos-nix": "logos-nix_838",
+        "logos-nix": "logos-nix_843",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4510,7 +4524,7 @@
     },
     "logos-design-system_22": {
       "inputs": {
-        "logos-nix": "logos-nix_849",
+        "logos-nix": "logos-nix_854",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4571,7 +4585,7 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_125",
+        "logos-nix": "logos-nix_127",
         "nixpkgs": [
           "logos-design-system",
           "logos-nix",
@@ -4594,7 +4608,7 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_153",
+        "logos-nix": "logos-nix_152",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -4624,7 +4638,7 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_186",
+        "logos-nix": "logos-nix_185",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -4651,7 +4665,7 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -4682,7 +4696,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_293",
+        "logos-nix": "logos-nix_292",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -4711,7 +4725,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -4722,11 +4736,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778224414,
-        "narHash": "sha256-QSSCCE4eKGiIS5PqHDfk9Lj4VFmeCh18khbFWrGxvvc=",
+        "lastModified": 1780947586,
+        "narHash": "sha256-0l5Xjbx9bLRc6LF0FU3LZ15RmEYK9oOPy/EaOxQYHkc=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "6176f0d7a5dfeb64a7f0f98e7ca2bf71a4804772",
+        "rev": "4a37b34446ef4e55b16a5aeb011ffc5e8cbcbbb8",
         "type": "github"
       },
       "original": {
@@ -4771,9 +4785,9 @@
     "logos-liblogos_10": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_20",
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_343",
+        "logos-nix": "logos-nix_342",
         "logos-package-manager": "logos-package-manager_16",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -4805,9 +4819,9 @@
     "logos-liblogos_11": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_23",
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-module": "logos-module_60",
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_433",
         "logos-package-manager": "logos-package-manager_21",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4838,10 +4852,12 @@
     "logos-liblogos_12": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_24",
-        "logos-cpp-sdk": "logos-cpp-sdk_50",
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_505",
         "logos-package-manager": "logos-package-manager_25",
+        "logos-protocol": "logos-protocol_18",
+        "logos-qt-sdk": "logos-qt-sdk_13",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4853,11 +4869,11 @@
         "process-stats": "process-stats_13"
       },
       "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "lastModified": 1781311549,
+        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
         "type": "github"
       },
       "original": {
@@ -4869,9 +4885,9 @@
     "logos-liblogos_13": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_26",
-        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_476",
+        "logos-nix": "logos-nix_477",
         "logos-package-manager": "logos-package-manager_23",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4903,9 +4919,9 @@
     "logos-liblogos_14": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_29",
-        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-module": "logos-module_76",
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_563",
         "logos-package-manager": "logos-package-manager_28",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -4936,10 +4952,12 @@
     "logos-liblogos_15": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_30",
-        "logos-cpp-sdk": "logos-cpp-sdk_62",
+        "logos-cpp-sdk": "logos-cpp-sdk_61",
         "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_632",
+        "logos-nix": "logos-nix_635",
         "logos-package-manager": "logos-package-manager_32",
+        "logos-protocol": "logos-protocol_25",
+        "logos-qt-sdk": "logos-qt-sdk_18",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4951,11 +4969,11 @@
         "process-stats": "process-stats_16"
       },
       "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "lastModified": 1781311549,
+        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
         "type": "github"
       },
       "original": {
@@ -4967,9 +4985,9 @@
     "logos-liblogos_16": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_32",
-        "logos-cpp-sdk": "logos-cpp-sdk_61",
+        "logos-cpp-sdk": "logos-cpp-sdk_60",
         "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_604",
+        "logos-nix": "logos-nix_607",
         "logos-package-manager": "logos-package-manager_30",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5001,9 +5019,9 @@
     "logos-liblogos_17": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_35",
-        "logos-cpp-sdk": "logos-cpp-sdk_68",
+        "logos-cpp-sdk": "logos-cpp-sdk_67",
         "logos-module": "logos-module_92",
-        "logos-nix": "logos-nix_683",
+        "logos-nix": "logos-nix_688",
         "logos-package-manager": "logos-package-manager_34",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5035,9 +5053,9 @@
     "logos-liblogos_18": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_36",
-        "logos-cpp-sdk": "logos-cpp-sdk_74",
+        "logos-cpp-sdk": "logos-cpp-sdk_73",
         "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_755",
+        "logos-nix": "logos-nix_760",
         "logos-package-manager": "logos-package-manager_38",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5067,9 +5085,9 @@
     "logos-liblogos_19": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_38",
-        "logos-cpp-sdk": "logos-cpp-sdk_73",
+        "logos-cpp-sdk": "logos-cpp-sdk_72",
         "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_727",
+        "logos-nix": "logos-nix_732",
         "logos-package-manager": "logos-package-manager_36",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5106,6 +5124,8 @@
         "logos-module": "logos-module_16",
         "logos-nix": "logos-nix_98",
         "logos-package-manager": "logos-package-manager_5",
+        "logos-protocol": "logos-protocol_3",
+        "logos-qt-sdk": "logos-qt-sdk_2",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -5117,11 +5137,11 @@
         "process-stats": "process-stats_3"
       },
       "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "lastModified": 1781311549,
+        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
         "type": "github"
       },
       "original": {
@@ -5133,9 +5153,9 @@
     "logos-liblogos_20": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_41",
-        "logos-cpp-sdk": "logos-cpp-sdk_80",
+        "logos-cpp-sdk": "logos-cpp-sdk_79",
         "logos-module": "logos-module_108",
-        "logos-nix": "logos-nix_811",
+        "logos-nix": "logos-nix_816",
         "logos-package-manager": "logos-package-manager_40",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5167,9 +5187,9 @@
     "logos-liblogos_21": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_42",
-        "logos-cpp-sdk": "logos-cpp-sdk_86",
+        "logos-cpp-sdk": "logos-cpp-sdk_85",
         "logos-module": "logos-module_115",
-        "logos-nix": "logos-nix_883",
+        "logos-nix": "logos-nix_888",
         "logos-package-manager": "logos-package-manager_44",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5199,9 +5219,9 @@
     "logos-liblogos_22": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_44",
-        "logos-cpp-sdk": "logos-cpp-sdk_85",
+        "logos-cpp-sdk": "logos-cpp-sdk_84",
         "logos-module": "logos-module_114",
-        "logos-nix": "logos-nix_855",
+        "logos-nix": "logos-nix_860",
         "logos-package-manager": "logos-package-manager_42",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5271,13 +5291,13 @@
         "default-module-loader": "default-module-loader",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_4",
-        "logos-cpp-sdk": "logos-cpp-sdk_27",
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-module": "logos-module_34",
         "logos-module-loader": "logos-module-loader_2",
-        "logos-nix": "logos-nix_262",
+        "logos-nix": "logos-nix_261",
         "logos-package-manager": "logos-package-manager_13",
-        "logos-protocol": "logos-protocol_4",
-        "logos-qt-sdk": "logos-qt-sdk_4",
+        "logos-protocol": "logos-protocol_8",
+        "logos-qt-sdk": "logos-qt-sdk_6",
         "nixpkgs": [
           "logos-liblogos",
           "logos-nix",
@@ -5286,11 +5306,11 @@
         "process-stats": "process-stats_7"
       },
       "locked": {
-        "lastModified": 1782216859,
-        "narHash": "sha256-YeWDeqL+7pC4R5GAKGWCOzQi022ZTAkNOzxClX/5vYI=",
+        "lastModified": 1782391637,
+        "narHash": "sha256-CPJaolu/H+534A9yUNAfo4ROdDjspvojIY4BNInV+9k=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "bcccf2db6562439ea124aab06af5bf8125adf2a3",
+        "rev": "a86ca2897195c985b6c5bc9fd24b4cba1b9f793a",
         "type": "github"
       },
       "original": {
@@ -5302,9 +5322,9 @@
     "logos-liblogos_5": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_11",
-        "logos-cpp-sdk": "logos-cpp-sdk_19",
+        "logos-cpp-sdk": "logos-cpp-sdk_18",
         "logos-module": "logos-module_26",
-        "logos-nix": "logos-nix_159",
+        "logos-nix": "logos-nix_158",
         "logos-package-manager": "logos-package-manager_7",
         "nixpkgs": [
           "logos-liblogos",
@@ -5336,9 +5356,9 @@
     "logos-liblogos_6": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_12",
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-cpp-sdk": "logos-cpp-sdk_24",
         "logos-module": "logos-module_33",
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_230",
         "logos-package-manager": "logos-package-manager_11",
         "nixpkgs": [
           "logos-liblogos",
@@ -5368,9 +5388,9 @@
     "logos-liblogos_7": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_14",
-        "logos-cpp-sdk": "logos-cpp-sdk_24",
+        "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-module": "logos-module_32",
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_202",
         "logos-package-manager": "logos-package-manager_9",
         "nixpkgs": [
           "logos-liblogos",
@@ -5403,9 +5423,9 @@
     "logos-liblogos_8": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_17",
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
         "logos-module": "logos-module_44",
-        "logos-nix": "logos-nix_299",
+        "logos-nix": "logos-nix_298",
         "logos-package-manager": "logos-package-manager_14",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -5436,10 +5456,12 @@
     "logos-liblogos_9": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_18",
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_370",
         "logos-package-manager": "logos-package-manager_18",
+        "logos-protocol": "logos-protocol_11",
+        "logos-qt-sdk": "logos-qt-sdk_8",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5451,11 +5473,11 @@
         "process-stats": "process-stats_10"
       },
       "locked": {
-        "lastModified": 1779724404,
-        "narHash": "sha256-HKgY1cbcm1BgFau0KBJba0pKGNZ/7oJMcqJMhPDQ20Q=",
+        "lastModified": 1781311549,
+        "narHash": "sha256-1laKvOevI1RrXQxllvlXFJnFmRQWLbvWfmbUZ02O7NY=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "be7c8fd8e89e9c7506421735e18dc85bde0c1cb2",
+        "rev": "050f2d36284d29e0660a4086b5a8af49fd70f4ff",
         "type": "github"
       },
       "original": {
@@ -5498,15 +5520,15 @@
     "logos-lidl_10": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5529,15 +5551,15 @@
     "logos-lidl_11": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5562,13 +5584,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5591,15 +5613,15 @@
     "logos-lidl_13": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5622,15 +5644,15 @@
     "logos-lidl_14": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5655,13 +5677,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5685,14 +5707,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5716,14 +5740,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5749,14 +5775,14 @@
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5780,16 +5806,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "package_manager",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "package_manager",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5844,16 +5870,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "package_manager",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "package_manager",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5879,14 +5905,14 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5907,72 +5933,6 @@
       }
     },
     "logos-lidl_22": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_23": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781653473,
-        "narHash": "sha256-8l2tE2K5nY1grcFROQHC1By1jVI0NrfkS3k2v2y6R2I=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "8c95d4f0cc6a10195c70ed71e85b7a4cddca02f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_24": {
       "inputs": {
         "logos-nix": [
           "logos-qt-sdk",
@@ -6061,13 +6021,11 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6092,13 +6050,11 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "default-module-loader",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6122,12 +6078,14 @@
     "logos-lidl_7": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
+          "logos-package-downloader-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
+          "logos-package-downloader-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6151,12 +6109,14 @@
     "logos-lidl_8": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
+          "logos-package-downloader-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
+          "logos-package-downloader-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6182,13 +6142,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6220,11 +6180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1781873810,
+        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
         "type": "github"
       },
       "original": {
@@ -6256,11 +6216,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782146416,
-        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
+        "lastModified": 1782297704,
+        "narHash": "sha256-7BtfWuFsBvZ9dBcF2LjZttXhHzt/3tuHI7TJ4p+w2E0=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
+        "rev": "0325d6aa9d5737fca461482c204f594339da24e2",
         "type": "github"
       },
       "original": {
@@ -6271,13 +6231,13 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_410",
         "logos-plugin-core": "logos-plugin-core_10",
         "logos-plugin-qt": "logos-plugin-qt_10",
-        "logos-protocol": "logos-protocol_7",
-        "logos-qt-sdk": "logos-qt-sdk_7",
+        "logos-protocol": "logos-protocol_16",
+        "logos-qt-sdk": "logos-qt-sdk_12",
         "logos-rust-sdk": "logos-rust-sdk_3",
         "logos-standalone-app": "logos-standalone-app_10",
         "logos-test-framework": "logos-test-framework_12",
@@ -6292,11 +6252,11 @@
         "rust-overlay": "rust-overlay_3"
       },
       "locked": {
-        "lastModified": 1782146416,
-        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
+        "lastModified": 1782297704,
+        "narHash": "sha256-7BtfWuFsBvZ9dBcF2LjZttXhHzt/3tuHI7TJ4p+w2E0=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
+        "rev": "0325d6aa9d5737fca461482c204f594339da24e2",
         "type": "github"
       },
       "original": {
@@ -6307,9 +6267,9 @@
     },
     "logos-module-builder_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_418",
+        "logos-nix": "logos-nix_419",
         "logos-plugin-core": "logos-plugin-core_11",
         "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-standalone-app": "logos-standalone-app_11",
@@ -6342,9 +6302,9 @@
     },
     "logos-module-builder_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
         "logos-module": "logos-module_61",
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_463",
         "logos-plugin-core": "logos-plugin-core_12",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-standalone-app": "logos-standalone-app_12",
@@ -6378,13 +6338,13 @@
     },
     "logos-module-builder_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_52",
+        "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_537",
+        "logos-nix": "logos-nix_540",
         "logos-plugin-core": "logos-plugin-core_13",
         "logos-plugin-qt": "logos-plugin-qt_13",
-        "logos-protocol": "logos-protocol_9",
-        "logos-qt-sdk": "logos-qt-sdk_9",
+        "logos-protocol": "logos-protocol_23",
+        "logos-qt-sdk": "logos-qt-sdk_17",
         "logos-rust-sdk": "logos-rust-sdk_4",
         "logos-standalone-app": "logos-standalone-app_13",
         "logos-test-framework": "logos-test-framework_15",
@@ -6399,11 +6359,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1782146416,
-        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
+        "lastModified": 1782297704,
+        "narHash": "sha256-7BtfWuFsBvZ9dBcF2LjZttXhHzt/3tuHI7TJ4p+w2E0=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
+        "rev": "0325d6aa9d5737fca461482c204f594339da24e2",
         "type": "github"
       },
       "original": {
@@ -6414,9 +6374,9 @@
     },
     "logos-module-builder_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_53",
+        "logos-cpp-sdk": "logos-cpp-sdk_52",
         "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_549",
         "logos-plugin-core": "logos-plugin-core_14",
         "logos-plugin-qt": "logos-plugin-qt_14",
         "logos-standalone-app": "logos-standalone-app_14",
@@ -6449,9 +6409,9 @@
     },
     "logos-module-builder_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_58",
+        "logos-cpp-sdk": "logos-cpp-sdk_57",
         "logos-module": "logos-module_77",
-        "logos-nix": "logos-nix_590",
+        "logos-nix": "logos-nix_593",
         "logos-plugin-core": "logos-plugin-core_15",
         "logos-plugin-qt": "logos-plugin-qt_15",
         "logos-standalone-app": "logos-standalone-app_15",
@@ -6485,13 +6445,13 @@
     },
     "logos-module-builder_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_64",
+        "logos-cpp-sdk": "logos-cpp-sdk_63",
         "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_660",
+        "logos-nix": "logos-nix_665",
         "logos-plugin-core": "logos-plugin-core_16",
         "logos-plugin-qt": "logos-plugin-qt_16",
-        "logos-protocol": "logos-protocol_11",
-        "logos-qt-sdk": "logos-qt-sdk_11",
+        "logos-protocol": "logos-protocol_30",
+        "logos-qt-sdk": "logos-qt-sdk_22",
         "logos-rust-sdk": "logos-rust-sdk_5",
         "logos-standalone-app": "logos-standalone-app_16",
         "logos-test-framework": "logos-test-framework_18",
@@ -6522,9 +6482,9 @@
     },
     "logos-module-builder_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_65",
+        "logos-cpp-sdk": "logos-cpp-sdk_64",
         "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_674",
         "logos-plugin-core": "logos-plugin-core_17",
         "logos-plugin-qt": "logos-plugin-qt_17",
         "logos-standalone-app": "logos-standalone-app_17",
@@ -6558,9 +6518,9 @@
     },
     "logos-module-builder_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_70",
+        "logos-cpp-sdk": "logos-cpp-sdk_69",
         "logos-module": "logos-module_93",
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_718",
         "logos-plugin-core": "logos-plugin-core_18",
         "logos-plugin-qt": "logos-plugin-qt_18",
         "logos-standalone-app": "logos-standalone-app_18",
@@ -6595,13 +6555,13 @@
     },
     "logos-module-builder_19": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_76",
+        "logos-cpp-sdk": "logos-cpp-sdk_75",
         "logos-module": "logos-module_100",
-        "logos-nix": "logos-nix_788",
+        "logos-nix": "logos-nix_793",
         "logos-plugin-core": "logos-plugin-core_19",
         "logos-plugin-qt": "logos-plugin-qt_19",
-        "logos-protocol": "logos-protocol_13",
-        "logos-qt-sdk": "logos-qt-sdk_13",
+        "logos-protocol": "logos-protocol_32",
+        "logos-qt-sdk": "logos-qt-sdk_24",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": "logos-standalone-app_19",
         "logos-test-framework": "logos-test-framework_21",
@@ -6667,9 +6627,9 @@
     },
     "logos-module-builder_20": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_77",
+        "logos-cpp-sdk": "logos-cpp-sdk_76",
         "logos-module": "logos-module_103",
-        "logos-nix": "logos-nix_797",
+        "logos-nix": "logos-nix_802",
         "logos-plugin-core": "logos-plugin-core_20",
         "logos-plugin-qt": "logos-plugin-qt_20",
         "logos-standalone-app": "logos-standalone-app_20",
@@ -6703,9 +6663,9 @@
     },
     "logos-module-builder_21": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_82",
+        "logos-cpp-sdk": "logos-cpp-sdk_81",
         "logos-module": "logos-module_109",
-        "logos-nix": "logos-nix_841",
+        "logos-nix": "logos-nix_846",
         "logos-plugin-core": "logos-plugin-core_21",
         "logos-plugin-qt": "logos-plugin-qt_21",
         "logos-standalone-app": "logos-standalone-app_21",
@@ -6776,9 +6736,9 @@
     },
     "logos-module-builder_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_15",
+        "logos-cpp-sdk": "logos-cpp-sdk_14",
         "logos-module": "logos-module_18",
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_137",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_4",
         "logos-standalone-app": "logos-standalone-app_4",
@@ -6809,9 +6769,9 @@
     },
     "logos-module-builder_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_16",
+        "logos-cpp-sdk": "logos-cpp-sdk_15",
         "logos-module": "logos-module_21",
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_144",
         "logos-plugin-core": "logos-plugin-core_5",
         "logos-plugin-qt": "logos-plugin-qt_5",
         "logos-standalone-app": "logos-standalone-app_5",
@@ -6845,9 +6805,9 @@
     },
     "logos-module-builder_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-cpp-sdk": "logos-cpp-sdk_20",
         "logos-module": "logos-module_27",
-        "logos-nix": "logos-nix_189",
+        "logos-nix": "logos-nix_188",
         "logos-plugin-core": "logos-plugin-core_6",
         "logos-plugin-qt": "logos-plugin-qt_6",
         "logos-standalone-app": "logos-standalone-app_6",
@@ -6882,13 +6842,13 @@
     },
     "logos-module-builder_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_276",
+        "logos-nix": "logos-nix_275",
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_5",
-        "logos-qt-sdk": "logos-qt-sdk_5",
+        "logos-protocol": "logos-protocol_9",
+        "logos-qt-sdk": "logos-qt-sdk_7",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": "logos-standalone-app_7",
         "logos-test-framework": "logos-test-framework_9",
@@ -6903,11 +6863,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1782146416,
-        "narHash": "sha256-WkkDTc8p0YkZ5H1w9KmYih0WFT1+k/yjPKXtM3Mt6+E=",
+        "lastModified": 1782297704,
+        "narHash": "sha256-7BtfWuFsBvZ9dBcF2LjZttXhHzt/3tuHI7TJ4p+w2E0=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "f4942648c28127d4ef4d4b467b22bd33873ab4fa",
+        "rev": "0325d6aa9d5737fca461482c204f594339da24e2",
         "type": "github"
       },
       "original": {
@@ -6918,9 +6878,9 @@
     },
     "logos-module-builder_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_284",
         "logos-plugin-core": "logos-plugin-core_8",
         "logos-plugin-qt": "logos-plugin-qt_8",
         "logos-standalone-app": "logos-standalone-app_8",
@@ -6953,9 +6913,9 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-module": "logos-module_45",
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_328",
         "logos-plugin-core": "logos-plugin-core_9",
         "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-standalone-app": "logos-standalone-app_9",
@@ -6990,7 +6950,7 @@
     "logos-module-loader": {
       "inputs": {
         "logos-container": "logos-container_3",
-        "logos-nix": "logos-nix_132",
+        "logos-nix": "logos-nix_133",
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -7016,7 +6976,7 @@
     "logos-module-loader_2": {
       "inputs": {
         "logos-container": "logos-container_5",
-        "logos-nix": "logos-nix_261",
+        "logos-nix": "logos-nix_260",
         "nixpkgs": [
           "logos-liblogos",
           "logos-module-loader",
@@ -7069,7 +7029,7 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_787",
+        "logos-nix": "logos-nix_792",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7095,7 +7055,7 @@
     },
     "logos-module_101": {
       "inputs": {
-        "logos-nix": "logos-nix_789",
+        "logos-nix": "logos-nix_794",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7122,7 +7082,7 @@
     },
     "logos-module_102": {
       "inputs": {
-        "logos-nix": "logos-nix_791",
+        "logos-nix": "logos-nix_796",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7149,7 +7109,7 @@
     },
     "logos-module_103": {
       "inputs": {
-        "logos-nix": "logos-nix_796",
+        "logos-nix": "logos-nix_801",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7178,7 +7138,7 @@
     },
     "logos-module_104": {
       "inputs": {
-        "logos-nix": "logos-nix_798",
+        "logos-nix": "logos-nix_803",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7208,7 +7168,7 @@
     },
     "logos-module_105": {
       "inputs": {
-        "logos-nix": "logos-nix_800",
+        "logos-nix": "logos-nix_805",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7238,7 +7198,7 @@
     },
     "logos-module_106": {
       "inputs": {
-        "logos-nix": "logos-nix_802",
+        "logos-nix": "logos-nix_807",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7269,7 +7229,7 @@
     },
     "logos-module_107": {
       "inputs": {
-        "logos-nix": "logos-nix_807",
+        "logos-nix": "logos-nix_812",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7301,7 +7261,7 @@
     },
     "logos-module_108": {
       "inputs": {
-        "logos-nix": "logos-nix_810",
+        "logos-nix": "logos-nix_815",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7332,7 +7292,7 @@
     },
     "logos-module_109": {
       "inputs": {
-        "logos-nix": "logos-nix_840",
+        "logos-nix": "logos-nix_845",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7392,7 +7352,7 @@
     },
     "logos-module_110": {
       "inputs": {
-        "logos-nix": "logos-nix_842",
+        "logos-nix": "logos-nix_847",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7423,7 +7383,7 @@
     },
     "logos-module_111": {
       "inputs": {
-        "logos-nix": "logos-nix_844",
+        "logos-nix": "logos-nix_849",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7454,7 +7414,7 @@
     },
     "logos-module_112": {
       "inputs": {
-        "logos-nix": "logos-nix_846",
+        "logos-nix": "logos-nix_851",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7486,7 +7446,7 @@
     },
     "logos-module_113": {
       "inputs": {
-        "logos-nix": "logos-nix_851",
+        "logos-nix": "logos-nix_856",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7519,7 +7479,7 @@
     },
     "logos-module_114": {
       "inputs": {
-        "logos-nix": "logos-nix_854",
+        "logos-nix": "logos-nix_859",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7551,7 +7511,7 @@
     },
     "logos-module_115": {
       "inputs": {
-        "logos-nix": "logos-nix_882",
+        "logos-nix": "logos-nix_887",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7715,11 +7675,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1781310867,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
         "type": "github"
       },
       "original": {
@@ -7730,7 +7690,7 @@
     },
     "logos-module_17": {
       "inputs": {
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_131",
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -7755,7 +7715,7 @@
     },
     "logos-module_18": {
       "inputs": {
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_136",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7781,7 +7741,7 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_139",
+        "logos-nix": "logos-nix_138",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7834,7 +7794,7 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7861,7 +7821,7 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_143",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7890,7 +7850,7 @@
     },
     "logos-module_22": {
       "inputs": {
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_145",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7920,7 +7880,7 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_148",
+        "logos-nix": "logos-nix_147",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7950,7 +7910,7 @@
     },
     "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_150",
+        "logos-nix": "logos-nix_149",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -7981,7 +7941,7 @@
     },
     "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_155",
+        "logos-nix": "logos-nix_154",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8013,7 +7973,7 @@
     },
     "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_158",
+        "logos-nix": "logos-nix_157",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8044,7 +8004,7 @@
     },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_187",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8074,7 +8034,7 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_190",
+        "logos-nix": "logos-nix_189",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8105,7 +8065,7 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_191",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8162,7 +8122,7 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_193",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8194,7 +8154,7 @@
     },
     "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8227,7 +8187,7 @@
     },
     "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_201",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8259,7 +8219,7 @@
     },
     "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -8287,7 +8247,7 @@
     },
     "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_259",
+        "logos-nix": "logos-nix_258",
         "nixpkgs": [
           "logos-liblogos",
           "logos-module",
@@ -8311,7 +8271,7 @@
     },
     "logos-module_35": {
       "inputs": {
-        "logos-nix": "logos-nix_271",
+        "logos-nix": "logos-nix_270",
         "nixpkgs": [
           "logos-module",
           "logos-nix",
@@ -8334,7 +8294,7 @@
     },
     "logos-module_36": {
       "inputs": {
-        "logos-nix": "logos-nix_275",
+        "logos-nix": "logos-nix_274",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8344,11 +8304,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1781873810,
+        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
         "type": "github"
       },
       "original": {
@@ -8359,7 +8319,7 @@
     },
     "logos-module_37": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8385,7 +8345,7 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8411,7 +8371,7 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_284",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8467,7 +8427,7 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_285",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8496,7 +8456,7 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-nix": "logos-nix_287",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8525,7 +8485,7 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_290",
+        "logos-nix": "logos-nix_289",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8555,7 +8515,7 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
+        "logos-nix": "logos-nix_294",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8586,7 +8546,7 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_297",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8616,7 +8576,7 @@
     },
     "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8645,7 +8605,7 @@
     },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8675,7 +8635,7 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_332",
+        "logos-nix": "logos-nix_331",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8705,7 +8665,7 @@
     },
     "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8736,7 +8696,7 @@
     },
     "logos-module_49": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8797,7 +8757,7 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_341",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8828,7 +8788,7 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -8840,11 +8800,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1781310867,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
         "type": "github"
       },
       "original": {
@@ -8855,7 +8815,7 @@
     },
     "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -8865,11 +8825,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1781873810,
+        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
         "type": "github"
       },
       "original": {
@@ -8880,7 +8840,7 @@
     },
     "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
+        "logos-nix": "logos-nix_411",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -8906,7 +8866,7 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_413",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -8932,7 +8892,7 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_417",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -8960,7 +8920,7 @@
     },
     "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -8989,7 +8949,7 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_422",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9018,7 +8978,7 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_424",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9048,7 +9008,7 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_429",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9108,7 +9068,7 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_431",
+        "logos-nix": "logos-nix_432",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9138,7 +9098,7 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_462",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9167,7 +9127,7 @@
     },
     "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_464",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9197,7 +9157,7 @@
     },
     "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_466",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9227,7 +9187,7 @@
     },
     "logos-module_64": {
       "inputs": {
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9258,7 +9218,7 @@
     },
     "logos-module_65": {
       "inputs": {
-        "logos-nix": "logos-nix_472",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9290,7 +9250,7 @@
     },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9321,7 +9281,7 @@
     },
     "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_504",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -9333,11 +9293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1781310867,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
         "type": "github"
       },
       "original": {
@@ -9348,7 +9308,7 @@
     },
     "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_539",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9358,11 +9318,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1781873810,
+        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
         "type": "github"
       },
       "original": {
@@ -9373,7 +9333,7 @@
     },
     "logos-module_69": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9429,7 +9389,7 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9455,7 +9415,7 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_545",
+        "logos-nix": "logos-nix_548",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9483,7 +9443,7 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
+        "logos-nix": "logos-nix_550",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9512,7 +9472,7 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9541,7 +9501,7 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9571,7 +9531,7 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_559",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9602,7 +9562,7 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_559",
+        "logos-nix": "logos-nix_562",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9632,7 +9592,7 @@
     },
     "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_592",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9661,7 +9621,7 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_591",
+        "logos-nix": "logos-nix_594",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9691,7 +9651,7 @@
     },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9752,7 +9712,7 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_595",
+        "logos-nix": "logos-nix_598",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9783,7 +9743,7 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_600",
+        "logos-nix": "logos-nix_603",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9815,7 +9775,7 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_603",
+        "logos-nix": "logos-nix_606",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9846,7 +9806,7 @@
     },
     "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_631",
+        "logos-nix": "logos-nix_634",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -9858,11 +9818,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776369033,
-        "narHash": "sha256-ehePoUEd/u3Ng0TvCmjocXYJWWH6P61PA7tNpgV59lo=",
+        "lastModified": 1781310867,
+        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "194778491ef4dd36967ac40cc2fec6b8a8b1d660",
+        "rev": "b42805dac2874d8f72e1c12f7ac6a92ca7e5452c",
         "type": "github"
       },
       "original": {
@@ -9873,7 +9833,7 @@
     },
     "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_659",
+        "logos-nix": "logos-nix_664",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -9899,7 +9859,7 @@
     },
     "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_661",
+        "logos-nix": "logos-nix_666",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -9926,7 +9886,7 @@
     },
     "logos-module_86": {
       "inputs": {
-        "logos-nix": "logos-nix_663",
+        "logos-nix": "logos-nix_668",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -9953,7 +9913,7 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_668",
+        "logos-nix": "logos-nix_673",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -9982,7 +9942,7 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_670",
+        "logos-nix": "logos-nix_675",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10012,7 +9972,7 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_677",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10072,7 +10032,7 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_679",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10103,7 +10063,7 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_684",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10135,7 +10095,7 @@
     },
     "logos-module_92": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_687",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10166,7 +10126,7 @@
     },
     "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
+        "logos-nix": "logos-nix_717",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10196,7 +10156,7 @@
     },
     "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_714",
+        "logos-nix": "logos-nix_719",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10227,7 +10187,7 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_716",
+        "logos-nix": "logos-nix_721",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10258,7 +10218,7 @@
     },
     "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_723",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10290,7 +10250,7 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_723",
+        "logos-nix": "logos-nix_728",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10323,7 +10283,7 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_726",
+        "logos-nix": "logos-nix_731",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10355,7 +10315,7 @@
     },
     "logos-module_99": {
       "inputs": {
-        "logos-nix": "logos-nix_754",
+        "logos-nix": "logos-nix_759",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -10494,11 +10454,11 @@
         "nixpkgs": "nixpkgs_104"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10566,11 +10526,11 @@
         "nixpkgs": "nixpkgs_108"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10584,11 +10544,11 @@
         "nixpkgs": "nixpkgs_109"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10620,11 +10580,11 @@
         "nixpkgs": "nixpkgs_110"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10638,11 +10598,11 @@
         "nixpkgs": "nixpkgs_111"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10656,11 +10616,11 @@
         "nixpkgs": "nixpkgs_112"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10674,11 +10634,11 @@
         "nixpkgs": "nixpkgs_113"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10692,11 +10652,11 @@
         "nixpkgs": "nixpkgs_114"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10710,11 +10670,11 @@
         "nixpkgs": "nixpkgs_115"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10728,11 +10688,11 @@
         "nixpkgs": "nixpkgs_116"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10746,11 +10706,11 @@
         "nixpkgs": "nixpkgs_117"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10764,11 +10724,11 @@
         "nixpkgs": "nixpkgs_118"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10836,11 +10796,11 @@
         "nixpkgs": "nixpkgs_121"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10872,11 +10832,11 @@
         "nixpkgs": "nixpkgs_123"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -10890,11 +10850,11 @@
         "nixpkgs": "nixpkgs_124"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -10944,11 +10904,11 @@
         "nixpkgs": "nixpkgs_127"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11016,11 +10976,11 @@
         "nixpkgs": "nixpkgs_130"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11034,11 +10994,11 @@
         "nixpkgs": "nixpkgs_131"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11124,11 +11084,11 @@
         "nixpkgs": "nixpkgs_136"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11142,24 +11102,6 @@
         "nixpkgs": "nixpkgs_137"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_138": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_138"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -11173,9 +11115,9 @@
         "type": "github"
       }
     },
-    "logos-nix_139": {
+    "logos-nix_138": {
       "inputs": {
-        "nixpkgs": "nixpkgs_139"
+        "nixpkgs": "nixpkgs_138"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -11183,6 +11125,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_139": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_139"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11214,11 +11174,11 @@
         "nixpkgs": "nixpkgs_140"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11232,11 +11192,11 @@
         "nixpkgs": "nixpkgs_141"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11268,11 +11228,11 @@
         "nixpkgs": "nixpkgs_143"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11286,11 +11246,11 @@
         "nixpkgs": "nixpkgs_144"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11304,11 +11264,11 @@
         "nixpkgs": "nixpkgs_145"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11322,11 +11282,11 @@
         "nixpkgs": "nixpkgs_146"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11340,24 +11300,6 @@
         "nixpkgs": "nixpkgs_147"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_148": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_148"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -11371,9 +11313,9 @@
         "type": "github"
       }
     },
-    "logos-nix_149": {
+    "logos-nix_148": {
       "inputs": {
-        "nixpkgs": "nixpkgs_149"
+        "nixpkgs": "nixpkgs_148"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -11381,6 +11323,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_149": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_149"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11430,11 +11390,11 @@
         "nixpkgs": "nixpkgs_151"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11448,11 +11408,11 @@
         "nixpkgs": "nixpkgs_152"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11520,24 +11480,6 @@
         "nixpkgs": "nixpkgs_156"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_157": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_157"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -11551,9 +11493,9 @@
         "type": "github"
       }
     },
-    "logos-nix_158": {
+    "logos-nix_157": {
       "inputs": {
-        "nixpkgs": "nixpkgs_158"
+        "nixpkgs": "nixpkgs_157"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -11561,6 +11503,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_158": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_158"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11610,11 +11570,11 @@
         "nixpkgs": "nixpkgs_160"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11700,24 +11660,6 @@
         "nixpkgs": "nixpkgs_165"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_166": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_166"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -11731,9 +11673,9 @@
         "type": "github"
       }
     },
-    "logos-nix_167": {
+    "logos-nix_166": {
       "inputs": {
-        "nixpkgs": "nixpkgs_167"
+        "nixpkgs": "nixpkgs_166"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -11741,6 +11683,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_167": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_167"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11772,11 +11732,11 @@
         "nixpkgs": "nixpkgs_169"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11826,11 +11786,11 @@
         "nixpkgs": "nixpkgs_171"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11862,11 +11822,11 @@
         "nixpkgs": "nixpkgs_173"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -11898,11 +11858,11 @@
         "nixpkgs": "nixpkgs_175"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -11934,11 +11894,11 @@
         "nixpkgs": "nixpkgs_177"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12024,11 +11984,11 @@
         "nixpkgs": "nixpkgs_181"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12042,11 +12002,11 @@
         "nixpkgs": "nixpkgs_182"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12078,11 +12038,11 @@
         "nixpkgs": "nixpkgs_184"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12096,11 +12056,11 @@
         "nixpkgs": "nixpkgs_185"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12114,11 +12074,11 @@
         "nixpkgs": "nixpkgs_186"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12132,24 +12092,6 @@
         "nixpkgs": "nixpkgs_187"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_188": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_188"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -12163,9 +12105,9 @@
         "type": "github"
       }
     },
-    "logos-nix_189": {
+    "logos-nix_188": {
       "inputs": {
-        "nixpkgs": "nixpkgs_189"
+        "nixpkgs": "nixpkgs_188"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -12173,6 +12115,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_189": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_189"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12204,11 +12164,11 @@
         "nixpkgs": "nixpkgs_190"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12222,24 +12182,6 @@
         "nixpkgs": "nixpkgs_191"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_192": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_192"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -12253,9 +12195,9 @@
         "type": "github"
       }
     },
-    "logos-nix_193": {
+    "logos-nix_192": {
       "inputs": {
-        "nixpkgs": "nixpkgs_193"
+        "nixpkgs": "nixpkgs_192"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -12263,6 +12205,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_193": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_193"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12294,11 +12254,11 @@
         "nixpkgs": "nixpkgs_195"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12312,11 +12272,11 @@
         "nixpkgs": "nixpkgs_196"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12420,24 +12380,6 @@
         "nixpkgs": "nixpkgs_200"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_201": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_201"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -12451,9 +12393,9 @@
         "type": "github"
       }
     },
-    "logos-nix_202": {
+    "logos-nix_201": {
       "inputs": {
-        "nixpkgs": "nixpkgs_202"
+        "nixpkgs": "nixpkgs_201"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -12461,6 +12403,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_202": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_202"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12492,11 +12452,11 @@
         "nixpkgs": "nixpkgs_204"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12582,11 +12542,11 @@
         "nixpkgs": "nixpkgs_209"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12618,11 +12578,11 @@
         "nixpkgs": "nixpkgs_210"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12636,11 +12596,11 @@
         "nixpkgs": "nixpkgs_211"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12672,11 +12632,11 @@
         "nixpkgs": "nixpkgs_213"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12708,11 +12668,11 @@
         "nixpkgs": "nixpkgs_215"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12744,11 +12704,11 @@
         "nixpkgs": "nixpkgs_217"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12780,11 +12740,11 @@
         "nixpkgs": "nixpkgs_219"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12834,11 +12794,11 @@
         "nixpkgs": "nixpkgs_221"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12906,11 +12866,11 @@
         "nixpkgs": "nixpkgs_225"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12924,11 +12884,11 @@
         "nixpkgs": "nixpkgs_226"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -12960,11 +12920,11 @@
         "nixpkgs": "nixpkgs_228"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -12978,11 +12938,11 @@
         "nixpkgs": "nixpkgs_229"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13014,11 +12974,11 @@
         "nixpkgs": "nixpkgs_230"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13050,11 +13010,11 @@
         "nixpkgs": "nixpkgs_232"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13140,24 +13100,6 @@
         "nixpkgs": "nixpkgs_237"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_238": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_238"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -13171,9 +13113,9 @@
         "type": "github"
       }
     },
-    "logos-nix_239": {
+    "logos-nix_238": {
       "inputs": {
-        "nixpkgs": "nixpkgs_239"
+        "nixpkgs": "nixpkgs_238"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -13181,6 +13123,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_239": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_239"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13230,11 +13190,11 @@
         "nixpkgs": "nixpkgs_241"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13266,11 +13226,11 @@
         "nixpkgs": "nixpkgs_243"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13302,11 +13262,11 @@
         "nixpkgs": "nixpkgs_245"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13338,11 +13298,11 @@
         "nixpkgs": "nixpkgs_247"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13374,11 +13334,11 @@
         "nixpkgs": "nixpkgs_249"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13464,11 +13424,11 @@
         "nixpkgs": "nixpkgs_253"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13482,11 +13442,11 @@
         "nixpkgs": "nixpkgs_254"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13518,11 +13478,11 @@
         "nixpkgs": "nixpkgs_256"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13554,11 +13514,11 @@
         "nixpkgs": "nixpkgs_258"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13572,11 +13532,11 @@
         "nixpkgs": "nixpkgs_259"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13662,11 +13622,11 @@
         "nixpkgs": "nixpkgs_263"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13734,11 +13694,11 @@
         "nixpkgs": "nixpkgs_267"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13770,11 +13730,11 @@
         "nixpkgs": "nixpkgs_269"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13824,11 +13784,11 @@
         "nixpkgs": "nixpkgs_271"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13842,11 +13802,11 @@
         "nixpkgs": "nixpkgs_272"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13860,11 +13820,11 @@
         "nixpkgs": "nixpkgs_273"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13878,11 +13838,11 @@
         "nixpkgs": "nixpkgs_274"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13896,11 +13856,11 @@
         "nixpkgs": "nixpkgs_275"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -13914,11 +13874,11 @@
         "nixpkgs": "nixpkgs_276"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13932,24 +13892,6 @@
         "nixpkgs": "nixpkgs_277"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_278": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_278"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -13963,9 +13905,9 @@
         "type": "github"
       }
     },
-    "logos-nix_279": {
+    "logos-nix_278": {
       "inputs": {
-        "nixpkgs": "nixpkgs_279"
+        "nixpkgs": "nixpkgs_278"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -13973,6 +13915,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_279": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_279"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14058,11 +14018,11 @@
         "nixpkgs": "nixpkgs_283"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14076,11 +14036,11 @@
         "nixpkgs": "nixpkgs_284"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14094,11 +14054,11 @@
         "nixpkgs": "nixpkgs_285"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14112,11 +14072,11 @@
         "nixpkgs": "nixpkgs_286"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14130,24 +14090,6 @@
         "nixpkgs": "nixpkgs_287"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_288": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_288"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -14161,9 +14103,9 @@
         "type": "github"
       }
     },
-    "logos-nix_289": {
+    "logos-nix_288": {
       "inputs": {
-        "nixpkgs": "nixpkgs_289"
+        "nixpkgs": "nixpkgs_288"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -14171,6 +14113,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_289": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_289"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14220,11 +14180,11 @@
         "nixpkgs": "nixpkgs_291"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14238,11 +14198,11 @@
         "nixpkgs": "nixpkgs_292"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14310,24 +14270,6 @@
         "nixpkgs": "nixpkgs_296"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_297": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_297"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -14341,9 +14283,9 @@
         "type": "github"
       }
     },
-    "logos-nix_298": {
+    "logos-nix_297": {
       "inputs": {
-        "nixpkgs": "nixpkgs_298"
+        "nixpkgs": "nixpkgs_297"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -14351,6 +14293,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_298": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_298"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14418,11 +14378,11 @@
         "nixpkgs": "nixpkgs_300"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14508,24 +14468,6 @@
         "nixpkgs": "nixpkgs_305"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_306": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_306"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -14539,9 +14481,9 @@
         "type": "github"
       }
     },
-    "logos-nix_307": {
+    "logos-nix_306": {
       "inputs": {
-        "nixpkgs": "nixpkgs_307"
+        "nixpkgs": "nixpkgs_306"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -14549,6 +14491,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_307": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_307"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14580,11 +14540,11 @@
         "nixpkgs": "nixpkgs_309"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14634,11 +14594,11 @@
         "nixpkgs": "nixpkgs_311"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14670,11 +14630,11 @@
         "nixpkgs": "nixpkgs_313"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14706,11 +14666,11 @@
         "nixpkgs": "nixpkgs_315"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14742,11 +14702,11 @@
         "nixpkgs": "nixpkgs_317"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14832,11 +14792,11 @@
         "nixpkgs": "nixpkgs_321"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14850,11 +14810,11 @@
         "nixpkgs": "nixpkgs_322"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14886,11 +14846,11 @@
         "nixpkgs": "nixpkgs_324"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14904,11 +14864,11 @@
         "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14922,11 +14882,11 @@
         "nixpkgs": "nixpkgs_326"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -14940,24 +14900,6 @@
         "nixpkgs": "nixpkgs_327"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_328": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_328"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -14971,9 +14913,9 @@
         "type": "github"
       }
     },
-    "logos-nix_329": {
+    "logos-nix_328": {
       "inputs": {
-        "nixpkgs": "nixpkgs_329"
+        "nixpkgs": "nixpkgs_328"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -14981,6 +14923,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_329": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_329"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15012,11 +14972,11 @@
         "nixpkgs": "nixpkgs_330"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15030,24 +14990,6 @@
         "nixpkgs": "nixpkgs_331"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_332": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_332"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -15061,9 +15003,9 @@
         "type": "github"
       }
     },
-    "logos-nix_333": {
+    "logos-nix_332": {
       "inputs": {
-        "nixpkgs": "nixpkgs_333"
+        "nixpkgs": "nixpkgs_332"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -15071,6 +15013,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_333": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_333"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15102,11 +15062,11 @@
         "nixpkgs": "nixpkgs_335"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15120,11 +15080,11 @@
         "nixpkgs": "nixpkgs_336"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15210,24 +15170,6 @@
         "nixpkgs": "nixpkgs_340"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_341": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_341"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -15241,9 +15183,9 @@
         "type": "github"
       }
     },
-    "logos-nix_342": {
+    "logos-nix_341": {
       "inputs": {
-        "nixpkgs": "nixpkgs_342"
+        "nixpkgs": "nixpkgs_341"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -15251,6 +15193,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_342": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_342"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15282,11 +15242,11 @@
         "nixpkgs": "nixpkgs_344"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15372,11 +15332,11 @@
         "nixpkgs": "nixpkgs_349"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15408,11 +15368,11 @@
         "nixpkgs": "nixpkgs_350"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15426,11 +15386,11 @@
         "nixpkgs": "nixpkgs_351"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15462,11 +15422,11 @@
         "nixpkgs": "nixpkgs_353"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15498,11 +15458,11 @@
         "nixpkgs": "nixpkgs_355"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15534,11 +15494,11 @@
         "nixpkgs": "nixpkgs_357"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15570,11 +15530,11 @@
         "nixpkgs": "nixpkgs_359"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15624,11 +15584,11 @@
         "nixpkgs": "nixpkgs_361"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15696,11 +15656,11 @@
         "nixpkgs": "nixpkgs_365"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15714,11 +15674,11 @@
         "nixpkgs": "nixpkgs_366"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15750,11 +15710,11 @@
         "nixpkgs": "nixpkgs_368"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15768,11 +15728,11 @@
         "nixpkgs": "nixpkgs_369"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15804,11 +15764,11 @@
         "nixpkgs": "nixpkgs_370"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15840,11 +15800,11 @@
         "nixpkgs": "nixpkgs_372"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15912,11 +15872,11 @@
         "nixpkgs": "nixpkgs_376"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15928,24 +15888,6 @@
     "logos-nix_377": {
       "inputs": {
         "nixpkgs": "nixpkgs_377"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_378": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_378"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -15961,9 +15903,9 @@
         "type": "github"
       }
     },
-    "logos-nix_379": {
+    "logos-nix_378": {
       "inputs": {
-        "nixpkgs": "nixpkgs_379"
+        "nixpkgs": "nixpkgs_378"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -15971,6 +15913,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_379": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_379"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16002,11 +15962,11 @@
         "nixpkgs": "nixpkgs_380"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16038,11 +15998,11 @@
         "nixpkgs": "nixpkgs_382"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16074,11 +16034,11 @@
         "nixpkgs": "nixpkgs_384"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16110,11 +16070,11 @@
         "nixpkgs": "nixpkgs_386"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16146,11 +16106,11 @@
         "nixpkgs": "nixpkgs_388"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16200,11 +16160,11 @@
         "nixpkgs": "nixpkgs_390"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16272,11 +16232,11 @@
         "nixpkgs": "nixpkgs_394"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16290,11 +16250,11 @@
         "nixpkgs": "nixpkgs_395"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16326,24 +16286,6 @@
         "nixpkgs": "nixpkgs_397"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_398": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_398"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -16357,9 +16299,9 @@
         "type": "github"
       }
     },
-    "logos-nix_399": {
+    "logos-nix_398": {
       "inputs": {
-        "nixpkgs": "nixpkgs_399"
+        "nixpkgs": "nixpkgs_398"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -16367,6 +16309,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_399": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_399"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16416,11 +16376,11 @@
         "nixpkgs": "nixpkgs_400"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16452,11 +16412,11 @@
         "nixpkgs": "nixpkgs_402"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16470,11 +16430,11 @@
         "nixpkgs": "nixpkgs_403"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16542,24 +16502,6 @@
         "nixpkgs": "nixpkgs_407"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_408": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_408"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -16573,9 +16515,9 @@
         "type": "github"
       }
     },
-    "logos-nix_409": {
+    "logos-nix_408": {
       "inputs": {
-        "nixpkgs": "nixpkgs_409"
+        "nixpkgs": "nixpkgs_408"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -16583,6 +16525,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_409": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_409"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16614,11 +16574,11 @@
         "nixpkgs": "nixpkgs_410"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16632,24 +16592,6 @@
         "nixpkgs": "nixpkgs_411"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_412": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_412"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -16663,9 +16605,9 @@
         "type": "github"
       }
     },
-    "logos-nix_413": {
+    "logos-nix_412": {
       "inputs": {
-        "nixpkgs": "nixpkgs_413"
+        "nixpkgs": "nixpkgs_412"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -16673,6 +16615,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_413": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_413"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16740,24 +16700,6 @@
         "nixpkgs": "nixpkgs_417"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_418": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_418"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -16771,9 +16713,9 @@
         "type": "github"
       }
     },
-    "logos-nix_419": {
+    "logos-nix_418": {
       "inputs": {
-        "nixpkgs": "nixpkgs_419"
+        "nixpkgs": "nixpkgs_418"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -16781,6 +16723,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_419": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_419"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16812,11 +16772,11 @@
         "nixpkgs": "nixpkgs_420"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16830,24 +16790,6 @@
         "nixpkgs": "nixpkgs_421"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_422": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_422"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -16861,9 +16803,9 @@
         "type": "github"
       }
     },
-    "logos-nix_423": {
+    "logos-nix_422": {
       "inputs": {
-        "nixpkgs": "nixpkgs_423"
+        "nixpkgs": "nixpkgs_422"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -16871,6 +16813,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_423": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_423"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16902,11 +16862,11 @@
         "nixpkgs": "nixpkgs_425"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16920,11 +16880,11 @@
         "nixpkgs": "nixpkgs_426"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17010,24 +16970,6 @@
         "nixpkgs": "nixpkgs_430"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_431": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_431"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17041,9 +16983,9 @@
         "type": "github"
       }
     },
-    "logos-nix_432": {
+    "logos-nix_431": {
       "inputs": {
-        "nixpkgs": "nixpkgs_432"
+        "nixpkgs": "nixpkgs_431"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17051,6 +16993,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_432": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_432"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17082,11 +17042,11 @@
         "nixpkgs": "nixpkgs_434"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17172,11 +17132,11 @@
         "nixpkgs": "nixpkgs_439"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17208,11 +17168,11 @@
         "nixpkgs": "nixpkgs_440"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17226,11 +17186,11 @@
         "nixpkgs": "nixpkgs_441"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17262,11 +17222,11 @@
         "nixpkgs": "nixpkgs_443"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17298,11 +17258,11 @@
         "nixpkgs": "nixpkgs_445"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17334,11 +17294,11 @@
         "nixpkgs": "nixpkgs_447"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17370,11 +17330,11 @@
         "nixpkgs": "nixpkgs_449"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17424,11 +17384,11 @@
         "nixpkgs": "nixpkgs_451"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17496,11 +17456,11 @@
         "nixpkgs": "nixpkgs_455"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17514,11 +17474,11 @@
         "nixpkgs": "nixpkgs_456"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17550,11 +17510,11 @@
         "nixpkgs": "nixpkgs_458"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17568,11 +17528,11 @@
         "nixpkgs": "nixpkgs_459"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17604,11 +17564,11 @@
         "nixpkgs": "nixpkgs_460"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17622,11 +17582,11 @@
         "nixpkgs": "nixpkgs_461"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17640,11 +17600,11 @@
         "nixpkgs": "nixpkgs_462"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17658,11 +17618,11 @@
         "nixpkgs": "nixpkgs_463"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17676,11 +17636,11 @@
         "nixpkgs": "nixpkgs_464"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17694,24 +17654,6 @@
         "nixpkgs": "nixpkgs_465"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_466": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_466"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -17725,9 +17667,9 @@
         "type": "github"
       }
     },
-    "logos-nix_467": {
+    "logos-nix_466": {
       "inputs": {
-        "nixpkgs": "nixpkgs_467"
+        "nixpkgs": "nixpkgs_466"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -17735,6 +17677,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_467": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_467"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17766,11 +17726,11 @@
         "nixpkgs": "nixpkgs_469"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17802,11 +17762,11 @@
         "nixpkgs": "nixpkgs_470"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -17874,24 +17834,6 @@
         "nixpkgs": "nixpkgs_474"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_475": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_475"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -17905,9 +17847,9 @@
         "type": "github"
       }
     },
-    "logos-nix_476": {
+    "logos-nix_475": {
       "inputs": {
-        "nixpkgs": "nixpkgs_476"
+        "nixpkgs": "nixpkgs_475"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -17915,6 +17857,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_476": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_476"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17946,11 +17906,11 @@
         "nixpkgs": "nixpkgs_478"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18054,24 +18014,6 @@
         "nixpkgs": "nixpkgs_483"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_484": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_484"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -18085,9 +18027,9 @@
         "type": "github"
       }
     },
-    "logos-nix_485": {
+    "logos-nix_484": {
       "inputs": {
-        "nixpkgs": "nixpkgs_485"
+        "nixpkgs": "nixpkgs_484"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -18095,6 +18037,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_485": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_485"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18126,11 +18086,11 @@
         "nixpkgs": "nixpkgs_487"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18162,11 +18122,11 @@
         "nixpkgs": "nixpkgs_489"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18216,11 +18176,11 @@
         "nixpkgs": "nixpkgs_491"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18252,11 +18212,11 @@
         "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18288,11 +18248,11 @@
         "nixpkgs": "nixpkgs_495"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18360,11 +18320,11 @@
         "nixpkgs": "nixpkgs_499"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18414,11 +18374,11 @@
         "nixpkgs": "nixpkgs_500"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18450,24 +18410,6 @@
         "nixpkgs": "nixpkgs_502"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_503": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_503"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -18481,9 +18423,9 @@
         "type": "github"
       }
     },
-    "logos-nix_504": {
+    "logos-nix_503": {
       "inputs": {
-        "nixpkgs": "nixpkgs_504"
+        "nixpkgs": "nixpkgs_503"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -18491,6 +18433,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_504": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_504"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18522,11 +18482,11 @@
         "nixpkgs": "nixpkgs_506"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18648,11 +18608,11 @@
         "nixpkgs": "nixpkgs_512"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18666,11 +18626,11 @@
         "nixpkgs": "nixpkgs_513"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18720,11 +18680,11 @@
         "nixpkgs": "nixpkgs_516"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18756,11 +18716,11 @@
         "nixpkgs": "nixpkgs_518"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18810,11 +18770,11 @@
         "nixpkgs": "nixpkgs_520"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18846,11 +18806,11 @@
         "nixpkgs": "nixpkgs_522"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18882,11 +18842,11 @@
         "nixpkgs": "nixpkgs_524"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18900,11 +18860,11 @@
         "nixpkgs": "nixpkgs_525"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18936,11 +18896,11 @@
         "nixpkgs": "nixpkgs_527"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19062,11 +19022,11 @@
         "nixpkgs": "nixpkgs_533"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19098,11 +19058,11 @@
         "nixpkgs": "nixpkgs_535"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19134,24 +19094,6 @@
         "nixpkgs": "nixpkgs_537"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_538": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_538"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -19165,9 +19107,9 @@
         "type": "github"
       }
     },
-    "logos-nix_539": {
+    "logos-nix_538": {
       "inputs": {
-        "nixpkgs": "nixpkgs_539"
+        "nixpkgs": "nixpkgs_538"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -19175,6 +19117,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_539": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_539"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19206,11 +19166,11 @@
         "nixpkgs": "nixpkgs_540"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19224,11 +19184,11 @@
         "nixpkgs": "nixpkgs_541"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19260,11 +19220,11 @@
         "nixpkgs": "nixpkgs_543"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19296,11 +19256,11 @@
         "nixpkgs": "nixpkgs_545"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19332,24 +19292,6 @@
         "nixpkgs": "nixpkgs_547"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_548": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_548"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -19363,9 +19305,9 @@
         "type": "github"
       }
     },
-    "logos-nix_549": {
+    "logos-nix_548": {
       "inputs": {
-        "nixpkgs": "nixpkgs_549"
+        "nixpkgs": "nixpkgs_548"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -19373,6 +19315,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_549": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_549"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19404,11 +19364,11 @@
         "nixpkgs": "nixpkgs_550"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19422,11 +19382,11 @@
         "nixpkgs": "nixpkgs_551"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19512,11 +19472,11 @@
         "nixpkgs": "nixpkgs_556"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19548,11 +19508,11 @@
         "nixpkgs": "nixpkgs_558"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19602,11 +19562,11 @@
         "nixpkgs": "nixpkgs_560"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19656,11 +19616,11 @@
         "nixpkgs": "nixpkgs_563"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19674,11 +19634,11 @@
         "nixpkgs": "nixpkgs_564"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19728,11 +19688,11 @@
         "nixpkgs": "nixpkgs_567"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19764,11 +19724,11 @@
         "nixpkgs": "nixpkgs_569"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19836,11 +19796,11 @@
         "nixpkgs": "nixpkgs_572"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19872,11 +19832,11 @@
         "nixpkgs": "nixpkgs_574"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19908,11 +19868,11 @@
         "nixpkgs": "nixpkgs_576"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19944,11 +19904,11 @@
         "nixpkgs": "nixpkgs_578"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19998,11 +19958,11 @@
         "nixpkgs": "nixpkgs_580"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20016,11 +19976,11 @@
         "nixpkgs": "nixpkgs_581"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20052,11 +20012,11 @@
         "nixpkgs": "nixpkgs_583"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20142,11 +20102,11 @@
         "nixpkgs": "nixpkgs_588"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20160,11 +20120,11 @@
         "nixpkgs": "nixpkgs_589"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20196,11 +20156,11 @@
         "nixpkgs": "nixpkgs_590"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20214,11 +20174,11 @@
         "nixpkgs": "nixpkgs_591"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20232,11 +20192,11 @@
         "nixpkgs": "nixpkgs_592"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20250,24 +20210,6 @@
         "nixpkgs": "nixpkgs_593"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_594": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_594"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -20281,9 +20223,9 @@
         "type": "github"
       }
     },
-    "logos-nix_595": {
+    "logos-nix_594": {
       "inputs": {
-        "nixpkgs": "nixpkgs_595"
+        "nixpkgs": "nixpkgs_594"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -20291,6 +20233,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_595": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_595"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20412,11 +20372,11 @@
         "nixpkgs": "nixpkgs_600"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20448,11 +20408,11 @@
         "nixpkgs": "nixpkgs_602"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20484,11 +20444,11 @@
         "nixpkgs": "nixpkgs_604"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20538,11 +20498,11 @@
         "nixpkgs": "nixpkgs_607"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20556,11 +20516,11 @@
         "nixpkgs": "nixpkgs_608"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20628,11 +20588,11 @@
         "nixpkgs": "nixpkgs_611"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20664,11 +20624,11 @@
         "nixpkgs": "nixpkgs_613"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20718,11 +20678,11 @@
         "nixpkgs": "nixpkgs_616"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20754,11 +20714,11 @@
         "nixpkgs": "nixpkgs_618"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20808,11 +20768,11 @@
         "nixpkgs": "nixpkgs_620"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20844,11 +20804,11 @@
         "nixpkgs": "nixpkgs_622"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20880,11 +20840,11 @@
         "nixpkgs": "nixpkgs_624"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20898,11 +20858,11 @@
         "nixpkgs": "nixpkgs_625"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20934,11 +20894,11 @@
         "nixpkgs": "nixpkgs_627"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21042,11 +21002,11 @@
         "nixpkgs": "nixpkgs_632"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21096,11 +21056,11 @@
         "nixpkgs": "nixpkgs_635"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21114,11 +21074,11 @@
         "nixpkgs": "nixpkgs_636"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21168,11 +21128,11 @@
         "nixpkgs": "nixpkgs_639"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21276,11 +21236,11 @@
         "nixpkgs": "nixpkgs_644"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21294,11 +21254,11 @@
         "nixpkgs": "nixpkgs_645"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21330,11 +21290,11 @@
         "nixpkgs": "nixpkgs_647"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21366,11 +21326,11 @@
         "nixpkgs": "nixpkgs_649"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21420,11 +21380,11 @@
         "nixpkgs": "nixpkgs_651"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21474,11 +21434,11 @@
         "nixpkgs": "nixpkgs_654"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21546,11 +21506,11 @@
         "nixpkgs": "nixpkgs_658"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21636,24 +21596,6 @@
         "nixpkgs": "nixpkgs_662"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_663": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_663"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -21667,9 +21609,9 @@
         "type": "github"
       }
     },
-    "logos-nix_664": {
+    "logos-nix_663": {
       "inputs": {
-        "nixpkgs": "nixpkgs_664"
+        "nixpkgs": "nixpkgs_663"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -21677,6 +21619,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_664": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_664"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21708,11 +21668,11 @@
         "nixpkgs": "nixpkgs_666"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21798,11 +21758,11 @@
         "nixpkgs": "nixpkgs_670"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21834,24 +21794,6 @@
         "nixpkgs": "nixpkgs_672"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_673": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_673"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -21865,9 +21807,9 @@
         "type": "github"
       }
     },
-    "logos-nix_674": {
+    "logos-nix_673": {
       "inputs": {
-        "nixpkgs": "nixpkgs_674"
+        "nixpkgs": "nixpkgs_673"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -21875,6 +21817,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_674": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_674"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21942,11 +21902,11 @@
         "nixpkgs": "nixpkgs_678"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22050,11 +22010,11 @@
         "nixpkgs": "nixpkgs_683"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22068,11 +22028,11 @@
         "nixpkgs": "nixpkgs_684"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22104,11 +22064,11 @@
         "nixpkgs": "nixpkgs_686"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22140,11 +22100,11 @@
         "nixpkgs": "nixpkgs_688"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22158,11 +22118,11 @@
         "nixpkgs": "nixpkgs_689"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22194,11 +22154,11 @@
         "nixpkgs": "nixpkgs_690"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22230,11 +22190,11 @@
         "nixpkgs": "nixpkgs_692"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22248,11 +22208,11 @@
         "nixpkgs": "nixpkgs_693"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22284,11 +22244,11 @@
         "nixpkgs": "nixpkgs_695"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22302,11 +22262,11 @@
         "nixpkgs": "nixpkgs_696"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22338,11 +22298,11 @@
         "nixpkgs": "nixpkgs_698"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22410,11 +22370,11 @@
         "nixpkgs": "nixpkgs_700"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22446,11 +22406,11 @@
         "nixpkgs": "nixpkgs_702"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22500,11 +22460,11 @@
         "nixpkgs": "nixpkgs_705"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22572,11 +22532,11 @@
         "nixpkgs": "nixpkgs_709"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22662,11 +22622,11 @@
         "nixpkgs": "nixpkgs_713"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22680,11 +22640,11 @@
         "nixpkgs": "nixpkgs_714"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22698,11 +22658,11 @@
         "nixpkgs": "nixpkgs_715"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22716,24 +22676,6 @@
         "nixpkgs": "nixpkgs_716"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_717": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_717"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -22747,9 +22689,9 @@
         "type": "github"
       }
     },
-    "logos-nix_718": {
+    "logos-nix_717": {
       "inputs": {
-        "nixpkgs": "nixpkgs_718"
+        "nixpkgs": "nixpkgs_717"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -22757,6 +22699,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_718": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_718"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22842,11 +22802,11 @@
         "nixpkgs": "nixpkgs_722"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -22932,11 +22892,11 @@
         "nixpkgs": "nixpkgs_727"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22950,11 +22910,11 @@
         "nixpkgs": "nixpkgs_728"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23004,11 +22964,11 @@
         "nixpkgs": "nixpkgs_730"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23040,11 +23000,11 @@
         "nixpkgs": "nixpkgs_732"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23058,11 +23018,11 @@
         "nixpkgs": "nixpkgs_733"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23076,11 +23036,11 @@
         "nixpkgs": "nixpkgs_734"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23112,11 +23072,11 @@
         "nixpkgs": "nixpkgs_736"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23130,11 +23090,11 @@
         "nixpkgs": "nixpkgs_737"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23166,11 +23126,11 @@
         "nixpkgs": "nixpkgs_739"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23202,11 +23162,11 @@
         "nixpkgs": "nixpkgs_740"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23238,11 +23198,11 @@
         "nixpkgs": "nixpkgs_742"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23274,11 +23234,11 @@
         "nixpkgs": "nixpkgs_744"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23310,11 +23270,11 @@
         "nixpkgs": "nixpkgs_746"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23364,11 +23324,11 @@
         "nixpkgs": "nixpkgs_749"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23454,11 +23414,11 @@
         "nixpkgs": "nixpkgs_753"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23508,11 +23468,11 @@
         "nixpkgs": "nixpkgs_756"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23544,11 +23504,11 @@
         "nixpkgs": "nixpkgs_758"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23598,11 +23558,11 @@
         "nixpkgs": "nixpkgs_760"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23616,11 +23576,11 @@
         "nixpkgs": "nixpkgs_761"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23634,11 +23594,11 @@
         "nixpkgs": "nixpkgs_762"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23670,11 +23630,11 @@
         "nixpkgs": "nixpkgs_764"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23688,11 +23648,11 @@
         "nixpkgs": "nixpkgs_765"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23724,11 +23684,11 @@
         "nixpkgs": "nixpkgs_767"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23742,11 +23702,11 @@
         "nixpkgs": "nixpkgs_768"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23796,11 +23756,11 @@
         "nixpkgs": "nixpkgs_770"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23832,11 +23792,11 @@
         "nixpkgs": "nixpkgs_772"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23868,11 +23828,11 @@
         "nixpkgs": "nixpkgs_774"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23922,11 +23882,11 @@
         "nixpkgs": "nixpkgs_777"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24012,11 +23972,11 @@
         "nixpkgs": "nixpkgs_781"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24192,24 +24152,6 @@
         "nixpkgs": "nixpkgs_790"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_791": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_791"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -24223,9 +24165,9 @@
         "type": "github"
       }
     },
-    "logos-nix_792": {
+    "logos-nix_791": {
       "inputs": {
-        "nixpkgs": "nixpkgs_792"
+        "nixpkgs": "nixpkgs_791"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -24233,6 +24175,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_792": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_792"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24264,11 +24224,11 @@
         "nixpkgs": "nixpkgs_794"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24336,11 +24296,11 @@
         "nixpkgs": "nixpkgs_798"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24408,24 +24368,6 @@
         "nixpkgs": "nixpkgs_800"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_801": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_801"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -24439,9 +24381,9 @@
         "type": "github"
       }
     },
-    "logos-nix_802": {
+    "logos-nix_801": {
       "inputs": {
-        "nixpkgs": "nixpkgs_802"
+        "nixpkgs": "nixpkgs_801"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24449,6 +24391,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_802": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_802"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24516,11 +24476,11 @@
         "nixpkgs": "nixpkgs_806"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24624,11 +24584,11 @@
         "nixpkgs": "nixpkgs_811"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24642,11 +24602,11 @@
         "nixpkgs": "nixpkgs_812"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24678,11 +24638,11 @@
         "nixpkgs": "nixpkgs_814"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24714,11 +24674,11 @@
         "nixpkgs": "nixpkgs_816"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24732,11 +24692,11 @@
         "nixpkgs": "nixpkgs_817"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24750,11 +24710,11 @@
         "nixpkgs": "nixpkgs_818"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24804,11 +24764,11 @@
         "nixpkgs": "nixpkgs_820"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24822,11 +24782,11 @@
         "nixpkgs": "nixpkgs_821"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24858,11 +24818,11 @@
         "nixpkgs": "nixpkgs_823"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24876,11 +24836,11 @@
         "nixpkgs": "nixpkgs_824"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24912,11 +24872,11 @@
         "nixpkgs": "nixpkgs_826"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24948,11 +24908,11 @@
         "nixpkgs": "nixpkgs_828"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25002,11 +24962,11 @@
         "nixpkgs": "nixpkgs_830"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25056,11 +25016,11 @@
         "nixpkgs": "nixpkgs_833"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25128,11 +25088,11 @@
         "nixpkgs": "nixpkgs_837"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25218,11 +25178,11 @@
         "nixpkgs": "nixpkgs_841"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25236,11 +25196,11 @@
         "nixpkgs": "nixpkgs_842"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25254,11 +25214,11 @@
         "nixpkgs": "nixpkgs_843"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25272,24 +25232,6 @@
         "nixpkgs": "nixpkgs_844"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_845": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_845"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -25303,9 +25245,9 @@
         "type": "github"
       }
     },
-    "logos-nix_846": {
+    "logos-nix_845": {
       "inputs": {
-        "nixpkgs": "nixpkgs_846"
+        "nixpkgs": "nixpkgs_845"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -25313,6 +25255,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_846": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_846"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25398,11 +25358,11 @@
         "nixpkgs": "nixpkgs_850"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25488,11 +25448,11 @@
         "nixpkgs": "nixpkgs_855"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25506,11 +25466,11 @@
         "nixpkgs": "nixpkgs_856"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25542,11 +25502,11 @@
         "nixpkgs": "nixpkgs_858"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25596,11 +25556,11 @@
         "nixpkgs": "nixpkgs_860"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25614,11 +25574,11 @@
         "nixpkgs": "nixpkgs_861"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25632,11 +25592,11 @@
         "nixpkgs": "nixpkgs_862"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25668,11 +25628,11 @@
         "nixpkgs": "nixpkgs_864"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25686,11 +25646,11 @@
         "nixpkgs": "nixpkgs_865"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25722,11 +25682,11 @@
         "nixpkgs": "nixpkgs_867"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25740,11 +25700,11 @@
         "nixpkgs": "nixpkgs_868"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25794,11 +25754,11 @@
         "nixpkgs": "nixpkgs_870"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25830,11 +25790,11 @@
         "nixpkgs": "nixpkgs_872"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25866,11 +25826,11 @@
         "nixpkgs": "nixpkgs_874"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25920,11 +25880,11 @@
         "nixpkgs": "nixpkgs_877"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26010,11 +25970,11 @@
         "nixpkgs": "nixpkgs_881"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26064,11 +26024,11 @@
         "nixpkgs": "nixpkgs_884"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26100,11 +26060,11 @@
         "nixpkgs": "nixpkgs_886"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26136,11 +26096,11 @@
         "nixpkgs": "nixpkgs_888"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26154,11 +26114,11 @@
         "nixpkgs": "nixpkgs_889"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26190,11 +26150,11 @@
         "nixpkgs": "nixpkgs_890"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26226,11 +26186,11 @@
         "nixpkgs": "nixpkgs_892"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26244,11 +26204,11 @@
         "nixpkgs": "nixpkgs_893"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26280,11 +26240,11 @@
         "nixpkgs": "nixpkgs_895"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26298,11 +26258,11 @@
         "nixpkgs": "nixpkgs_896"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26334,11 +26294,11 @@
         "nixpkgs": "nixpkgs_898"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26406,11 +26366,11 @@
         "nixpkgs": "nixpkgs_900"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26442,11 +26402,11 @@
         "nixpkgs": "nixpkgs_902"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26496,11 +26456,11 @@
         "nixpkgs": "nixpkgs_905"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26568,11 +26528,11 @@
         "nixpkgs": "nixpkgs_909"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26622,11 +26582,11 @@
         "nixpkgs": "nixpkgs_911"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26676,11 +26636,11 @@
         "nixpkgs": "nixpkgs_914"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26694,11 +26654,11 @@
         "nixpkgs": "nixpkgs_915"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26712,11 +26672,11 @@
         "nixpkgs": "nixpkgs_916"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26766,11 +26726,11 @@
         "nixpkgs": "nixpkgs_919"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26820,11 +26780,11 @@
         "nixpkgs": "nixpkgs_921"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26874,11 +26834,11 @@
         "nixpkgs": "nixpkgs_924"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26946,6 +26906,42 @@
         "nixpkgs": "nixpkgs_928"
       },
       "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_929": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_929"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_93": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_93"
+      },
+      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -26959,9 +26955,63 @@
         "type": "github"
       }
     },
-    "logos-nix_93": {
+    "logos-nix_930": {
       "inputs": {
-        "nixpkgs": "nixpkgs_93"
+        "nixpkgs": "nixpkgs_930"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_931": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_931"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_932": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_932"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_933": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_933"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -27118,7 +27168,7 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
+        "logos-nix": "logos-nix_398",
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_67",
@@ -27149,11 +27199,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1782210443,
-        "narHash": "sha256-a39fW9ki/QVUV/fLzu31DKxZqKXKQadqP3pvOEp7ZTU=",
+        "lastModified": 1782404234,
+        "narHash": "sha256-OvOYAyPlElbiWzBl593xFo60aKc/n2RqXe/elYLB6jw=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "7c9bd77b38e6fdafe27150b45d50548875f8d1eb",
+        "rev": "6dbcf341a7c354b14d1a5012b57facfe6b33bc94",
         "type": "github"
       },
       "original": {
@@ -27164,7 +27214,7 @@
     },
     "logos-package-downloader_2": {
       "inputs": {
-        "logos-nix": "logos-nix_781",
+        "logos-nix": "logos-nix_786",
         "logos-package": "logos-package_96",
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_136",
@@ -27229,11 +27279,11 @@
         "logos-package-manager": "logos-package-manager_27"
       },
       "locked": {
-        "lastModified": 1782210111,
-        "narHash": "sha256-EZVxDmHhGLd1nY+3bs0RPaOVVTLBoSrSPAOs5eyo2rM=",
+        "lastModified": 1782404199,
+        "narHash": "sha256-kc5JUOhWdiuZeempRMiUssCTCd/pjWL+5QMcXsazxMQ=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "d8968c609416538b9872d85291f76d4c9cb1da54",
+        "rev": "39b3209b6294adc7df0a1628cb6b17550ad959c9",
         "type": "github"
       },
       "original": {
@@ -27249,11 +27299,11 @@
         "package_manager": "package_manager"
       },
       "locked": {
-        "lastModified": 1782212163,
-        "narHash": "sha256-Bb3hGnzf+02vPprjGKiHNVShIothjGCPegDNofeV3aI=",
+        "lastModified": 1782404251,
+        "narHash": "sha256-5UpgNXaymJ7Stx1oc3djcmzH5jrXGHVXaAyWh22nIp4=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "7c8c3acd7b1215fef956a05b9423ab169a09becc",
+        "rev": "9f9cb90e5bfb2f514bf980a234017f42cecd7fe2",
         "type": "github"
       },
       "original": {
@@ -27264,7 +27314,7 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_220",
         "logos-package": "logos-package_24",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_34",
@@ -27298,7 +27348,7 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_231",
         "logos-package": "logos-package_26",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_37",
@@ -27329,7 +27379,7 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_249",
+        "logos-nix": "logos-nix_248",
         "logos-package": "logos-package_29",
         "nix-bundle-appimage": "nix-bundle-appimage_12",
         "nix-bundle-dir": "nix-bundle-dir_41",
@@ -27359,7 +27409,7 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_263",
+        "logos-nix": "logos-nix_262",
         "logos-package": "logos-package_31",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
         "nix-bundle-dir": "nix-bundle-dir_44",
@@ -27386,7 +27436,7 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
+        "logos-nix": "logos-nix_299",
         "logos-package": "logos-package_33",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
         "nix-bundle-dir": "nix-bundle-dir_46",
@@ -27419,7 +27469,7 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_317",
+        "logos-nix": "logos-nix_316",
         "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
         "nix-bundle-dir": "nix-bundle-dir_50",
@@ -27451,7 +27501,7 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_343",
         "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_53",
@@ -27485,7 +27535,7 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_360",
         "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_57",
@@ -27518,7 +27568,7 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_371",
         "logos-package": "logos-package_43",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_60",
@@ -27548,7 +27598,7 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_390",
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_64",
@@ -27562,11 +27612,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -27609,7 +27659,7 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_403",
         "logos-package": "logos-package_49",
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_69",
@@ -27635,7 +27685,7 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_434",
         "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_71",
@@ -27668,7 +27718,7 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_451",
         "logos-package": "logos-package_53",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_75",
@@ -27700,7 +27750,7 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_477",
+        "logos-nix": "logos-nix_478",
         "logos-package": "logos-package_55",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_78",
@@ -27734,7 +27784,7 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_495",
         "logos-package": "logos-package_58",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_82",
@@ -27767,7 +27817,7 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
+        "logos-nix": "logos-nix_506",
         "logos-package": "logos-package_60",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_85",
@@ -27797,7 +27847,7 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-        "logos-nix": "logos-nix_522",
+        "logos-nix": "logos-nix_525",
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_89",
@@ -27811,11 +27861,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -27826,7 +27876,7 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_533",
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_92",
@@ -27853,7 +27903,7 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_561",
+        "logos-nix": "logos-nix_564",
         "logos-package": "logos-package_66",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_94",
@@ -27886,7 +27936,7 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_581",
         "logos-package": "logos-package_69",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_98",
@@ -27952,7 +28002,7 @@
     },
     "logos-package-manager_30": {
       "inputs": {
-        "logos-nix": "logos-nix_605",
+        "logos-nix": "logos-nix_608",
         "logos-package": "logos-package_71",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_101",
@@ -27986,7 +28036,7 @@
     },
     "logos-package-manager_31": {
       "inputs": {
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_625",
         "logos-package": "logos-package_74",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_105",
@@ -28019,7 +28069,7 @@
     },
     "logos-package-manager_32": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_636",
         "logos-package": "logos-package_76",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_108",
@@ -28049,7 +28099,7 @@
     },
     "logos-package-manager_33": {
       "inputs": {
-        "logos-nix": "logos-nix_650",
+        "logos-nix": "logos-nix_655",
         "logos-package": "logos-package_79",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_112",
@@ -28063,11 +28113,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -28078,7 +28128,7 @@
     },
     "logos-package-manager_34": {
       "inputs": {
-        "logos-nix": "logos-nix_684",
+        "logos-nix": "logos-nix_689",
         "logos-package": "logos-package_81",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_115",
@@ -28112,7 +28162,7 @@
     },
     "logos-package-manager_35": {
       "inputs": {
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_706",
         "logos-package": "logos-package_84",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_119",
@@ -28145,7 +28195,7 @@
     },
     "logos-package-manager_36": {
       "inputs": {
-        "logos-nix": "logos-nix_728",
+        "logos-nix": "logos-nix_733",
         "logos-package": "logos-package_86",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_122",
@@ -28180,7 +28230,7 @@
     },
     "logos-package-manager_37": {
       "inputs": {
-        "logos-nix": "logos-nix_745",
+        "logos-nix": "logos-nix_750",
         "logos-package": "logos-package_89",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_126",
@@ -28214,7 +28264,7 @@
     },
     "logos-package-manager_38": {
       "inputs": {
-        "logos-nix": "logos-nix_756",
+        "logos-nix": "logos-nix_761",
         "logos-package": "logos-package_91",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_129",
@@ -28245,7 +28295,7 @@
     },
     "logos-package-manager_39": {
       "inputs": {
-        "logos-nix": "logos-nix_773",
+        "logos-nix": "logos-nix_778",
         "logos-package": "logos-package_94",
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_133",
@@ -28308,7 +28358,7 @@
     },
     "logos-package-manager_40": {
       "inputs": {
-        "logos-nix": "logos-nix_812",
+        "logos-nix": "logos-nix_817",
         "logos-package": "logos-package_97",
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_138",
@@ -28342,7 +28392,7 @@
     },
     "logos-package-manager_41": {
       "inputs": {
-        "logos-nix": "logos-nix_829",
+        "logos-nix": "logos-nix_834",
         "logos-package": "logos-package_100",
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_142",
@@ -28375,7 +28425,7 @@
     },
     "logos-package-manager_42": {
       "inputs": {
-        "logos-nix": "logos-nix_856",
+        "logos-nix": "logos-nix_861",
         "logos-package": "logos-package_102",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_145",
@@ -28410,7 +28460,7 @@
     },
     "logos-package-manager_43": {
       "inputs": {
-        "logos-nix": "logos-nix_873",
+        "logos-nix": "logos-nix_878",
         "logos-package": "logos-package_105",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
         "nix-bundle-dir": "nix-bundle-dir_149",
@@ -28444,7 +28494,7 @@
     },
     "logos-package-manager_44": {
       "inputs": {
-        "logos-nix": "logos-nix_884",
+        "logos-nix": "logos-nix_889",
         "logos-package": "logos-package_107",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
         "nix-bundle-dir": "nix-bundle-dir_152",
@@ -28475,7 +28525,7 @@
     },
     "logos-package-manager_45": {
       "inputs": {
-        "logos-nix": "logos-nix_901",
+        "logos-nix": "logos-nix_906",
         "logos-package": "logos-package_110",
         "nix-bundle-appimage": "nix-bundle-appimage_47",
         "nix-bundle-dir": "nix-bundle-dir_156",
@@ -28505,7 +28555,7 @@
     },
     "logos-package-manager_46": {
       "inputs": {
-        "logos-nix": "logos-nix_909",
+        "logos-nix": "logos-nix_914",
         "logos-package": "logos-package_112",
         "nix-bundle-appimage": "nix-bundle-appimage_48",
         "nix-bundle-dir": "nix-bundle-dir_159",
@@ -28533,7 +28583,7 @@
     },
     "logos-package-manager_47": {
       "inputs": {
-        "logos-nix": "logos-nix_920",
+        "logos-nix": "logos-nix_925",
         "logos-package": "logos-package_113",
         "nix-bundle-appimage": "nix-bundle-appimage_50",
         "nix-bundle-dir": "nix-bundle-dir_163",
@@ -28590,7 +28640,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_118",
         "logos-package": "logos-package_14",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_20",
@@ -28604,11 +28654,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836847,
-        "narHash": "sha256-pU7GShEizE8HkDGvR9NWZPqksiGyvfcWodtFyc318TM=",
+        "lastModified": 1782134133,
+        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "39118d6c52226e88a77c6ff7d1196229f56b757e",
+        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
         "type": "github"
       },
       "original": {
@@ -28619,7 +28669,7 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_160",
+        "logos-nix": "logos-nix_159",
         "logos-package": "logos-package_16",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_23",
@@ -28653,7 +28703,7 @@
     },
     "logos-package-manager_8": {
       "inputs": {
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_176",
         "logos-package": "logos-package_19",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_27",
@@ -28686,7 +28736,7 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_203",
         "logos-package": "logos-package_21",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_30",
@@ -28752,7 +28802,7 @@
     },
     "logos-package_100": {
       "inputs": {
-        "logos-nix": "logos-nix_830",
+        "logos-nix": "logos-nix_835",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28783,7 +28833,7 @@
     },
     "logos-package_101": {
       "inputs": {
-        "logos-nix": "logos-nix_835",
+        "logos-nix": "logos-nix_840",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28814,7 +28864,7 @@
     },
     "logos-package_102": {
       "inputs": {
-        "logos-nix": "logos-nix_857",
+        "logos-nix": "logos-nix_862",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28847,7 +28897,7 @@
     },
     "logos-package_103": {
       "inputs": {
-        "logos-nix": "logos-nix_866",
+        "logos-nix": "logos-nix_871",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28879,7 +28929,7 @@
     },
     "logos-package_104": {
       "inputs": {
-        "logos-nix": "logos-nix_870",
+        "logos-nix": "logos-nix_875",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28910,7 +28960,7 @@
     },
     "logos-package_105": {
       "inputs": {
-        "logos-nix": "logos-nix_874",
+        "logos-nix": "logos-nix_879",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28942,7 +28992,7 @@
     },
     "logos-package_106": {
       "inputs": {
-        "logos-nix": "logos-nix_879",
+        "logos-nix": "logos-nix_884",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28974,7 +29024,7 @@
     },
     "logos-package_107": {
       "inputs": {
-        "logos-nix": "logos-nix_885",
+        "logos-nix": "logos-nix_890",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29003,7 +29053,7 @@
     },
     "logos-package_108": {
       "inputs": {
-        "logos-nix": "logos-nix_894",
+        "logos-nix": "logos-nix_899",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29031,7 +29081,7 @@
     },
     "logos-package_109": {
       "inputs": {
-        "logos-nix": "logos-nix_898",
+        "logos-nix": "logos-nix_903",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29086,7 +29136,7 @@
     },
     "logos-package_110": {
       "inputs": {
-        "logos-nix": "logos-nix_902",
+        "logos-nix": "logos-nix_907",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29114,7 +29164,7 @@
     },
     "logos-package_111": {
       "inputs": {
-        "logos-nix": "logos-nix_907",
+        "logos-nix": "logos-nix_912",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29142,7 +29192,7 @@
     },
     "logos-package_112": {
       "inputs": {
-        "logos-nix": "logos-nix_910",
+        "logos-nix": "logos-nix_915",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29168,7 +29218,7 @@
     },
     "logos-package_113": {
       "inputs": {
-        "logos-nix": "logos-nix_921",
+        "logos-nix": "logos-nix_926",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -29193,7 +29243,7 @@
     },
     "logos-package_114": {
       "inputs": {
-        "logos-nix": "logos-nix_926",
+        "logos-nix": "logos-nix_931",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -29218,7 +29268,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -29245,7 +29295,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_115",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -29271,7 +29321,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -29283,11 +29333,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -29298,7 +29348,7 @@
     },
     "logos-package_15": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
+        "logos-nix": "logos-nix_124",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -29310,11 +29360,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -29325,7 +29375,7 @@
     },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_161",
+        "logos-nix": "logos-nix_160",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29357,7 +29407,7 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_170",
+        "logos-nix": "logos-nix_169",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29388,7 +29438,7 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_174",
+        "logos-nix": "logos-nix_173",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29418,7 +29468,7 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_178",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29479,7 +29529,7 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_183",
+        "logos-nix": "logos-nix_182",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29510,7 +29560,7 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29543,7 +29593,7 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29575,7 +29625,7 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_218",
+        "logos-nix": "logos-nix_217",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29606,7 +29656,7 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_221",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29638,7 +29688,7 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_226",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29670,7 +29720,7 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_232",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29699,7 +29749,7 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
+        "logos-nix": "logos-nix_241",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29727,7 +29777,7 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_246",
+        "logos-nix": "logos-nix_245",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29754,7 +29804,7 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
+        "logos-nix": "logos-nix_249",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29811,7 +29861,7 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_255",
+        "logos-nix": "logos-nix_254",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -29839,7 +29889,7 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_264",
+        "logos-nix": "logos-nix_263",
         "nixpkgs": [
           "logos-liblogos",
           "logos-package-manager",
@@ -29864,7 +29914,7 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_272",
         "nixpkgs": [
           "logos-package",
           "logos-nix",
@@ -29887,7 +29937,7 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_301",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -29918,7 +29968,7 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_310",
+        "logos-nix": "logos-nix_309",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -29948,7 +29998,7 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_313",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -29977,7 +30027,7 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_317",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30007,7 +30057,7 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_323",
+        "logos-nix": "logos-nix_322",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30037,7 +30087,7 @@
     },
     "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30069,7 +30119,7 @@
     },
     "logos-package_39": {
       "inputs": {
-        "logos-nix": "logos-nix_354",
+        "logos-nix": "logos-nix_353",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30130,7 +30180,7 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_357",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30160,7 +30210,7 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_361",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30191,7 +30241,7 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30222,7 +30272,7 @@
     },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
+        "logos-nix": "logos-nix_372",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30250,7 +30300,7 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30277,7 +30327,7 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_387",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30303,7 +30353,7 @@
     },
     "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30315,11 +30365,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -30330,7 +30380,7 @@
     },
     "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -30342,11 +30392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -30357,7 +30407,7 @@
     },
     "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_399",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -30382,7 +30432,7 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
+        "logos-nix": "logos-nix_404",
         "nixpkgs": [
           "logos-package-manager",
           "logos-package",
@@ -30436,7 +30486,7 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_434",
+        "logos-nix": "logos-nix_435",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30467,7 +30517,7 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_444",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30497,7 +30547,7 @@
     },
     "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_448",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30526,7 +30576,7 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_452",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30556,7 +30606,7 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30586,7 +30636,7 @@
     },
     "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_479",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30618,7 +30668,7 @@
     },
     "logos-package_56": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
+        "logos-nix": "logos-nix_488",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30649,7 +30699,7 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30679,7 +30729,7 @@
     },
     "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
+        "logos-nix": "logos-nix_496",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30710,7 +30760,7 @@
     },
     "logos-package_59": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_501",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30773,7 +30823,7 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_507",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30801,7 +30851,7 @@
     },
     "logos-package_61": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
+        "logos-nix": "logos-nix_518",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30828,7 +30878,7 @@
     },
     "logos-package_62": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30854,7 +30904,7 @@
     },
     "logos-package_63": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30866,11 +30916,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -30881,7 +30931,7 @@
     },
     "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
+        "logos-nix": "logos-nix_531",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -30893,11 +30943,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -30908,7 +30958,7 @@
     },
     "logos-package_65": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_534",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -30933,7 +30983,7 @@
     },
     "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_565",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -30964,7 +31014,7 @@
     },
     "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_574",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -30994,7 +31044,7 @@
     },
     "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_578",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31023,7 +31073,7 @@
     },
     "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_579",
+        "logos-nix": "logos-nix_582",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31084,7 +31134,7 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_584",
+        "logos-nix": "logos-nix_587",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31114,7 +31164,7 @@
     },
     "logos-package_71": {
       "inputs": {
-        "logos-nix": "logos-nix_606",
+        "logos-nix": "logos-nix_609",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31146,7 +31196,7 @@
     },
     "logos-package_72": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_618",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31177,7 +31227,7 @@
     },
     "logos-package_73": {
       "inputs": {
-        "logos-nix": "logos-nix_619",
+        "logos-nix": "logos-nix_622",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31207,7 +31257,7 @@
     },
     "logos-package_74": {
       "inputs": {
-        "logos-nix": "logos-nix_623",
+        "logos-nix": "logos-nix_626",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31238,7 +31288,7 @@
     },
     "logos-package_75": {
       "inputs": {
-        "logos-nix": "logos-nix_628",
+        "logos-nix": "logos-nix_631",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31269,7 +31319,7 @@
     },
     "logos-package_76": {
       "inputs": {
-        "logos-nix": "logos-nix_634",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31297,7 +31347,7 @@
     },
     "logos-package_77": {
       "inputs": {
-        "logos-nix": "logos-nix_643",
+        "logos-nix": "logos-nix_648",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31324,7 +31374,7 @@
     },
     "logos-package_78": {
       "inputs": {
-        "logos-nix": "logos-nix_647",
+        "logos-nix": "logos-nix_652",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31350,7 +31400,7 @@
     },
     "logos-package_79": {
       "inputs": {
-        "logos-nix": "logos-nix_651",
+        "logos-nix": "logos-nix_656",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31362,11 +31412,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781873979,
+        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "c207525d30f48620696668c38486884bad5384bc",
         "type": "github"
       },
       "original": {
@@ -31407,7 +31457,7 @@
     },
     "logos-package_80": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
+        "logos-nix": "logos-nix_661",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -31419,11 +31469,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -31434,7 +31484,7 @@
     },
     "logos-package_81": {
       "inputs": {
-        "logos-nix": "logos-nix_685",
+        "logos-nix": "logos-nix_690",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31466,7 +31516,7 @@
     },
     "logos-package_82": {
       "inputs": {
-        "logos-nix": "logos-nix_694",
+        "logos-nix": "logos-nix_699",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31497,7 +31547,7 @@
     },
     "logos-package_83": {
       "inputs": {
-        "logos-nix": "logos-nix_698",
+        "logos-nix": "logos-nix_703",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31527,7 +31577,7 @@
     },
     "logos-package_84": {
       "inputs": {
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_707",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31558,7 +31608,7 @@
     },
     "logos-package_85": {
       "inputs": {
-        "logos-nix": "logos-nix_707",
+        "logos-nix": "logos-nix_712",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31589,7 +31639,7 @@
     },
     "logos-package_86": {
       "inputs": {
-        "logos-nix": "logos-nix_729",
+        "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31622,7 +31672,7 @@
     },
     "logos-package_87": {
       "inputs": {
-        "logos-nix": "logos-nix_738",
+        "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31654,7 +31704,7 @@
     },
     "logos-package_88": {
       "inputs": {
-        "logos-nix": "logos-nix_742",
+        "logos-nix": "logos-nix_747",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31685,7 +31735,7 @@
     },
     "logos-package_89": {
       "inputs": {
-        "logos-nix": "logos-nix_746",
+        "logos-nix": "logos-nix_751",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31748,7 +31798,7 @@
     },
     "logos-package_90": {
       "inputs": {
-        "logos-nix": "logos-nix_751",
+        "logos-nix": "logos-nix_756",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31780,7 +31830,7 @@
     },
     "logos-package_91": {
       "inputs": {
-        "logos-nix": "logos-nix_757",
+        "logos-nix": "logos-nix_762",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31809,7 +31859,7 @@
     },
     "logos-package_92": {
       "inputs": {
-        "logos-nix": "logos-nix_766",
+        "logos-nix": "logos-nix_771",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31837,7 +31887,7 @@
     },
     "logos-package_93": {
       "inputs": {
-        "logos-nix": "logos-nix_770",
+        "logos-nix": "logos-nix_775",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31864,7 +31914,7 @@
     },
     "logos-package_94": {
       "inputs": {
-        "logos-nix": "logos-nix_774",
+        "logos-nix": "logos-nix_779",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31892,7 +31942,7 @@
     },
     "logos-package_95": {
       "inputs": {
-        "logos-nix": "logos-nix_779",
+        "logos-nix": "logos-nix_784",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31920,7 +31970,7 @@
     },
     "logos-package_96": {
       "inputs": {
-        "logos-nix": "logos-nix_782",
+        "logos-nix": "logos-nix_787",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -31946,7 +31996,7 @@
     },
     "logos-package_97": {
       "inputs": {
-        "logos-nix": "logos-nix_813",
+        "logos-nix": "logos-nix_818",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31978,7 +32028,7 @@
     },
     "logos-package_98": {
       "inputs": {
-        "logos-nix": "logos-nix_822",
+        "logos-nix": "logos-nix_827",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32009,7 +32059,7 @@
     },
     "logos-package_99": {
       "inputs": {
-        "logos-nix": "logos-nix_826",
+        "logos-nix": "logos-nix_831",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32066,7 +32116,7 @@
     "logos-plugin-core_10": {
       "inputs": {
         "logos-module": "logos-module_53",
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32092,7 +32142,7 @@
     "logos-plugin-core_11": {
       "inputs": {
         "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_420",
+        "logos-nix": "logos-nix_421",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32121,7 +32171,7 @@
     "logos-plugin-core_12": {
       "inputs": {
         "logos-module": "logos-module_62",
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_465",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32151,7 +32201,7 @@
     "logos-plugin-core_13": {
       "inputs": {
         "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_542",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32177,7 +32227,7 @@
     "logos-plugin-core_14": {
       "inputs": {
         "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_548",
+        "logos-nix": "logos-nix_551",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32206,7 +32256,7 @@
     "logos-plugin-core_15": {
       "inputs": {
         "logos-module": "logos-module_78",
-        "logos-nix": "logos-nix_592",
+        "logos-nix": "logos-nix_595",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32236,7 +32286,7 @@
     "logos-plugin-core_16": {
       "inputs": {
         "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32263,7 +32313,7 @@
     "logos-plugin-core_17": {
       "inputs": {
         "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_671",
+        "logos-nix": "logos-nix_676",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32293,7 +32343,7 @@
     "logos-plugin-core_18": {
       "inputs": {
         "logos-module": "logos-module_94",
-        "logos-nix": "logos-nix_715",
+        "logos-nix": "logos-nix_720",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32324,7 +32374,7 @@
     "logos-plugin-core_19": {
       "inputs": {
         "logos-module": "logos-module_101",
-        "logos-nix": "logos-nix_790",
+        "logos-nix": "logos-nix_795",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32380,7 +32430,7 @@
     "logos-plugin-core_20": {
       "inputs": {
         "logos-module": "logos-module_104",
-        "logos-nix": "logos-nix_799",
+        "logos-nix": "logos-nix_804",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32410,7 +32460,7 @@
     "logos-plugin-core_21": {
       "inputs": {
         "logos-module": "logos-module_110",
-        "logos-nix": "logos-nix_843",
+        "logos-nix": "logos-nix_848",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32471,7 +32521,7 @@
     "logos-plugin-core_4": {
       "inputs": {
         "logos-module": "logos-module_19",
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_139",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -32498,7 +32548,7 @@
     "logos-plugin-core_5": {
       "inputs": {
         "logos-module": "logos-module_22",
-        "logos-nix": "logos-nix_147",
+        "logos-nix": "logos-nix_146",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -32528,7 +32578,7 @@
     "logos-plugin-core_6": {
       "inputs": {
         "logos-module": "logos-module_28",
-        "logos-nix": "logos-nix_191",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -32559,7 +32609,7 @@
     "logos-plugin-core_7": {
       "inputs": {
         "logos-module": "logos-module_37",
-        "logos-nix": "logos-nix_278",
+        "logos-nix": "logos-nix_277",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -32585,7 +32635,7 @@
     "logos-plugin-core_8": {
       "inputs": {
         "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_286",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -32614,7 +32664,7 @@
     "logos-plugin-core_9": {
       "inputs": {
         "logos-module": "logos-module_46",
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -32670,7 +32720,7 @@
     "logos-plugin-qt_10": {
       "inputs": {
         "logos-module": "logos-module_54",
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_414",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32696,7 +32746,7 @@
     "logos-plugin-qt_11": {
       "inputs": {
         "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_422",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32725,7 +32775,7 @@
     "logos-plugin-qt_12": {
       "inputs": {
         "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_467",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -32755,7 +32805,7 @@
     "logos-plugin-qt_13": {
       "inputs": {
         "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_544",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32781,7 +32831,7 @@
     "logos-plugin-qt_14": {
       "inputs": {
         "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_550",
+        "logos-nix": "logos-nix_553",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32810,7 +32860,7 @@
     "logos-plugin-qt_15": {
       "inputs": {
         "logos-module": "logos-module_79",
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_597",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -32840,7 +32890,7 @@
     "logos-plugin-qt_16": {
       "inputs": {
         "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_664",
+        "logos-nix": "logos-nix_669",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32867,7 +32917,7 @@
     "logos-plugin-qt_17": {
       "inputs": {
         "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_678",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32897,7 +32947,7 @@
     "logos-plugin-qt_18": {
       "inputs": {
         "logos-module": "logos-module_95",
-        "logos-nix": "logos-nix_717",
+        "logos-nix": "logos-nix_722",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32928,7 +32978,7 @@
     "logos-plugin-qt_19": {
       "inputs": {
         "logos-module": "logos-module_102",
-        "logos-nix": "logos-nix_792",
+        "logos-nix": "logos-nix_797",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32984,7 +33034,7 @@
     "logos-plugin-qt_20": {
       "inputs": {
         "logos-module": "logos-module_105",
-        "logos-nix": "logos-nix_801",
+        "logos-nix": "logos-nix_806",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -33014,7 +33064,7 @@
     "logos-plugin-qt_21": {
       "inputs": {
         "logos-module": "logos-module_111",
-        "logos-nix": "logos-nix_845",
+        "logos-nix": "logos-nix_850",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -33075,7 +33125,7 @@
     "logos-plugin-qt_4": {
       "inputs": {
         "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_142",
+        "logos-nix": "logos-nix_141",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -33102,7 +33152,7 @@
     "logos-plugin-qt_5": {
       "inputs": {
         "logos-module": "logos-module_23",
-        "logos-nix": "logos-nix_149",
+        "logos-nix": "logos-nix_148",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -33132,7 +33182,7 @@
     "logos-plugin-qt_6": {
       "inputs": {
         "logos-module": "logos-module_29",
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -33163,7 +33213,7 @@
     "logos-plugin-qt_7": {
       "inputs": {
         "logos-module": "logos-module_38",
-        "logos-nix": "logos-nix_280",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -33189,7 +33239,7 @@
     "logos-plugin-qt_8": {
       "inputs": {
         "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_288",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -33218,7 +33268,7 @@
     "logos-plugin-qt_9": {
       "inputs": {
         "logos-module": "logos-module_47",
-        "logos-nix": "logos-nix_333",
+        "logos-nix": "logos-nix_332",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -33257,11 +33307,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
         "type": "github"
       },
       "original": {
@@ -33273,24 +33323,28 @@
     "logos-protocol_10": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -33301,22 +33355,23 @@
     },
     "logos-protocol_11": {
       "inputs": {
-        "logos-nix": "logos-nix_665",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -33328,6 +33383,634 @@
     "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_13": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_14": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_15": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_16": {
+      "inputs": {
+        "logos-nix": "logos-nix_415",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_17": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_18": {
+      "inputs": {
+        "logos-nix": "logos-nix_511",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_19": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_2": {
+      "inputs": {
+        "logos-nix": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_20": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_21": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_22": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_23": {
+      "inputs": {
+        "logos-nix": "logos-nix_545",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_24": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_25": {
+      "inputs": {
+        "logos-nix": "logos-nix_641",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_26": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_27": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_28": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_29": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_3": {
+      "inputs": {
+        "logos-nix": "logos-nix_104",
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_30": {
+      "inputs": {
+        "logos-nix": "logos-nix_670",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782082589,
+        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_31": {
+      "inputs": {
+        "logos-nix": [
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
@@ -33356,9 +34039,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_13": {
+    "logos-protocol_32": {
       "inputs": {
-        "logos-nix": "logos-nix_793",
+        "logos-nix": "logos-nix_798",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -33382,7 +34065,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_14": {
+    "logos-protocol_33": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -33413,7 +34096,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_15": {
+    "logos-protocol_34": {
       "inputs": {
         "logos-nix": [
           "logos-nix"
@@ -33438,7 +34121,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_16": {
+    "logos-protocol_35": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -33446,60 +34129,6 @@
         ],
         "nixpkgs": [
           "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781303997,
-        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_2": {
-      "inputs": {
-        "logos-nix": [
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_3": {
-      "inputs": {
-        "logos-nix": "logos-nix_134",
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol",
-          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -33519,11 +34148,16 @@
     },
     "logos-protocol_4": {
       "inputs": {
-        "logos-nix": "logos-nix_268",
+        "logos-nix": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "nixpkgs"
         ]
       },
@@ -33543,21 +34177,31 @@
     },
     "logos-protocol_5": {
       "inputs": {
-        "logos-nix": "logos-nix_281",
-        "nixpkgs": [
-          "logos-package-downloader-module",
+        "logos-nix": [
+          "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -33569,24 +34213,26 @@
     "logos-protocol_6": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -33597,21 +34243,25 @@
     },
     "logos-protocol_7": {
       "inputs": {
-        "logos-nix": "logos-nix_414",
-        "nixpkgs": [
-          "logos-package-manager-module",
+        "logos-nix": [
+          "logos-capability-module",
           "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1781303997,
+        "narHash": "sha256-j9U4wPlHdN5oA+65h1SAo/s2YUHvNYKxij4/pCqEtAs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "9de4165ab68ece4071647026cb2596bed8a8d7e2",
         "type": "github"
       },
       "original": {
@@ -33622,25 +34272,20 @@
     },
     "logos-protocol_8": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_267",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781065710,
-        "narHash": "sha256-QmNQ7LdrfzyvsZGISGKJKbHqB03F6JExgGF2K1f2WcE=",
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "ca28190272eef2772edf9b3e1df47e121f02a726",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
         "type": "github"
       },
       "original": {
@@ -33651,9 +34296,9 @@
     },
     "logos-protocol_9": {
       "inputs": {
-        "logos-nix": "logos-nix_542",
+        "logos-nix": "logos-nix_280",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -33661,11 +34306,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782082589,
-        "narHash": "sha256-Qeqxp0HYb3oTpmfD5YlFPJzpAJa7Ilb9o4sMeVvmHRI=",
+        "lastModified": 1782291447,
+        "narHash": "sha256-Jkc8MOuJNuQEEs69GMOwDL1bzAPxdMsJ7hlEUz6nkQM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "315a3a2e0af61bc47aad5601ee44cd7689975820",
+        "rev": "c6234940fc030af2fd5c445db82120dc2162887f",
         "type": "github"
       },
       "original": {
@@ -33704,7 +34349,7 @@
     },
     "logos-qt-mcp_10": {
       "inputs": {
-        "logos-nix": "logos-nix_440",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -33732,7 +34377,7 @@
     },
     "logos-qt-mcp_11": {
       "inputs": {
-        "logos-nix": "logos-nix_484",
+        "logos-nix": "logos-nix_485",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -33761,7 +34406,7 @@
     },
     "logos-qt-mcp_12": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_515",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -33772,11 +34417,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -33787,7 +34432,7 @@
     },
     "logos-qt-mcp_13": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_571",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -33815,7 +34460,7 @@
     },
     "logos-qt-mcp_14": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
+        "logos-nix": "logos-nix_615",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -33844,7 +34489,7 @@
     },
     "logos-qt-mcp_15": {
       "inputs": {
-        "logos-nix": "logos-nix_640",
+        "logos-nix": "logos-nix_645",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -33855,11 +34500,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -33870,7 +34515,7 @@
     },
     "logos-qt-mcp_16": {
       "inputs": {
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_696",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -33899,7 +34544,7 @@
     },
     "logos-qt-mcp_17": {
       "inputs": {
-        "logos-nix": "logos-nix_735",
+        "logos-nix": "logos-nix_740",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -33929,7 +34574,7 @@
     },
     "logos-qt-mcp_18": {
       "inputs": {
-        "logos-nix": "logos-nix_763",
+        "logos-nix": "logos-nix_768",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -33956,7 +34601,7 @@
     },
     "logos-qt-mcp_19": {
       "inputs": {
-        "logos-nix": "logos-nix_819",
+        "logos-nix": "logos-nix_824",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34014,7 +34659,7 @@
     },
     "logos-qt-mcp_20": {
       "inputs": {
-        "logos-nix": "logos-nix_863",
+        "logos-nix": "logos-nix_868",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34044,7 +34689,7 @@
     },
     "logos-qt-mcp_21": {
       "inputs": {
-        "logos-nix": "logos-nix_891",
+        "logos-nix": "logos-nix_896",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34071,7 +34716,7 @@
     },
     "logos-qt-mcp_22": {
       "inputs": {
-        "logos-nix": "logos-nix_914",
+        "logos-nix": "logos-nix_919",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -34094,7 +34739,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_108",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -34105,11 +34750,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -34120,7 +34765,7 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_167",
+        "logos-nix": "logos-nix_166",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -34149,7 +34794,7 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_211",
+        "logos-nix": "logos-nix_210",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -34179,7 +34824,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_238",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -34206,7 +34851,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_307",
+        "logos-nix": "logos-nix_306",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -34234,7 +34879,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_350",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -34263,7 +34908,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_379",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -34274,11 +34919,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455349,
-        "narHash": "sha256-rebrtH1UxC1hDuwQBwyYbGzNCrnuuqiVL7OvzUhk65k=",
+        "lastModified": 1781077555,
+        "narHash": "sha256-rkqva3DbhhxWrVp6KLyhVxbAK2MLIWfUcPG5HM7wnsQ=",
         "owner": "logos-co",
         "repo": "logos-qt-mcp",
-        "rev": "c5223b4b640add09e461983b8fddbd12c8b31f4f",
+        "rev": "c87f6bd985a07ec2809081c8d0830108aa895819",
         "type": "github"
       },
       "original": {
@@ -34310,11 +34955,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "lastModified": 1782296555,
+        "narHash": "sha256-1M/TzEn/1Whby0eGlaovwHQQ1eiCXSJ/AOMFihoOHSI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "rev": "9020fa99f214458fd1f1c69a8ed16e02536ac9f9",
         "type": "github"
       },
       "original": {
@@ -34326,36 +34971,40 @@
     "logos-qt-sdk_10": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -34367,34 +35016,36 @@
     "logos-qt-sdk_11": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_19",
-        "logos-nix": "logos-nix_666",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
+        "logos-nix": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -34406,6 +35057,494 @@
     "logos-qt-sdk_12": {
       "inputs": {
         "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_11",
+        "logos-nix": "logos-nix_416",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782296555,
+        "narHash": "sha256-1M/TzEn/1Whby0eGlaovwHQQ1eiCXSJ/AOMFihoOHSI=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "9020fa99f214458fd1f1c69a8ed16e02536ac9f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_13": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_512",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_14": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_15": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_16": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_17": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_14",
+        "logos-nix": "logos-nix_546",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782296555,
+        "narHash": "sha256-1M/TzEn/1Whby0eGlaovwHQQ1eiCXSJ/AOMFihoOHSI=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "9020fa99f214458fd1f1c69a8ed16e02536ac9f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_18": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_642",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_19": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_2": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_105",
+        "logos-protocol": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_20": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_21": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_22": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_17",
+        "logos-nix": "logos-nix_671",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781962335,
+        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_23": {
+      "inputs": {
+        "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
@@ -34448,7 +35587,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_13": {
+    "logos-qt-sdk_24": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -34456,8 +35595,8 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_794",
+        "logos-lidl": "logos-lidl_20",
+        "logos-nix": "logos-nix_799",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34487,7 +35626,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_14": {
+    "logos-qt-sdk_25": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -34532,12 +35671,12 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_15": {
+    "logos-qt-sdk_26": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_24",
+        "logos-lidl": "logos-lidl_22",
         "logos-nix": [
           "logos-nix"
         ],
@@ -34564,7 +35703,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_16": {
+    "logos-qt-sdk_27": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-view-module-runtime",
@@ -34597,75 +35736,39 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_2": {
+    "logos-qt-sdk_3": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_3": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_6",
-        "logos-nix": "logos-nix_135",
-        "logos-protocol": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781655169,
-        "narHash": "sha256-wjbHmczSG8VUMlRkIp3pviVTLPTzReDbIRfBpqnlQr4=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "812369213719773f6486755a30c476a699469b37",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -34677,11 +35780,97 @@
     "logos-qt-sdk_4": {
       "inputs": {
         "logos-cpp-sdk": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_5": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_6": {
+      "inputs": {
+        "logos-cpp-sdk": [
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_8",
-        "logos-nix": "logos-nix_269",
+        "logos-lidl": "logos-lidl_6",
+        "logos-nix": "logos-nix_268",
         "logos-protocol": [
           "logos-liblogos",
           "logos-protocol"
@@ -34707,99 +35896,22 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_5": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_10",
-        "logos-nix": "logos-nix_282",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_6": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
     "logos-qt-sdk_7": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_13",
-        "logos-nix": "logos-nix_415",
+        "logos-lidl": "logos-lidl_8",
+        "logos-nix": "logos-nix_281",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -34807,11 +35919,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "lastModified": 1782296555,
+        "narHash": "sha256-1M/TzEn/1Whby0eGlaovwHQQ1eiCXSJ/AOMFihoOHSI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "rev": "9020fa99f214458fd1f1c69a8ed16e02536ac9f9",
         "type": "github"
       },
       "original": {
@@ -34823,36 +35935,36 @@
     "logos-qt-sdk_8": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_377",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781066423,
-        "narHash": "sha256-3pVeJ/cK2z4OEi5iLORjoC7YpdrRrHmigl9SyvEapI8=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "355774603877637b486ea0aeefbf7828ae321868",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -34864,31 +35976,36 @@
     "logos-qt-sdk_9": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_16",
-        "logos-nix": "logos-nix_543",
-        "logos-protocol": [
-          "logos-package-manager-ui",
+        "logos-nix": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
+          "logos-standalone-app",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781962335,
-        "narHash": "sha256-TThOj0o115vPawAPJgv5zhDnV/hVfnDqjpga9Z2SlPU=",
+        "lastModified": 1781306785,
+        "narHash": "sha256-Z8nAECXYUx4mt0fH9Q9IFpLlAZc+m/Z43GD8mZEIoKE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "cdf077cdb296b39fe45d6f774a0b4ae71be48d45",
+        "rev": "8d0e5d98990261407b50600d886158a1f78e1b1c",
         "type": "github"
       },
       "original": {
@@ -34945,7 +36062,7 @@
     },
     "logos-rust-sdk_2": {
       "inputs": {
-        "logos-lidl": "logos-lidl_11",
+        "logos-lidl": "logos-lidl_9",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -34991,7 +36108,7 @@
     },
     "logos-rust-sdk_3": {
       "inputs": {
-        "logos-lidl": "logos-lidl_14",
+        "logos-lidl": "logos-lidl_12",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35037,7 +36154,7 @@
     },
     "logos-rust-sdk_4": {
       "inputs": {
-        "logos-lidl": "logos-lidl_17",
+        "logos-lidl": "logos-lidl_15",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -35083,7 +36200,7 @@
     },
     "logos-rust-sdk_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_20",
+        "logos-lidl": "logos-lidl_18",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -35134,7 +36251,7 @@
     },
     "logos-rust-sdk_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_23",
+        "logos-lidl": "logos-lidl_21",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_manager",
@@ -35189,8 +36306,10 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-design-system": "logos-design-system_2",
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_107",
+        "logos-protocol": "logos-protocol_4",
         "logos-qt-mcp": "logos-qt-mcp_3",
+        "logos-qt-sdk": "logos-qt-sdk_3",
         "logos-view-module-runtime": "logos-view-module-runtime_3",
         "nix-bundle-lgx": "nix-bundle-lgx_7",
         "nixpkgs": [
@@ -35202,11 +36321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725202,
-        "narHash": "sha256-7IqnkRG1CkOKfiw5qf1o+Kg9ci+MKlcJNXgrg6GyYXk=",
+        "lastModified": 1781319979,
+        "narHash": "sha256-7rbkfuCeHmhv+eVqWUeVzJqtNDW9ynjf5TkajNIySDU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "f812b43f73f3c264ee0f8a8354f40721431d6846",
+        "rev": "c8c0bece1fe8f0d21541e136b222aecbe2755b9f",
         "type": "github"
       },
       "original": {
@@ -35218,11 +36337,13 @@
     "logos-standalone-app_10": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_21",
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-design-system": "logos-design-system_12",
         "logos-liblogos": "logos-liblogos_12",
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_514",
+        "logos-protocol": "logos-protocol_19",
         "logos-qt-mcp": "logos-qt-mcp_12",
+        "logos-qt-sdk": "logos-qt-sdk_14",
         "logos-view-module-runtime": "logos-view-module-runtime_12",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
@@ -35234,11 +36355,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725202,
-        "narHash": "sha256-7IqnkRG1CkOKfiw5qf1o+Kg9ci+MKlcJNXgrg6GyYXk=",
+        "lastModified": 1781319979,
+        "narHash": "sha256-7rbkfuCeHmhv+eVqWUeVzJqtNDW9ynjf5TkajNIySDU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "f812b43f73f3c264ee0f8a8354f40721431d6846",
+        "rev": "c8c0bece1fe8f0d21541e136b222aecbe2755b9f",
         "type": "github"
       },
       "original": {
@@ -35250,10 +36371,10 @@
     "logos-standalone-app_11": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_22",
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-design-system": "logos-design-system_11",
         "logos-liblogos": "logos-liblogos_11",
-        "logos-nix": "logos-nix_439",
+        "logos-nix": "logos-nix_440",
         "logos-qt-mcp": "logos-qt-mcp_10",
         "logos-view-module-runtime": "logos-view-module-runtime_10",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
@@ -35285,10 +36406,10 @@
     "logos-standalone-app_12": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_25",
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
         "logos-design-system": "logos-design-system_13",
         "logos-liblogos": "logos-liblogos_13",
-        "logos-nix": "logos-nix_483",
+        "logos-nix": "logos-nix_484",
         "logos-qt-mcp": "logos-qt-mcp_11",
         "logos-view-module-runtime": "logos-view-module-runtime_11",
         "nix-bundle-lgx": "nix-bundle-lgx_31",
@@ -35321,11 +36442,13 @@
     "logos-standalone-app_13": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_27",
-        "logos-cpp-sdk": "logos-cpp-sdk_57",
+        "logos-cpp-sdk": "logos-cpp-sdk_56",
         "logos-design-system": "logos-design-system_15",
         "logos-liblogos": "logos-liblogos_15",
-        "logos-nix": "logos-nix_639",
+        "logos-nix": "logos-nix_644",
+        "logos-protocol": "logos-protocol_26",
         "logos-qt-mcp": "logos-qt-mcp_15",
+        "logos-qt-sdk": "logos-qt-sdk_19",
         "logos-view-module-runtime": "logos-view-module-runtime_15",
         "nix-bundle-lgx": "nix-bundle-lgx_43",
         "nixpkgs": [
@@ -35337,11 +36460,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725202,
-        "narHash": "sha256-7IqnkRG1CkOKfiw5qf1o+Kg9ci+MKlcJNXgrg6GyYXk=",
+        "lastModified": 1781319979,
+        "narHash": "sha256-7rbkfuCeHmhv+eVqWUeVzJqtNDW9ynjf5TkajNIySDU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "f812b43f73f3c264ee0f8a8354f40721431d6846",
+        "rev": "c8c0bece1fe8f0d21541e136b222aecbe2755b9f",
         "type": "github"
       },
       "original": {
@@ -35353,10 +36476,10 @@
     "logos-standalone-app_14": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_28",
-        "logos-cpp-sdk": "logos-cpp-sdk_54",
+        "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-design-system": "logos-design-system_14",
         "logos-liblogos": "logos-liblogos_14",
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_570",
         "logos-qt-mcp": "logos-qt-mcp_13",
         "logos-view-module-runtime": "logos-view-module-runtime_13",
         "nix-bundle-lgx": "nix-bundle-lgx_37",
@@ -35388,10 +36511,10 @@
     "logos-standalone-app_15": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_31",
-        "logos-cpp-sdk": "logos-cpp-sdk_59",
+        "logos-cpp-sdk": "logos-cpp-sdk_58",
         "logos-design-system": "logos-design-system_16",
         "logos-liblogos": "logos-liblogos_16",
-        "logos-nix": "logos-nix_611",
+        "logos-nix": "logos-nix_614",
         "logos-qt-mcp": "logos-qt-mcp_14",
         "logos-view-module-runtime": "logos-view-module-runtime_14",
         "nix-bundle-lgx": "nix-bundle-lgx_40",
@@ -35424,10 +36547,10 @@
     "logos-standalone-app_16": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_33",
-        "logos-cpp-sdk": "logos-cpp-sdk_69",
+        "logos-cpp-sdk": "logos-cpp-sdk_68",
         "logos-design-system": "logos-design-system_18",
         "logos-liblogos": "logos-liblogos_18",
-        "logos-nix": "logos-nix_762",
+        "logos-nix": "logos-nix_767",
         "logos-qt-mcp": "logos-qt-mcp_18",
         "logos-view-module-runtime": "logos-view-module-runtime_18",
         "nix-bundle-lgx": "nix-bundle-lgx_52",
@@ -35457,10 +36580,10 @@
     "logos-standalone-app_17": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_34",
-        "logos-cpp-sdk": "logos-cpp-sdk_66",
+        "logos-cpp-sdk": "logos-cpp-sdk_65",
         "logos-design-system": "logos-design-system_17",
         "logos-liblogos": "logos-liblogos_17",
-        "logos-nix": "logos-nix_690",
+        "logos-nix": "logos-nix_695",
         "logos-qt-mcp": "logos-qt-mcp_16",
         "logos-view-module-runtime": "logos-view-module-runtime_16",
         "nix-bundle-lgx": "nix-bundle-lgx_46",
@@ -35493,10 +36616,10 @@
     "logos-standalone-app_18": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_37",
-        "logos-cpp-sdk": "logos-cpp-sdk_71",
+        "logos-cpp-sdk": "logos-cpp-sdk_70",
         "logos-design-system": "logos-design-system_19",
         "logos-liblogos": "logos-liblogos_19",
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_739",
         "logos-qt-mcp": "logos-qt-mcp_17",
         "logos-view-module-runtime": "logos-view-module-runtime_17",
         "nix-bundle-lgx": "nix-bundle-lgx_49",
@@ -35530,10 +36653,10 @@
     "logos-standalone-app_19": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_39",
-        "logos-cpp-sdk": "logos-cpp-sdk_81",
+        "logos-cpp-sdk": "logos-cpp-sdk_80",
         "logos-design-system": "logos-design-system_21",
         "logos-liblogos": "logos-liblogos_21",
-        "logos-nix": "logos-nix_890",
+        "logos-nix": "logos-nix_895",
         "logos-qt-mcp": "logos-qt-mcp_21",
         "logos-view-module-runtime": "logos-view-module-runtime_21",
         "nix-bundle-lgx": "nix-bundle-lgx_61",
@@ -35598,10 +36721,10 @@
     "logos-standalone-app_20": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_40",
-        "logos-cpp-sdk": "logos-cpp-sdk_78",
+        "logos-cpp-sdk": "logos-cpp-sdk_77",
         "logos-design-system": "logos-design-system_20",
         "logos-liblogos": "logos-liblogos_20",
-        "logos-nix": "logos-nix_818",
+        "logos-nix": "logos-nix_823",
         "logos-qt-mcp": "logos-qt-mcp_19",
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-lgx": "nix-bundle-lgx_55",
@@ -35634,10 +36757,10 @@
     "logos-standalone-app_21": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_43",
-        "logos-cpp-sdk": "logos-cpp-sdk_83",
+        "logos-cpp-sdk": "logos-cpp-sdk_82",
         "logos-design-system": "logos-design-system_22",
         "logos-liblogos": "logos-liblogos_22",
-        "logos-nix": "logos-nix_862",
+        "logos-nix": "logos-nix_867",
         "logos-qt-mcp": "logos-qt-mcp_20",
         "logos-view-module-runtime": "logos-view-module-runtime_20",
         "nix-bundle-lgx": "nix-bundle-lgx_58",
@@ -35707,10 +36830,10 @@
     "logos-standalone-app_4": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_9",
-        "logos-cpp-sdk": "logos-cpp-sdk_20",
+        "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-design-system": "logos-design-system_6",
         "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_238",
+        "logos-nix": "logos-nix_237",
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": "logos-view-module-runtime_6",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
@@ -35740,10 +36863,10 @@
     "logos-standalone-app_5": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_10",
-        "logos-cpp-sdk": "logos-cpp-sdk_17",
+        "logos-cpp-sdk": "logos-cpp-sdk_16",
         "logos-design-system": "logos-design-system_5",
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_166",
+        "logos-nix": "logos-nix_165",
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": "logos-view-module-runtime_4",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
@@ -35776,10 +36899,10 @@
     "logos-standalone-app_6": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_13",
-        "logos-cpp-sdk": "logos-cpp-sdk_22",
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
         "logos-design-system": "logos-design-system_7",
         "logos-liblogos": "logos-liblogos_7",
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_209",
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": "logos-view-module-runtime_5",
         "nix-bundle-lgx": "nix-bundle-lgx_13",
@@ -35813,11 +36936,13 @@
     "logos-standalone-app_7": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_15",
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-design-system": "logos-design-system_9",
         "logos-liblogos": "logos-liblogos_9",
-        "logos-nix": "logos-nix_378",
+        "logos-nix": "logos-nix_379",
+        "logos-protocol": "logos-protocol_12",
         "logos-qt-mcp": "logos-qt-mcp_9",
+        "logos-qt-sdk": "logos-qt-sdk_9",
         "logos-view-module-runtime": "logos-view-module-runtime_9",
         "nix-bundle-lgx": "nix-bundle-lgx_25",
         "nixpkgs": [
@@ -35829,11 +36954,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779725202,
-        "narHash": "sha256-7IqnkRG1CkOKfiw5qf1o+Kg9ci+MKlcJNXgrg6GyYXk=",
+        "lastModified": 1781319979,
+        "narHash": "sha256-7rbkfuCeHmhv+eVqWUeVzJqtNDW9ynjf5TkajNIySDU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "f812b43f73f3c264ee0f8a8354f40721431d6846",
+        "rev": "c8c0bece1fe8f0d21541e136b222aecbe2755b9f",
         "type": "github"
       },
       "original": {
@@ -35845,10 +36970,10 @@
     "logos-standalone-app_8": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_16",
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
         "logos-design-system": "logos-design-system_8",
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_305",
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": "logos-view-module-runtime_7",
         "nix-bundle-lgx": "nix-bundle-lgx_19",
@@ -35880,10 +37005,10 @@
     "logos-standalone-app_9": {
       "inputs": {
         "logos-capability-module": "logos-capability-module_19",
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-design-system": "logos-design-system_10",
         "logos-liblogos": "logos-liblogos_10",
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_349",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": "logos-view-module-runtime_8",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
@@ -35959,7 +37084,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35996,7 +37121,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_489",
+        "logos-nix": "logos-nix_490",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36030,9 +37155,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_517",
-        "logos-protocol": "logos-protocol_8",
-        "logos-qt-sdk": "logos-qt-sdk_8",
+        "logos-nix": "logos-nix_520",
+        "logos-protocol": "logos-protocol_22",
+        "logos-qt-sdk": "logos-qt-sdk_16",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36042,11 +37167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781118884,
-        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
+        "lastModified": 1781319474,
+        "narHash": "sha256-dcJJymaY43fBCluUocVZHpDuUwO4Inm/vGnlO880j/0=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
+        "rev": "9665bc792905527553cfaed1e27ce10cf5e812a4",
         "type": "github"
       },
       "original": {
@@ -36065,7 +37190,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_573",
+        "logos-nix": "logos-nix_576",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36102,7 +37227,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_620",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36136,9 +37261,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_645",
-        "logos-protocol": "logos-protocol_10",
-        "logos-qt-sdk": "logos-qt-sdk_10",
+        "logos-nix": "logos-nix_650",
+        "logos-protocol": "logos-protocol_29",
+        "logos-qt-sdk": "logos-qt-sdk_21",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36148,11 +37273,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781118884,
-        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
+        "lastModified": 1781319474,
+        "narHash": "sha256-dcJJymaY43fBCluUocVZHpDuUwO4Inm/vGnlO880j/0=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
+        "rev": "9665bc792905527553cfaed1e27ce10cf5e812a4",
         "type": "github"
       },
       "original": {
@@ -36172,7 +37297,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_701",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -36211,7 +37336,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_740",
+        "logos-nix": "logos-nix_745",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -36247,9 +37372,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_768",
-        "logos-protocol": "logos-protocol_12",
-        "logos-qt-sdk": "logos-qt-sdk_12",
+        "logos-nix": "logos-nix_773",
+        "logos-protocol": "logos-protocol_31",
+        "logos-qt-sdk": "logos-qt-sdk_23",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -36284,7 +37409,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_824",
+        "logos-nix": "logos-nix_829",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36361,7 +37486,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_868",
+        "logos-nix": "logos-nix_873",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36397,9 +37522,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_896",
-        "logos-protocol": "logos-protocol_14",
-        "logos-qt-sdk": "logos-qt-sdk_14",
+        "logos-nix": "logos-nix_901",
+        "logos-protocol": "logos-protocol_33",
+        "logos-qt-sdk": "logos-qt-sdk_25",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36430,9 +37555,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_111",
-        "logos-protocol": "logos-protocol_2",
-        "logos-qt-sdk": "logos-qt-sdk_2",
+        "logos-nix": "logos-nix_113",
+        "logos-protocol": "logos-protocol_7",
+        "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -36442,11 +37567,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781118884,
-        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
+        "lastModified": 1781319474,
+        "narHash": "sha256-dcJJymaY43fBCluUocVZHpDuUwO4Inm/vGnlO880j/0=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
+        "rev": "9665bc792905527553cfaed1e27ce10cf5e812a4",
         "type": "github"
       },
       "original": {
@@ -36466,7 +37591,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_171",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36505,7 +37630,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_215",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36541,7 +37666,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_244",
+        "logos-nix": "logos-nix_243",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36575,7 +37700,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_312",
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36612,7 +37737,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_356",
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36646,9 +37771,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_384",
-        "logos-protocol": "logos-protocol_6",
-        "logos-qt-sdk": "logos-qt-sdk_6",
+        "logos-nix": "logos-nix_385",
+        "logos-protocol": "logos-protocol_15",
+        "logos-qt-sdk": "logos-qt-sdk_11",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36658,11 +37783,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781118884,
-        "narHash": "sha256-bM8Deqf6soZeUqWy3RdyY0APRKLWmjD/78g1fbEObaY=",
+        "lastModified": 1781319474,
+        "narHash": "sha256-dcJJymaY43fBCluUocVZHpDuUwO4Inm/vGnlO880j/0=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5b8fcc9ffdc5c66511a95a6bf6b41dd74fbbacc9",
+        "rev": "9665bc792905527553cfaed1e27ce10cf5e812a4",
         "type": "github"
       },
       "original": {
@@ -36719,7 +37844,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_441",
+        "logos-nix": "logos-nix_442",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36757,7 +37882,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_486",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36786,8 +37911,10 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_51",
-        "logos-nix": "logos-nix_513",
+        "logos-cpp-sdk": "logos-cpp-sdk_50",
+        "logos-nix": "logos-nix_516",
+        "logos-protocol": "logos-protocol_21",
+        "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36798,11 +37925,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779723114,
-        "narHash": "sha256-6NNZG9FTaLRKwJZxtFWySlfiTanh25AmJK5Ru+S9HrM=",
+        "lastModified": 1781316066,
+        "narHash": "sha256-s5aaSGhu5HiotCXa0Vbjgp17TTMXedt52cqD/8FM4aQ=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "21dddc380eca36e7e865cf5a437f63e0e16f30d3",
+        "rev": "7541c318d85cabed61b9222d59d4110836ede430",
         "type": "github"
       },
       "original": {
@@ -36822,7 +37949,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36860,7 +37987,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_613",
+        "logos-nix": "logos-nix_616",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36889,8 +38016,10 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_63",
-        "logos-nix": "logos-nix_641",
+        "logos-cpp-sdk": "logos-cpp-sdk_62",
+        "logos-nix": "logos-nix_646",
+        "logos-protocol": "logos-protocol_28",
+        "logos-qt-sdk": "logos-qt-sdk_20",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36901,11 +38030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779723114,
-        "narHash": "sha256-6NNZG9FTaLRKwJZxtFWySlfiTanh25AmJK5Ru+S9HrM=",
+        "lastModified": 1781316066,
+        "narHash": "sha256-s5aaSGhu5HiotCXa0Vbjgp17TTMXedt52cqD/8FM4aQ=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "21dddc380eca36e7e865cf5a437f63e0e16f30d3",
+        "rev": "7541c318d85cabed61b9222d59d4110836ede430",
         "type": "github"
       },
       "original": {
@@ -36926,7 +38055,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_692",
+        "logos-nix": "logos-nix_697",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -36966,7 +38095,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_736",
+        "logos-nix": "logos-nix_741",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -36996,8 +38125,8 @@
     },
     "logos-view-module-runtime_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_75",
-        "logos-nix": "logos-nix_764",
+        "logos-cpp-sdk": "logos-cpp-sdk_74",
+        "logos-nix": "logos-nix_769",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -37034,7 +38163,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_820",
+        "logos-nix": "logos-nix_825",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37113,7 +38242,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_864",
+        "logos-nix": "logos-nix_869",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37143,8 +38272,8 @@
     },
     "logos-view-module-runtime_21": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_87",
-        "logos-nix": "logos-nix_892",
+        "logos-cpp-sdk": "logos-cpp-sdk_86",
+        "logos-nix": "logos-nix_897",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37174,9 +38303,9 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_915",
-        "logos-protocol": "logos-protocol_16",
-        "logos-qt-sdk": "logos-qt-sdk_16",
+        "logos-nix": "logos-nix_920",
+        "logos-protocol": "logos-protocol_35",
+        "logos-qt-sdk": "logos-qt-sdk_27",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -37198,7 +38327,9 @@
     "logos-view-module-runtime_3": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_12",
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_109",
+        "logos-protocol": "logos-protocol_6",
+        "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -37209,11 +38340,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779723114,
-        "narHash": "sha256-6NNZG9FTaLRKwJZxtFWySlfiTanh25AmJK5Ru+S9HrM=",
+        "lastModified": 1781316066,
+        "narHash": "sha256-s5aaSGhu5HiotCXa0Vbjgp17TTMXedt52cqD/8FM4aQ=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "21dddc380eca36e7e865cf5a437f63e0e16f30d3",
+        "rev": "7541c318d85cabed61b9222d59d4110836ede430",
         "type": "github"
       },
       "original": {
@@ -37234,7 +38365,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_167",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -37274,7 +38405,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_212",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -37304,8 +38435,8 @@
     },
     "logos-view-module-runtime_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
-        "logos-nix": "logos-nix_240",
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -37341,7 +38472,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_308",
+        "logos-nix": "logos-nix_307",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37379,7 +38510,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_351",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37408,8 +38539,10 @@
     },
     "logos-view-module-runtime_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-nix": "logos-nix_380",
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
+        "logos-nix": "logos-nix_381",
+        "logos-protocol": "logos-protocol_14",
+        "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37420,11 +38553,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779723114,
-        "narHash": "sha256-6NNZG9FTaLRKwJZxtFWySlfiTanh25AmJK5Ru+S9HrM=",
+        "lastModified": 1781316066,
+        "narHash": "sha256-s5aaSGhu5HiotCXa0Vbjgp17TTMXedt52cqD/8FM4aQ=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "21dddc380eca36e7e865cf5a437f63e0e16f30d3",
+        "rev": "7541c318d85cabed61b9222d59d4110836ede430",
         "type": "github"
       },
       "original": {
@@ -37467,7 +38600,7 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_223",
+        "logos-nix": "logos-nix_222",
         "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
           "logos-liblogos",
@@ -37500,7 +38633,7 @@
     },
     "nix-bundle-appimage_11": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_233",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nixpkgs": [
           "logos-liblogos",
@@ -37530,7 +38663,7 @@
     },
     "nix-bundle-appimage_12": {
       "inputs": {
-        "logos-nix": "logos-nix_251",
+        "logos-nix": "logos-nix_250",
         "nix-bundle-dir": "nix-bundle-dir_40",
         "nixpkgs": [
           "logos-liblogos",
@@ -37559,7 +38692,7 @@
     },
     "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_265",
+        "logos-nix": "logos-nix_264",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nixpkgs": [
           "logos-liblogos",
@@ -37585,7 +38718,7 @@
     },
     "nix-bundle-appimage_14": {
       "inputs": {
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_301",
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37617,7 +38750,7 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_319",
+        "logos-nix": "logos-nix_318",
         "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37648,7 +38781,7 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_345",
         "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37681,7 +38814,7 @@
     },
     "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_362",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37713,7 +38846,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_373",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37742,7 +38875,7 @@
     },
     "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_392",
         "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37801,7 +38934,7 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_400",
         "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -37827,7 +38960,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_405",
         "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
           "logos-package-manager",
@@ -37852,7 +38985,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_435",
+        "logos-nix": "logos-nix_436",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -37884,7 +39017,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_453",
         "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -37915,7 +39048,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_480",
         "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -37948,7 +39081,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_497",
         "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -37980,7 +39113,7 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_508",
         "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -38009,7 +39142,7 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
+        "logos-nix": "logos-nix_527",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -38037,7 +39170,7 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_535",
         "nix-bundle-dir": "nix-bundle-dir_91",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -38063,7 +39196,7 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_566",
         "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38128,7 +39261,7 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_580",
+        "logos-nix": "logos-nix_583",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38159,7 +39292,7 @@
     },
     "nix-bundle-appimage_31": {
       "inputs": {
-        "logos-nix": "logos-nix_607",
+        "logos-nix": "logos-nix_610",
         "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38192,7 +39325,7 @@
     },
     "nix-bundle-appimage_32": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_627",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38224,7 +39357,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_638",
         "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38253,7 +39386,7 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_652",
+        "logos-nix": "logos-nix_657",
         "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38281,7 +39414,7 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_686",
+        "logos-nix": "logos-nix_691",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38314,7 +39447,7 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
+        "logos-nix": "logos-nix_708",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38346,7 +39479,7 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
+        "logos-nix": "logos-nix_735",
         "nix-bundle-dir": "nix-bundle-dir_121",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38380,7 +39513,7 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_747",
+        "logos-nix": "logos-nix_752",
         "nix-bundle-dir": "nix-bundle-dir_125",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38413,7 +39546,7 @@
     },
     "nix-bundle-appimage_39": {
       "inputs": {
-        "logos-nix": "logos-nix_758",
+        "logos-nix": "logos-nix_763",
         "nix-bundle-dir": "nix-bundle-dir_128",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38475,7 +39608,7 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_775",
+        "logos-nix": "logos-nix_780",
         "nix-bundle-dir": "nix-bundle-dir_132",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38504,7 +39637,7 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_783",
+        "logos-nix": "logos-nix_788",
         "nix-bundle-dir": "nix-bundle-dir_135",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38531,7 +39664,7 @@
     },
     "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_814",
+        "logos-nix": "logos-nix_819",
         "nix-bundle-dir": "nix-bundle-dir_137",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38564,7 +39697,7 @@
     },
     "nix-bundle-appimage_43": {
       "inputs": {
-        "logos-nix": "logos-nix_831",
+        "logos-nix": "logos-nix_836",
         "nix-bundle-dir": "nix-bundle-dir_141",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38596,7 +39729,7 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_858",
+        "logos-nix": "logos-nix_863",
         "nix-bundle-dir": "nix-bundle-dir_144",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38630,7 +39763,7 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-        "logos-nix": "logos-nix_875",
+        "logos-nix": "logos-nix_880",
         "nix-bundle-dir": "nix-bundle-dir_148",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38663,7 +39796,7 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-        "logos-nix": "logos-nix_886",
+        "logos-nix": "logos-nix_891",
         "nix-bundle-dir": "nix-bundle-dir_151",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38693,7 +39826,7 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
-        "logos-nix": "logos-nix_903",
+        "logos-nix": "logos-nix_908",
         "nix-bundle-dir": "nix-bundle-dir_155",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38722,7 +39855,7 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
-        "logos-nix": "logos-nix_911",
+        "logos-nix": "logos-nix_916",
         "nix-bundle-dir": "nix-bundle-dir_158",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -38749,7 +39882,7 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
-        "logos-nix": "logos-nix_916",
+        "logos-nix": "logos-nix_921",
         "nix-bundle-dir": "nix-bundle-dir_160",
         "nixpkgs": [
           "nix-bundle-appimage",
@@ -38802,7 +39935,7 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
-        "logos-nix": "logos-nix_922",
+        "logos-nix": "logos-nix_927",
         "nix-bundle-dir": "nix-bundle-dir_162",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -38828,7 +39961,7 @@
     },
     "nix-bundle-appimage_6": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_120",
         "nix-bundle-dir": "nix-bundle-dir_19",
         "nixpkgs": [
           "logos-capability-module",
@@ -38856,7 +39989,7 @@
     },
     "nix-bundle-appimage_7": {
       "inputs": {
-        "logos-nix": "logos-nix_162",
+        "logos-nix": "logos-nix_161",
         "nix-bundle-dir": "nix-bundle-dir_22",
         "nixpkgs": [
           "logos-liblogos",
@@ -38889,7 +40022,7 @@
     },
     "nix-bundle-appimage_8": {
       "inputs": {
-        "logos-nix": "logos-nix_179",
+        "logos-nix": "logos-nix_178",
         "nix-bundle-dir": "nix-bundle-dir_26",
         "nixpkgs": [
           "logos-liblogos",
@@ -38921,7 +40054,7 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_205",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
           "logos-liblogos",
@@ -39016,7 +40149,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_608",
+        "logos-nix": "logos-nix_611",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39047,7 +40180,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_609",
+        "logos-nix": "logos-nix_612",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39079,7 +40212,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-        "logos-nix": "logos-nix_616",
+        "logos-nix": "logos-nix_619",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39110,7 +40243,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39140,7 +40273,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_628",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39170,7 +40303,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_629",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39201,7 +40334,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_629",
+        "logos-nix": "logos-nix_632",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39232,7 +40365,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_636",
+        "logos-nix": "logos-nix_639",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39259,7 +40392,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39287,7 +40420,7 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_649",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39344,7 +40477,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_648",
+        "logos-nix": "logos-nix_653",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39370,7 +40503,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_653",
+        "logos-nix": "logos-nix_658",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39396,7 +40529,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-        "logos-nix": "logos-nix_654",
+        "logos-nix": "logos-nix_659",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39423,7 +40556,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-        "logos-nix": "logos-nix_657",
+        "logos-nix": "logos-nix_662",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -39435,11 +40568,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -39450,7 +40583,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_687",
+        "logos-nix": "logos-nix_692",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39481,7 +40614,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_688",
+        "logos-nix": "logos-nix_693",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39513,7 +40646,7 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_700",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39544,7 +40677,7 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_704",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39574,7 +40707,7 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_709",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39604,7 +40737,7 @@
     },
     "nix-bundle-dir_119": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_710",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39665,7 +40798,7 @@
     },
     "nix-bundle-dir_120": {
       "inputs": {
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_713",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39696,7 +40829,7 @@
     },
     "nix-bundle-dir_121": {
       "inputs": {
-        "logos-nix": "logos-nix_731",
+        "logos-nix": "logos-nix_736",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39728,7 +40861,7 @@
     },
     "nix-bundle-dir_122": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
+        "logos-nix": "logos-nix_737",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39761,7 +40894,7 @@
     },
     "nix-bundle-dir_123": {
       "inputs": {
-        "logos-nix": "logos-nix_739",
+        "logos-nix": "logos-nix_744",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39793,7 +40926,7 @@
     },
     "nix-bundle-dir_124": {
       "inputs": {
-        "logos-nix": "logos-nix_743",
+        "logos-nix": "logos-nix_748",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39824,7 +40957,7 @@
     },
     "nix-bundle-dir_125": {
       "inputs": {
-        "logos-nix": "logos-nix_748",
+        "logos-nix": "logos-nix_753",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39855,7 +40988,7 @@
     },
     "nix-bundle-dir_126": {
       "inputs": {
-        "logos-nix": "logos-nix_749",
+        "logos-nix": "logos-nix_754",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39887,7 +41020,7 @@
     },
     "nix-bundle-dir_127": {
       "inputs": {
-        "logos-nix": "logos-nix_752",
+        "logos-nix": "logos-nix_757",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39919,7 +41052,7 @@
     },
     "nix-bundle-dir_128": {
       "inputs": {
-        "logos-nix": "logos-nix_759",
+        "logos-nix": "logos-nix_764",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -39947,7 +41080,7 @@
     },
     "nix-bundle-dir_129": {
       "inputs": {
-        "logos-nix": "logos-nix_760",
+        "logos-nix": "logos-nix_765",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40007,7 +41140,7 @@
     },
     "nix-bundle-dir_130": {
       "inputs": {
-        "logos-nix": "logos-nix_767",
+        "logos-nix": "logos-nix_772",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40035,7 +41168,7 @@
     },
     "nix-bundle-dir_131": {
       "inputs": {
-        "logos-nix": "logos-nix_771",
+        "logos-nix": "logos-nix_776",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40062,7 +41195,7 @@
     },
     "nix-bundle-dir_132": {
       "inputs": {
-        "logos-nix": "logos-nix_776",
+        "logos-nix": "logos-nix_781",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40089,7 +41222,7 @@
     },
     "nix-bundle-dir_133": {
       "inputs": {
-        "logos-nix": "logos-nix_777",
+        "logos-nix": "logos-nix_782",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40117,7 +41250,7 @@
     },
     "nix-bundle-dir_134": {
       "inputs": {
-        "logos-nix": "logos-nix_780",
+        "logos-nix": "logos-nix_785",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40145,7 +41278,7 @@
     },
     "nix-bundle-dir_135": {
       "inputs": {
-        "logos-nix": "logos-nix_784",
+        "logos-nix": "logos-nix_789",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40170,7 +41303,7 @@
     },
     "nix-bundle-dir_136": {
       "inputs": {
-        "logos-nix": "logos-nix_785",
+        "logos-nix": "logos-nix_790",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -40196,7 +41329,7 @@
     },
     "nix-bundle-dir_137": {
       "inputs": {
-        "logos-nix": "logos-nix_815",
+        "logos-nix": "logos-nix_820",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40227,7 +41360,7 @@
     },
     "nix-bundle-dir_138": {
       "inputs": {
-        "logos-nix": "logos-nix_816",
+        "logos-nix": "logos-nix_821",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40259,7 +41392,7 @@
     },
     "nix-bundle-dir_139": {
       "inputs": {
-        "logos-nix": "logos-nix_823",
+        "logos-nix": "logos-nix_828",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40321,7 +41454,7 @@
     },
     "nix-bundle-dir_140": {
       "inputs": {
-        "logos-nix": "logos-nix_827",
+        "logos-nix": "logos-nix_832",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40351,7 +41484,7 @@
     },
     "nix-bundle-dir_141": {
       "inputs": {
-        "logos-nix": "logos-nix_832",
+        "logos-nix": "logos-nix_837",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40381,7 +41514,7 @@
     },
     "nix-bundle-dir_142": {
       "inputs": {
-        "logos-nix": "logos-nix_833",
+        "logos-nix": "logos-nix_838",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40412,7 +41545,7 @@
     },
     "nix-bundle-dir_143": {
       "inputs": {
-        "logos-nix": "logos-nix_836",
+        "logos-nix": "logos-nix_841",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40443,7 +41576,7 @@
     },
     "nix-bundle-dir_144": {
       "inputs": {
-        "logos-nix": "logos-nix_859",
+        "logos-nix": "logos-nix_864",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40475,7 +41608,7 @@
     },
     "nix-bundle-dir_145": {
       "inputs": {
-        "logos-nix": "logos-nix_860",
+        "logos-nix": "logos-nix_865",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40508,7 +41641,7 @@
     },
     "nix-bundle-dir_146": {
       "inputs": {
-        "logos-nix": "logos-nix_867",
+        "logos-nix": "logos-nix_872",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40540,7 +41673,7 @@
     },
     "nix-bundle-dir_147": {
       "inputs": {
-        "logos-nix": "logos-nix_871",
+        "logos-nix": "logos-nix_876",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40571,7 +41704,7 @@
     },
     "nix-bundle-dir_148": {
       "inputs": {
-        "logos-nix": "logos-nix_876",
+        "logos-nix": "logos-nix_881",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40602,7 +41735,7 @@
     },
     "nix-bundle-dir_149": {
       "inputs": {
-        "logos-nix": "logos-nix_877",
+        "logos-nix": "logos-nix_882",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40661,7 +41794,7 @@
     },
     "nix-bundle-dir_150": {
       "inputs": {
-        "logos-nix": "logos-nix_880",
+        "logos-nix": "logos-nix_885",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40693,7 +41826,7 @@
     },
     "nix-bundle-dir_151": {
       "inputs": {
-        "logos-nix": "logos-nix_887",
+        "logos-nix": "logos-nix_892",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40721,7 +41854,7 @@
     },
     "nix-bundle-dir_152": {
       "inputs": {
-        "logos-nix": "logos-nix_888",
+        "logos-nix": "logos-nix_893",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40750,7 +41883,7 @@
     },
     "nix-bundle-dir_153": {
       "inputs": {
-        "logos-nix": "logos-nix_895",
+        "logos-nix": "logos-nix_900",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40778,7 +41911,7 @@
     },
     "nix-bundle-dir_154": {
       "inputs": {
-        "logos-nix": "logos-nix_899",
+        "logos-nix": "logos-nix_904",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40805,7 +41938,7 @@
     },
     "nix-bundle-dir_155": {
       "inputs": {
-        "logos-nix": "logos-nix_904",
+        "logos-nix": "logos-nix_909",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40832,7 +41965,7 @@
     },
     "nix-bundle-dir_156": {
       "inputs": {
-        "logos-nix": "logos-nix_905",
+        "logos-nix": "logos-nix_910",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40860,7 +41993,7 @@
     },
     "nix-bundle-dir_157": {
       "inputs": {
-        "logos-nix": "logos-nix_908",
+        "logos-nix": "logos-nix_913",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40888,7 +42021,7 @@
     },
     "nix-bundle-dir_158": {
       "inputs": {
-        "logos-nix": "logos-nix_912",
+        "logos-nix": "logos-nix_917",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40913,7 +42046,7 @@
     },
     "nix-bundle-dir_159": {
       "inputs": {
-        "logos-nix": "logos-nix_913",
+        "logos-nix": "logos-nix_918",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -40967,7 +42100,7 @@
     },
     "nix-bundle-dir_160": {
       "inputs": {
-        "logos-nix": "logos-nix_917",
+        "logos-nix": "logos-nix_922",
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -40989,7 +42122,7 @@
     },
     "nix-bundle-dir_161": {
       "inputs": {
-        "logos-nix": "logos-nix_918",
+        "logos-nix": "logos-nix_923",
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -41012,7 +42145,7 @@
     },
     "nix-bundle-dir_162": {
       "inputs": {
-        "logos-nix": "logos-nix_923",
+        "logos-nix": "logos-nix_928",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -41036,7 +42169,7 @@
     },
     "nix-bundle-dir_163": {
       "inputs": {
-        "logos-nix": "logos-nix_924",
+        "logos-nix": "logos-nix_929",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -41061,7 +42194,7 @@
     },
     "nix-bundle-dir_164": {
       "inputs": {
-        "logos-nix": "logos-nix_927",
+        "logos-nix": "logos-nix_932",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -41086,7 +42219,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_112",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -41113,7 +42246,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_116",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -41139,7 +42272,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -41196,7 +42329,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -41223,7 +42356,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_125",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -41235,11 +42368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -41250,7 +42383,7 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_163",
+        "logos-nix": "logos-nix_162",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41281,7 +42414,7 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_164",
+        "logos-nix": "logos-nix_163",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41313,7 +42446,7 @@
     },
     "nix-bundle-dir_24": {
       "inputs": {
-        "logos-nix": "logos-nix_171",
+        "logos-nix": "logos-nix_170",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41344,7 +42477,7 @@
     },
     "nix-bundle-dir_25": {
       "inputs": {
-        "logos-nix": "logos-nix_175",
+        "logos-nix": "logos-nix_174",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41374,7 +42507,7 @@
     },
     "nix-bundle-dir_26": {
       "inputs": {
-        "logos-nix": "logos-nix_180",
+        "logos-nix": "logos-nix_179",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41404,7 +42537,7 @@
     },
     "nix-bundle-dir_27": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_180",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41435,7 +42568,7 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_184",
+        "logos-nix": "logos-nix_183",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41466,7 +42599,7 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_206",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41528,7 +42661,7 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_207",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41561,7 +42694,7 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
+        "logos-nix": "logos-nix_214",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41593,7 +42726,7 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": "logos-nix_218",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41624,7 +42757,7 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_223",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41655,7 +42788,7 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_225",
+        "logos-nix": "logos-nix_224",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41687,7 +42820,7 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41719,7 +42852,7 @@
     },
     "nix-bundle-dir_36": {
       "inputs": {
-        "logos-nix": "logos-nix_235",
+        "logos-nix": "logos-nix_234",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41747,7 +42880,7 @@
     },
     "nix-bundle-dir_37": {
       "inputs": {
-        "logos-nix": "logos-nix_236",
+        "logos-nix": "logos-nix_235",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41776,7 +42909,7 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_242",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41804,7 +42937,7 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_246",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41860,7 +42993,7 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_252",
+        "logos-nix": "logos-nix_251",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41887,7 +43020,7 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_253",
+        "logos-nix": "logos-nix_252",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41915,7 +43048,7 @@
     },
     "nix-bundle-dir_42": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
+        "logos-nix": "logos-nix_255",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -41943,7 +43076,7 @@
     },
     "nix-bundle-dir_43": {
       "inputs": {
-        "logos-nix": "logos-nix_266",
+        "logos-nix": "logos-nix_265",
         "nixpkgs": [
           "logos-liblogos",
           "logos-package-manager",
@@ -41967,7 +43100,7 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": "logos-nix_267",
+        "logos-nix": "logos-nix_266",
         "nixpkgs": [
           "logos-liblogos",
           "logos-package-manager",
@@ -41992,7 +43125,7 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_302",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42022,7 +43155,7 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-        "logos-nix": "logos-nix_304",
+        "logos-nix": "logos-nix_303",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42053,7 +43186,7 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_310",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42083,7 +43216,7 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_315",
+        "logos-nix": "logos-nix_314",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42112,7 +43245,7 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_319",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42170,7 +43303,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42200,7 +43333,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_323",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42230,7 +43363,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_346",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42261,7 +43394,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
+        "logos-nix": "logos-nix_347",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42293,7 +43426,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_354",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42324,7 +43457,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_358",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42354,7 +43487,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_363",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42384,7 +43517,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_364",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42415,7 +43548,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42446,7 +43579,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_374",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42503,7 +43636,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_376",
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42531,7 +43664,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_384",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42558,7 +43691,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_387",
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42584,7 +43717,7 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_393",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42610,7 +43743,7 @@
     },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_394",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42637,7 +43770,7 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -42649,11 +43782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -42664,7 +43797,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -42688,7 +43821,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_402",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -42713,7 +43846,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_406",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -42736,7 +43869,7 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
+        "logos-nix": "logos-nix_407",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-dir",
@@ -42790,7 +43923,7 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_437",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42820,7 +43953,7 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
+        "logos-nix": "logos-nix_438",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42851,7 +43984,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
+        "logos-nix": "logos-nix_445",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42881,7 +44014,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_449",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42910,7 +44043,7 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42939,7 +44072,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_455",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42969,7 +44102,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_458",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42999,7 +44132,7 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_481",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43030,7 +44163,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_482",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43062,7 +44195,7 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_488",
+        "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43124,7 +44257,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_493",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43154,7 +44287,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43184,7 +44317,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_499",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43215,7 +44348,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43246,7 +44379,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_509",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43273,7 +44406,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_510",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43301,7 +44434,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43328,7 +44461,7 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_523",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43354,7 +44487,7 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_528",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43380,7 +44513,7 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_526",
+        "logos-nix": "logos-nix_529",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43439,7 +44572,7 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_532",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43451,11 +44584,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -43466,7 +44599,7 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -43490,7 +44623,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_537",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -43515,7 +44648,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
+        "logos-nix": "logos-nix_567",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43545,7 +44678,7 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43576,7 +44709,7 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_575",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43606,7 +44739,7 @@
     },
     "nix-bundle-dir_96": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_579",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43635,7 +44768,7 @@
     },
     "nix-bundle-dir_97": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_584",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43664,7 +44797,7 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_582",
+        "logos-nix": "logos-nix_585",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43694,7 +44827,7 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_585",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43754,7 +44887,7 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_169",
+        "logos-nix": "logos-nix_168",
         "logos-package": "logos-package_17",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nixpkgs": [
@@ -43785,7 +44918,7 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_173",
+        "logos-nix": "logos-nix_172",
         "logos-package": "logos-package_18",
         "nix-bundle-dir": "nix-bundle-dir_25",
         "nixpkgs": [
@@ -43816,7 +44949,7 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_182",
+        "logos-nix": "logos-nix_181",
         "logos-package": "logos-package_20",
         "nix-bundle-dir": "nix-bundle-dir_28",
         "nixpkgs": [
@@ -43848,7 +44981,7 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_212",
         "logos-package": "logos-package_22",
         "nix-bundle-dir": "nix-bundle-dir_31",
         "nixpkgs": [
@@ -43880,7 +45013,7 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_216",
         "logos-package": "logos-package_23",
         "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
@@ -43912,7 +45045,7 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_225",
         "logos-package": "logos-package_25",
         "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
@@ -43945,7 +45078,7 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_241",
+        "logos-nix": "logos-nix_240",
         "logos-package": "logos-package_27",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -43974,7 +45107,7 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
+        "logos-nix": "logos-nix_244",
         "logos-package": "logos-package_28",
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
@@ -44002,7 +45135,7 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_254",
+        "logos-nix": "logos-nix_253",
         "logos-package": "logos-package_30",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nixpkgs": [
@@ -44031,7 +45164,7 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_308",
         "logos-package": "logos-package_34",
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
@@ -44091,7 +45224,7 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_313",
+        "logos-nix": "logos-nix_312",
         "logos-package": "logos-package_35",
         "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
@@ -44121,7 +45254,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_321",
         "logos-package": "logos-package_37",
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
@@ -44152,7 +45285,7 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
+        "logos-nix": "logos-nix_352",
         "logos-package": "logos-package_39",
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
@@ -44183,7 +45316,7 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_356",
         "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
@@ -44214,7 +45347,7 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_365",
         "logos-package": "logos-package_42",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
@@ -44246,7 +45379,7 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_382",
         "logos-package": "logos-package_44",
         "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
@@ -44274,7 +45407,7 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_385",
+        "logos-nix": "logos-nix_386",
         "logos-package": "logos-package_45",
         "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
@@ -44301,7 +45434,7 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_395",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
@@ -44314,11 +45447,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -44329,7 +45462,7 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_443",
         "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
@@ -44359,7 +45492,7 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_447",
         "logos-package": "logos-package_52",
         "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
@@ -44420,7 +45553,7 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
+        "logos-nix": "logos-nix_456",
         "logos-package": "logos-package_54",
         "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
@@ -44451,7 +45584,7 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_487",
         "logos-package": "logos-package_56",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
@@ -44482,7 +45615,7 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_491",
         "logos-package": "logos-package_57",
         "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
@@ -44513,7 +45646,7 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": "logos-nix_500",
         "logos-package": "logos-package_59",
         "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
@@ -44545,7 +45678,7 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_517",
         "logos-package": "logos-package_61",
         "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
@@ -44573,7 +45706,7 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_518",
+        "logos-nix": "logos-nix_521",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
@@ -44600,7 +45733,7 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_527",
+        "logos-nix": "logos-nix_530",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
@@ -44613,11 +45746,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -44628,7 +45761,7 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_570",
+        "logos-nix": "logos-nix_573",
         "logos-package": "logos-package_67",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
@@ -44658,7 +45791,7 @@
     },
     "nix-bundle-lgx_38": {
       "inputs": {
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_577",
         "logos-package": "logos-package_68",
         "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
@@ -44688,7 +45821,7 @@
     },
     "nix-bundle-lgx_39": {
       "inputs": {
-        "logos-nix": "logos-nix_583",
+        "logos-nix": "logos-nix_586",
         "logos-package": "logos-package_70",
         "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
@@ -44750,7 +45883,7 @@
     },
     "nix-bundle-lgx_40": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_617",
         "logos-package": "logos-package_72",
         "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
@@ -44781,7 +45914,7 @@
     },
     "nix-bundle-lgx_41": {
       "inputs": {
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_621",
         "logos-package": "logos-package_73",
         "nix-bundle-dir": "nix-bundle-dir_103",
         "nixpkgs": [
@@ -44812,7 +45945,7 @@
     },
     "nix-bundle-lgx_42": {
       "inputs": {
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_630",
         "logos-package": "logos-package_75",
         "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
@@ -44844,7 +45977,7 @@
     },
     "nix-bundle-lgx_43": {
       "inputs": {
-        "logos-nix": "logos-nix_642",
+        "logos-nix": "logos-nix_647",
         "logos-package": "logos-package_77",
         "nix-bundle-dir": "nix-bundle-dir_109",
         "nixpkgs": [
@@ -44872,7 +46005,7 @@
     },
     "nix-bundle-lgx_44": {
       "inputs": {
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_651",
         "logos-package": "logos-package_78",
         "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
@@ -44899,7 +46032,7 @@
     },
     "nix-bundle-lgx_45": {
       "inputs": {
-        "logos-nix": "logos-nix_655",
+        "logos-nix": "logos-nix_660",
         "logos-package": "logos-package_80",
         "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
@@ -44912,11 +46045,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -44927,7 +46060,7 @@
     },
     "nix-bundle-lgx_46": {
       "inputs": {
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_698",
         "logos-package": "logos-package_82",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
@@ -44958,7 +46091,7 @@
     },
     "nix-bundle-lgx_47": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
+        "logos-nix": "logos-nix_702",
         "logos-package": "logos-package_83",
         "nix-bundle-dir": "nix-bundle-dir_117",
         "nixpkgs": [
@@ -44989,7 +46122,7 @@
     },
     "nix-bundle-lgx_48": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_711",
         "logos-package": "logos-package_85",
         "nix-bundle-dir": "nix-bundle-dir_120",
         "nixpkgs": [
@@ -45021,7 +46154,7 @@
     },
     "nix-bundle-lgx_49": {
       "inputs": {
-        "logos-nix": "logos-nix_737",
+        "logos-nix": "logos-nix_742",
         "logos-package": "logos-package_87",
         "nix-bundle-dir": "nix-bundle-dir_123",
         "nixpkgs": [
@@ -45084,7 +46217,7 @@
     },
     "nix-bundle-lgx_50": {
       "inputs": {
-        "logos-nix": "logos-nix_741",
+        "logos-nix": "logos-nix_746",
         "logos-package": "logos-package_88",
         "nix-bundle-dir": "nix-bundle-dir_124",
         "nixpkgs": [
@@ -45116,7 +46249,7 @@
     },
     "nix-bundle-lgx_51": {
       "inputs": {
-        "logos-nix": "logos-nix_750",
+        "logos-nix": "logos-nix_755",
         "logos-package": "logos-package_90",
         "nix-bundle-dir": "nix-bundle-dir_127",
         "nixpkgs": [
@@ -45149,7 +46282,7 @@
     },
     "nix-bundle-lgx_52": {
       "inputs": {
-        "logos-nix": "logos-nix_765",
+        "logos-nix": "logos-nix_770",
         "logos-package": "logos-package_92",
         "nix-bundle-dir": "nix-bundle-dir_130",
         "nixpkgs": [
@@ -45178,7 +46311,7 @@
     },
     "nix-bundle-lgx_53": {
       "inputs": {
-        "logos-nix": "logos-nix_769",
+        "logos-nix": "logos-nix_774",
         "logos-package": "logos-package_93",
         "nix-bundle-dir": "nix-bundle-dir_131",
         "nixpkgs": [
@@ -45206,7 +46339,7 @@
     },
     "nix-bundle-lgx_54": {
       "inputs": {
-        "logos-nix": "logos-nix_778",
+        "logos-nix": "logos-nix_783",
         "logos-package": "logos-package_95",
         "nix-bundle-dir": "nix-bundle-dir_134",
         "nixpkgs": [
@@ -45235,7 +46368,7 @@
     },
     "nix-bundle-lgx_55": {
       "inputs": {
-        "logos-nix": "logos-nix_821",
+        "logos-nix": "logos-nix_826",
         "logos-package": "logos-package_98",
         "nix-bundle-dir": "nix-bundle-dir_139",
         "nixpkgs": [
@@ -45266,7 +46399,7 @@
     },
     "nix-bundle-lgx_56": {
       "inputs": {
-        "logos-nix": "logos-nix_825",
+        "logos-nix": "logos-nix_830",
         "logos-package": "logos-package_99",
         "nix-bundle-dir": "nix-bundle-dir_140",
         "nixpkgs": [
@@ -45297,7 +46430,7 @@
     },
     "nix-bundle-lgx_57": {
       "inputs": {
-        "logos-nix": "logos-nix_834",
+        "logos-nix": "logos-nix_839",
         "logos-package": "logos-package_101",
         "nix-bundle-dir": "nix-bundle-dir_143",
         "nixpkgs": [
@@ -45329,7 +46462,7 @@
     },
     "nix-bundle-lgx_58": {
       "inputs": {
-        "logos-nix": "logos-nix_865",
+        "logos-nix": "logos-nix_870",
         "logos-package": "logos-package_103",
         "nix-bundle-dir": "nix-bundle-dir_146",
         "nixpkgs": [
@@ -45361,7 +46494,7 @@
     },
     "nix-bundle-lgx_59": {
       "inputs": {
-        "logos-nix": "logos-nix_869",
+        "logos-nix": "logos-nix_874",
         "logos-package": "logos-package_104",
         "nix-bundle-dir": "nix-bundle-dir_147",
         "nixpkgs": [
@@ -45425,7 +46558,7 @@
     },
     "nix-bundle-lgx_60": {
       "inputs": {
-        "logos-nix": "logos-nix_878",
+        "logos-nix": "logos-nix_883",
         "logos-package": "logos-package_106",
         "nix-bundle-dir": "nix-bundle-dir_150",
         "nixpkgs": [
@@ -45458,7 +46591,7 @@
     },
     "nix-bundle-lgx_61": {
       "inputs": {
-        "logos-nix": "logos-nix_893",
+        "logos-nix": "logos-nix_898",
         "logos-package": "logos-package_108",
         "nix-bundle-dir": "nix-bundle-dir_153",
         "nixpkgs": [
@@ -45487,7 +46620,7 @@
     },
     "nix-bundle-lgx_62": {
       "inputs": {
-        "logos-nix": "logos-nix_897",
+        "logos-nix": "logos-nix_902",
         "logos-package": "logos-package_109",
         "nix-bundle-dir": "nix-bundle-dir_154",
         "nixpkgs": [
@@ -45515,7 +46648,7 @@
     },
     "nix-bundle-lgx_63": {
       "inputs": {
-        "logos-nix": "logos-nix_906",
+        "logos-nix": "logos-nix_911",
         "logos-package": "logos-package_111",
         "nix-bundle-dir": "nix-bundle-dir_157",
         "nixpkgs": [
@@ -45544,7 +46677,7 @@
     },
     "nix-bundle-lgx_64": {
       "inputs": {
-        "logos-nix": "logos-nix_925",
+        "logos-nix": "logos-nix_930",
         "logos-package": "logos-package_114",
         "nix-bundle-dir": "nix-bundle-dir_164",
         "nixpkgs": [
@@ -45570,7 +46703,7 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_110",
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
@@ -45598,7 +46731,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_114",
         "logos-package": "logos-package_13",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
@@ -45625,7 +46758,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_123",
         "logos-package": "logos-package_15",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
@@ -45638,11 +46771,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775836380,
-        "narHash": "sha256-XbBPcMuDFA/SxYVw9TIRQbhie5Vj5MqwdU+Gh1iR1LA=",
+        "lastModified": 1781872587,
+        "narHash": "sha256-zl9odZ1Tq7QBAYJVrXiLSC47FVYra3kIakb/TeGPoZI=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "9d8f8602b1574ec9ac4c9b31ae0c92570221c268",
+        "rev": "b49074a8e1157832002b11d3d254c1aaa4b96680",
         "type": "github"
       },
       "original": {
@@ -45683,7 +46816,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_450",
         "logos-package-manager": "logos-package-manager_22",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -45713,7 +46846,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
+        "logos-nix": "logos-nix_494",
         "logos-package-manager": "logos-package-manager_24",
         "nix-bundle-lgx": "nix-bundle-lgx_33",
         "nixpkgs": [
@@ -45744,7 +46877,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_524",
         "logos-package-manager": "logos-package-manager_26",
         "nix-bundle-lgx": "nix-bundle-lgx_36",
         "nixpkgs": [
@@ -45756,11 +46889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "lastModified": 1782134900,
+        "narHash": "sha256-v5A+e+1Sk1BXbOkaPkc9Pc2BOozCN1cH4onkcV/jnUQ=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "rev": "55de9a6fce755387224ececd0493f46b028ee0a3",
         "type": "github"
       },
       "original": {
@@ -45771,7 +46904,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
+        "logos-nix": "logos-nix_580",
         "logos-package-manager": "logos-package-manager_29",
         "nix-bundle-lgx": "nix-bundle-lgx_39",
         "nixpkgs": [
@@ -45801,7 +46934,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_624",
         "logos-package-manager": "logos-package-manager_31",
         "nix-bundle-lgx": "nix-bundle-lgx_42",
         "nixpkgs": [
@@ -45832,7 +46965,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_649",
+        "logos-nix": "logos-nix_654",
         "logos-package-manager": "logos-package-manager_33",
         "nix-bundle-lgx": "nix-bundle-lgx_45",
         "nixpkgs": [
@@ -45844,11 +46977,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "lastModified": 1782134900,
+        "narHash": "sha256-v5A+e+1Sk1BXbOkaPkc9Pc2BOozCN1cH4onkcV/jnUQ=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "rev": "55de9a6fce755387224ececd0493f46b028ee0a3",
         "type": "github"
       },
       "original": {
@@ -45859,7 +46992,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_705",
         "logos-package-manager": "logos-package-manager_35",
         "nix-bundle-lgx": "nix-bundle-lgx_48",
         "nixpkgs": [
@@ -45890,7 +47023,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_744",
+        "logos-nix": "logos-nix_749",
         "logos-package-manager": "logos-package-manager_37",
         "nix-bundle-lgx": "nix-bundle-lgx_51",
         "nixpkgs": [
@@ -45922,7 +47055,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_772",
+        "logos-nix": "logos-nix_777",
         "logos-package-manager": "logos-package-manager_39",
         "nix-bundle-lgx": "nix-bundle-lgx_54",
         "nixpkgs": [
@@ -45950,7 +47083,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_828",
+        "logos-nix": "logos-nix_833",
         "logos-package-manager": "logos-package-manager_41",
         "nix-bundle-lgx": "nix-bundle-lgx_57",
         "nixpkgs": [
@@ -46012,7 +47145,7 @@
     },
     "nix-bundle-logos-module-install_20": {
       "inputs": {
-        "logos-nix": "logos-nix_872",
+        "logos-nix": "logos-nix_877",
         "logos-package-manager": "logos-package-manager_43",
         "nix-bundle-lgx": "nix-bundle-lgx_60",
         "nixpkgs": [
@@ -46044,7 +47177,7 @@
     },
     "nix-bundle-logos-module-install_21": {
       "inputs": {
-        "logos-nix": "logos-nix_900",
+        "logos-nix": "logos-nix_905",
         "logos-package-manager": "logos-package-manager_45",
         "nix-bundle-lgx": "nix-bundle-lgx_63",
         "nixpkgs": [
@@ -46072,7 +47205,7 @@
     },
     "nix-bundle-logos-module-install_22": {
       "inputs": {
-        "logos-nix": "logos-nix_919",
+        "logos-nix": "logos-nix_924",
         "logos-package-manager": "logos-package-manager_47",
         "nix-bundle-lgx": "nix-bundle-lgx_64",
         "nixpkgs": [
@@ -46097,7 +47230,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_117",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_9",
         "nixpkgs": [
@@ -46109,11 +47242,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "lastModified": 1782134900,
+        "narHash": "sha256-v5A+e+1Sk1BXbOkaPkc9Pc2BOozCN1cH4onkcV/jnUQ=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "rev": "55de9a6fce755387224ececd0493f46b028ee0a3",
         "type": "github"
       },
       "original": {
@@ -46124,7 +47257,7 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_176",
+        "logos-nix": "logos-nix_175",
         "logos-package-manager": "logos-package-manager_8",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
@@ -46155,7 +47288,7 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_220",
+        "logos-nix": "logos-nix_219",
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_15",
         "nixpkgs": [
@@ -46187,7 +47320,7 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_248",
+        "logos-nix": "logos-nix_247",
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -46215,7 +47348,7 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_315",
         "logos-package-manager": "logos-package-manager_15",
         "nix-bundle-lgx": "nix-bundle-lgx_21",
         "nixpkgs": [
@@ -46245,7 +47378,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_359",
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
@@ -46276,7 +47409,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_389",
         "logos-package-manager": "logos-package-manager_19",
         "nix-bundle-lgx": "nix-bundle-lgx_27",
         "nixpkgs": [
@@ -46288,11 +47421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775839388,
-        "narHash": "sha256-0QH146bzL2kKBYJq2yA35iPwug55j2xjEyKCS7tjhvg=",
+        "lastModified": 1782134900,
+        "narHash": "sha256-v5A+e+1Sk1BXbOkaPkc9Pc2BOozCN1cH4onkcV/jnUQ=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "89cc9ea91275396d589c767d76926459ac77ef20",
+        "rev": "55de9a6fce755387224ececd0493f46b028ee0a3",
         "type": "github"
       },
       "original": {
@@ -46303,7 +47436,7 @@
     },
     "nix-bundle-macos-app": {
       "inputs": {
-        "logos-nix": "logos-nix_928",
+        "logos-nix": "logos-nix_933",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -61061,7 +62194,87 @@
         "type": "github"
       }
     },
+    "nixpkgs_929": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_93": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_930": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_931": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_932": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_933": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -61243,7 +62456,7 @@
     },
     "process-stats_10": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
+        "logos-nix": "logos-nix_378",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61270,7 +62483,7 @@
     },
     "process-stats_11": {
       "inputs": {
-        "logos-nix": "logos-nix_438",
+        "logos-nix": "logos-nix_439",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61300,7 +62513,7 @@
     },
     "process-stats_12": {
       "inputs": {
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_483",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61331,7 +62544,7 @@
     },
     "process-stats_13": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_513",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61358,7 +62571,7 @@
     },
     "process-stats_14": {
       "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_569",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61388,7 +62601,7 @@
     },
     "process-stats_15": {
       "inputs": {
-        "logos-nix": "logos-nix_610",
+        "logos-nix": "logos-nix_613",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61419,7 +62632,7 @@
     },
     "process-stats_16": {
       "inputs": {
-        "logos-nix": "logos-nix_638",
+        "logos-nix": "logos-nix_643",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61446,7 +62659,7 @@
     },
     "process-stats_17": {
       "inputs": {
-        "logos-nix": "logos-nix_689",
+        "logos-nix": "logos-nix_694",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -61477,7 +62690,7 @@
     },
     "process-stats_18": {
       "inputs": {
-        "logos-nix": "logos-nix_733",
+        "logos-nix": "logos-nix_738",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -61509,7 +62722,7 @@
     },
     "process-stats_19": {
       "inputs": {
-        "logos-nix": "logos-nix_761",
+        "logos-nix": "logos-nix_766",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -61568,7 +62781,7 @@
     },
     "process-stats_20": {
       "inputs": {
-        "logos-nix": "logos-nix_817",
+        "logos-nix": "logos-nix_822",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -61599,7 +62812,7 @@
     },
     "process-stats_21": {
       "inputs": {
-        "logos-nix": "logos-nix_861",
+        "logos-nix": "logos-nix_866",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -61631,7 +62844,7 @@
     },
     "process-stats_22": {
       "inputs": {
-        "logos-nix": "logos-nix_889",
+        "logos-nix": "logos-nix_894",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -61659,7 +62872,7 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_106",
         "nixpkgs": [
           "logos-capability-module",
           "logos-module-builder",
@@ -61686,7 +62899,7 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_165",
+        "logos-nix": "logos-nix_164",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61717,7 +62930,7 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_209",
+        "logos-nix": "logos-nix_208",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61749,7 +62962,7 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_236",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61777,7 +62990,7 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_269",
         "nixpkgs": [
           "logos-liblogos",
           "process-stats",
@@ -61801,7 +63014,7 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_304",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61831,7 +63044,7 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_348",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61867,15 +63080,15 @@
         "logos-design-system": "logos-design-system_4",
         "logos-liblogos": "logos-liblogos_4",
         "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_272",
+        "logos-nix": "logos-nix_271",
         "logos-package": "logos-package_32",
         "logos-package-downloader-module": "logos-package-downloader-module",
         "logos-package-manager": "logos-package-manager_20",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-        "logos-protocol": "logos-protocol_15",
+        "logos-protocol": "logos-protocol_34",
         "logos-qt-mcp": "logos-qt-mcp_22",
-        "logos-qt-sdk": "logos-qt-sdk_15",
+        "logos-qt-sdk": "logos-qt-sdk_26",
         "logos-view-module-runtime": "logos-view-module-runtime_22",
         "nix-bundle-appimage": "nix-bundle-appimage_49",
         "nix-bundle-dir": "nix-bundle-dir_161",
@@ -61896,11 +63109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {
@@ -61918,11 +63131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {
@@ -61940,11 +63153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {
@@ -61962,11 +63175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782012058,
-        "narHash": "sha256-9mWUnReOUXfKjZuJAL/bAFH3LUyECTRtXgSNVjRw3UY=",
+        "lastModified": 1782271078,
+        "narHash": "sha256-Ukpyd+syDTr+ky+nI+SbUnWySfiqNRzA3gzFZYWepeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8534567325bd8a8d2928e6afd81e0a87d19efd3c",
+        "rev": "b7286019daa89e4e192c8913c3ec7002976034d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Two related changes so basecamp ships a coherent fix.

### 1. Pull the logos-protocol json-convert fix (lock bump)
Bumps **logos-liblogos** + the **capability / package-manager / package-downloader / package-manager-ui** modules to masters carrying **logos-protocol `c6234940`** (`fix/json-convert-nested-to-qvariant`). All build-relevant protocol paths (top-level, liblogos, each module's module-builder→qt-sdk→protocol glue) resolve to `c6234940`.

Fixes the package manager showing **every package "NOT AVAILABLE"**: the old protocol's `nlohmannToQVariant` made JSON arrays `QJsonArray`, so `package_manager.getValidVariants()` crossed IPC as a `QJsonArray` and `QVariant(QJsonArray).toStringList()` returned empty → no variant matched. Also restores `capability_module.registerRestriction` (its `QStringList` arg was a non-coercible `QJsonArray`).

Upstream chain (merged): logos-package-manager-module#54, logos-capability-module#18, logos-package-downloader-module#13, logos-package-manager-ui#44.

### 2. Disable the access policy (allow all) — `app/main.cpp`
Change 1 has a side effect: now that `registerRestriction` actually applies (it previously failed open on the same `QJsonArray` bug), `enforce` mode's **derived deny-by-default** is live. It gates every `ui_qml` app's calls to its own backend module, because UI plugins load out-of-process and aren't tracked as dependents in the core `ModuleRegistry` — so they're never in a module's derived allowed-caller set (e.g. `accounts_ui → accounts_module` is denied). This PR passes `NULL` to `logos_core_set_access_policy` to disable enforcement for now; the access policy will be redesigned to account for `ui_qml` callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)