### PR TITLE
chore: bump logos-package-downloader-module (portable TLS CA-bundle fix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27180,11 +27180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782210104,
-        "narHash": "sha256-30N8XKew2+TLvk/5bhfw275t70cI3Zq2i8bghhfnra8=",
+        "lastModified": 1782484430,
+        "narHash": "sha256-gm+SLNULJn1BHMKOP0aOFkX6T/I20ZlzzatB/OhM6AI=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "90af05714f093464eee587ddcd1042a24e0fb4ab",
+        "rev": "1e843e72bd7debedc2fd5a295684574189231df7",
         "type": "github"
       },
       "original": {
@@ -27199,11 +27199,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1782404234,
-        "narHash": "sha256-OvOYAyPlElbiWzBl593xFo60aKc/n2RqXe/elYLB6jw=",
+        "lastModified": 1782485023,
+        "narHash": "sha256-4W6TOKNl6ub0Vd9M/jePTWH1aBZLTcGCU2cFYIfFacs=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "6dbcf341a7c354b14d1a5012b57facfe6b33bc94",
+        "rev": "22b6cd62a81b25cb9b9ec193c880574f80ca7ffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Re-pins `logos-package-downloader-module` `6dbcf34` → **`22b6cd6`**, which carries the lib fix [logos-package-downloader#14](https://github.com/logos-co/logos-package-downloader/pull/14) (`1e843e7`) into the bundled `package_downloader` module. Final hop of the chain.

## Why

Portable (downloaded, **no Nix installed**) Basecamp builds couldn't fetch the package catalog — `package_downloader.refreshCatalog` failed with `fetch failed: …/logos-repo.json`. nixpkgs `curl` is OpenSSL-backed and, absent a cert env, its only trust anchor is a `/nix/var/nix/profiles/default/…` path that exists only when Nix is installed. The fix makes `HttpsFetcher` resolve a CA bundle from well-known system paths (`/etc/ssl/cert.pem` on macOS, `/etc/ssl/certs/ca-certificates.crt` on Linux, …) and pin it via `CURLOPT_CAINFO`.

This bumps the **direct** `logos-package-downloader-module` input — the one basecamp builds the bundled plugin from (`logosPackageDownloaderModule = …packages.${system}.default`). (A separate transitive pin of the module at `7c9bd77` exists via `logos-package-manager-ui`'s build input; it does not affect the runtime plugin basecamp bundles, so it's left as-is.)

## Verification

Lock-only change (module `6dbcf34→22b6cd6`, nested lib `→1e843e7`). `nix build .#default` (the app) builds green: the package_downloader module + lib rebuild against the bump and the app relinks cleanly.

## Chain

- [logos-package-downloader#14](https://github.com/logos-co/logos-package-downloader/pull/14) — lib fix ✅ merged
- [logos-package-downloader-module#14](https://github.com/logos-co/logos-package-downloader-module/pull/14) — module bump ✅ merged
- **this PR** — basecamp re-pin

Note: targets `master` per request; `release/0.2.0` would need a separate cherry-pick/merge-forward to ship in that release line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)