### PR TITLE
fix: widen default launch window so Package Manager columns are visible

### DIFF
--- a/app/window.cpp
+++ b/app/window.cpp
@@ -116,9 +116,13 @@ void Window::setupUi()
         qWarning() << "Failed to load main UI plugin from:" << mainUiPluginPath;
     }
 
-    // Set window title and size
+    // Set window title and size. The default launch width is wide enough for
+    // the Package Manager's full table (category sidebar + columns through
+    // Action and Description) to be visible without horizontal scrolling; at
+    // the old 1024px those rightmost columns were clipped off-screen. The
+    // window can still be resized down to MainContainer's 800x600 minimum.
     setWindowTitle("Logos Basecamp");
-    resize(1024, 768);
+    resize(1600, 900);
 
 #ifdef Q_OS_MAC
     setWindowFlags(windowFlags() | Qt::FramelessWindowHint);


### PR DESCRIPTION
Bumps the default launch size from **1024×768 → 1600×900** in `app/window.cpp`.

### Why
At 1024px wide the content area is only ~912px, but the Package Manager view needs **~1300px** to show the table's rightmost columns — **Action** and **Description** — with the details panel closed (the default no-selection view):

```
category sidebar 200 + table min 984 + table-container margins 24 + row spacing 12 + page margins 80 ≈ 1300px content
```

So Action/Description were clipped off the right edge at launch (the table is horizontally scrollable, but they shouldn't require scrolling by default). 1600×900 yields ~1504px of content area — ~200px of slack — so the full table shows and Description (the fill column) gets ~420px.

- Window **minimum stays 800×600** (`MainContainer`), so it can still be resized down.
- No geometry persistence exists in basecamp, so the new default applies on every launch.

Before/after is the difference between the clipped narrow launch and the wide layout in the screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)