### PR TITLE
fix: use the shared semver comparator for app install-status

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,7 +140,7 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_26",
-        "logos-nix": "logos-nix_1478",
+        "logos-nix": "logos-nix_1479",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -169,7 +169,7 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_31",
-        "logos-nix": "logos-nix_1778",
+        "logos-nix": "logos-nix_1779",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -451,7 +451,7 @@
         ],
         "logos-module": "logos-module_187",
         "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_1483",
+        "logos-nix": "logos-nix_1484",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -506,7 +506,7 @@
         ],
         "logos-module": "logos-module_224",
         "logos-module-loader": "logos-module-loader_13",
-        "logos-nix": "logos-nix_1783",
+        "logos-nix": "logos-nix_1784",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -2465,7 +2465,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_177",
-        "logos-nix": "logos-nix_1369",
+        "logos-nix": "logos-nix_1370",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2499,7 +2499,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_131",
         "logos-module": "logos-module_178",
-        "logos-nix": "logos-nix_1374",
+        "logos-nix": "logos-nix_1375",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2612,7 +2612,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_183",
-        "logos-nix": "logos-nix_1413",
+        "logos-nix": "logos-nix_1414",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2647,7 +2647,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_136",
         "logos-module": "logos-module_184",
-        "logos-nix": "logos-nix_1418",
+        "logos-nix": "logos-nix_1419",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2733,7 +2733,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_194",
-        "logos-nix": "logos-nix_1499",
+        "logos-nix": "logos-nix_1500",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2768,7 +2768,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_144",
         "logos-module": "logos-module_195",
-        "logos-nix": "logos-nix_1504",
+        "logos-nix": "logos-nix_1505",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2837,7 +2837,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_200",
-        "logos-nix": "logos-nix_1543",
+        "logos-nix": "logos-nix_1544",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2873,7 +2873,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_149",
         "logos-module": "logos-module_201",
-        "logos-nix": "logos-nix_1548",
+        "logos-nix": "logos-nix_1549",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -2995,7 +2995,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_214",
-        "logos-nix": "logos-nix_1669",
+        "logos-nix": "logos-nix_1670",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3029,7 +3029,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_159",
         "logos-module": "logos-module_215",
-        "logos-nix": "logos-nix_1674",
+        "logos-nix": "logos-nix_1675",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3096,7 +3096,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_220",
-        "logos-nix": "logos-nix_1713",
+        "logos-nix": "logos-nix_1714",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3131,7 +3131,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_164",
         "logos-module": "logos-module_221",
-        "logos-nix": "logos-nix_1718",
+        "logos-nix": "logos-nix_1719",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3217,7 +3217,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_231",
-        "logos-nix": "logos-nix_1799",
+        "logos-nix": "logos-nix_1800",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3252,7 +3252,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_172",
         "logos-module": "logos-module_232",
-        "logos-nix": "logos-nix_1804",
+        "logos-nix": "logos-nix_1805",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3339,7 +3339,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module": "logos-module_237",
-        "logos-nix": "logos-nix_1843",
+        "logos-nix": "logos-nix_1844",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3375,7 +3375,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_177",
         "logos-module": "logos-module_238",
-        "logos-nix": "logos-nix_1848",
+        "logos-nix": "logos-nix_1849",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3912,7 +3912,7 @@
     },
     "logos-container_26": {
       "inputs": {
-        "logos-nix": "logos-nix_1477",
+        "logos-nix": "logos-nix_1478",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3941,7 +3941,7 @@
     },
     "logos-container_27": {
       "inputs": {
-        "logos-nix": "logos-nix_1479",
+        "logos-nix": "logos-nix_1480",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3970,7 +3970,7 @@
     },
     "logos-container_28": {
       "inputs": {
-        "logos-nix": "logos-nix_1481",
+        "logos-nix": "logos-nix_1482",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4000,7 +4000,7 @@
     },
     "logos-container_29": {
       "inputs": {
-        "logos-nix": "logos-nix_1605",
+        "logos-nix": "logos-nix_1606",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4057,7 +4057,7 @@
     },
     "logos-container_30": {
       "inputs": {
-        "logos-nix": "logos-nix_1608",
+        "logos-nix": "logos-nix_1609",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -4086,7 +4086,7 @@
     },
     "logos-container_31": {
       "inputs": {
-        "logos-nix": "logos-nix_1777",
+        "logos-nix": "logos-nix_1778",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4115,7 +4115,7 @@
     },
     "logos-container_32": {
       "inputs": {
-        "logos-nix": "logos-nix_1779",
+        "logos-nix": "logos-nix_1780",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4144,7 +4144,7 @@
     },
     "logos-container_33": {
       "inputs": {
-        "logos-nix": "logos-nix_1781",
+        "logos-nix": "logos-nix_1782",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4174,7 +4174,7 @@
     },
     "logos-container_34": {
       "inputs": {
-        "logos-nix": "logos-nix_1905",
+        "logos-nix": "logos-nix_1906",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4202,7 +4202,7 @@
     },
     "logos-container_35": {
       "inputs": {
-        "logos-nix": "logos-nix_1908",
+        "logos-nix": "logos-nix_1909",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -5417,7 +5417,7 @@
     "logos-cpp-sdk_127": {
       "inputs": {
         "logos-lidl": "logos-lidl_56",
-        "logos-nix": "logos-nix_1343",
+        "logos-nix": "logos-nix_1344",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5450,7 +5450,7 @@
     "logos-cpp-sdk_128": {
       "inputs": {
         "logos-lidl": "logos-lidl_59",
-        "logos-nix": "logos-nix_1352",
+        "logos-nix": "logos-nix_1353",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5488,7 +5488,7 @@
     },
     "logos-cpp-sdk_129": {
       "inputs": {
-        "logos-nix": "logos-nix_1361",
+        "logos-nix": "logos-nix_1362",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5559,7 +5559,7 @@
     },
     "logos-cpp-sdk_130": {
       "inputs": {
-        "logos-nix": "logos-nix_1370",
+        "logos-nix": "logos-nix_1371",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5592,7 +5592,7 @@
     },
     "logos-cpp-sdk_131": {
       "inputs": {
-        "logos-nix": "logos-nix_1372",
+        "logos-nix": "logos-nix_1373",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5627,7 +5627,7 @@
     },
     "logos-cpp-sdk_132": {
       "inputs": {
-        "logos-nix": "logos-nix_1375",
+        "logos-nix": "logos-nix_1376",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5661,7 +5661,7 @@
     },
     "logos-cpp-sdk_133": {
       "inputs": {
-        "logos-nix": "logos-nix_1403",
+        "logos-nix": "logos-nix_1404",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5691,7 +5691,7 @@
     },
     "logos-cpp-sdk_134": {
       "inputs": {
-        "logos-nix": "logos-nix_1405",
+        "logos-nix": "logos-nix_1406",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5724,7 +5724,7 @@
     },
     "logos-cpp-sdk_135": {
       "inputs": {
-        "logos-nix": "logos-nix_1414",
+        "logos-nix": "logos-nix_1415",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5758,7 +5758,7 @@
     },
     "logos-cpp-sdk_136": {
       "inputs": {
-        "logos-nix": "logos-nix_1416",
+        "logos-nix": "logos-nix_1417",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5794,7 +5794,7 @@
     },
     "logos-cpp-sdk_137": {
       "inputs": {
-        "logos-nix": "logos-nix_1419",
+        "logos-nix": "logos-nix_1420",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5829,7 +5829,7 @@
     },
     "logos-cpp-sdk_138": {
       "inputs": {
-        "logos-nix": "logos-nix_1447",
+        "logos-nix": "logos-nix_1448",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5930,7 +5930,7 @@
     "logos-cpp-sdk_140": {
       "inputs": {
         "logos-lidl": "logos-lidl_62",
-        "logos-nix": "logos-nix_1475",
+        "logos-nix": "logos-nix_1476",
         "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5958,7 +5958,7 @@
     },
     "logos-cpp-sdk_141": {
       "inputs": {
-        "logos-nix": "logos-nix_1484",
+        "logos-nix": "logos-nix_1485",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -5988,7 +5988,7 @@
     },
     "logos-cpp-sdk_142": {
       "inputs": {
-        "logos-nix": "logos-nix_1491",
+        "logos-nix": "logos-nix_1492",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6021,7 +6021,7 @@
     },
     "logos-cpp-sdk_143": {
       "inputs": {
-        "logos-nix": "logos-nix_1500",
+        "logos-nix": "logos-nix_1501",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6055,7 +6055,7 @@
     },
     "logos-cpp-sdk_144": {
       "inputs": {
-        "logos-nix": "logos-nix_1502",
+        "logos-nix": "logos-nix_1503",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6091,7 +6091,7 @@
     },
     "logos-cpp-sdk_145": {
       "inputs": {
-        "logos-nix": "logos-nix_1505",
+        "logos-nix": "logos-nix_1506",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6126,7 +6126,7 @@
     },
     "logos-cpp-sdk_146": {
       "inputs": {
-        "logos-nix": "logos-nix_1533",
+        "logos-nix": "logos-nix_1534",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6157,7 +6157,7 @@
     },
     "logos-cpp-sdk_147": {
       "inputs": {
-        "logos-nix": "logos-nix_1535",
+        "logos-nix": "logos-nix_1536",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6191,7 +6191,7 @@
     },
     "logos-cpp-sdk_148": {
       "inputs": {
-        "logos-nix": "logos-nix_1544",
+        "logos-nix": "logos-nix_1545",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6226,7 +6226,7 @@
     },
     "logos-cpp-sdk_149": {
       "inputs": {
-        "logos-nix": "logos-nix_1546",
+        "logos-nix": "logos-nix_1547",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6292,7 +6292,7 @@
     },
     "logos-cpp-sdk_150": {
       "inputs": {
-        "logos-nix": "logos-nix_1549",
+        "logos-nix": "logos-nix_1550",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6328,7 +6328,7 @@
     },
     "logos-cpp-sdk_151": {
       "inputs": {
-        "logos-nix": "logos-nix_1577",
+        "logos-nix": "logos-nix_1578",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6404,7 +6404,7 @@
     "logos-cpp-sdk_153": {
       "inputs": {
         "logos-lidl": "logos-lidl_63",
-        "logos-nix": "logos-nix_1606",
+        "logos-nix": "logos-nix_1607",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -6478,7 +6478,7 @@
     "logos-cpp-sdk_155": {
       "inputs": {
         "logos-lidl": "logos-lidl_69",
-        "logos-nix": "logos-nix_1643",
+        "logos-nix": "logos-nix_1644",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6511,7 +6511,7 @@
     "logos-cpp-sdk_156": {
       "inputs": {
         "logos-lidl": "logos-lidl_72",
-        "logos-nix": "logos-nix_1652",
+        "logos-nix": "logos-nix_1653",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6549,7 +6549,7 @@
     },
     "logos-cpp-sdk_157": {
       "inputs": {
-        "logos-nix": "logos-nix_1661",
+        "logos-nix": "logos-nix_1662",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6581,7 +6581,7 @@
     },
     "logos-cpp-sdk_158": {
       "inputs": {
-        "logos-nix": "logos-nix_1670",
+        "logos-nix": "logos-nix_1671",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6614,7 +6614,7 @@
     },
     "logos-cpp-sdk_159": {
       "inputs": {
-        "logos-nix": "logos-nix_1672",
+        "logos-nix": "logos-nix_1673",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6681,7 +6681,7 @@
     },
     "logos-cpp-sdk_160": {
       "inputs": {
-        "logos-nix": "logos-nix_1675",
+        "logos-nix": "logos-nix_1676",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6715,7 +6715,7 @@
     },
     "logos-cpp-sdk_161": {
       "inputs": {
-        "logos-nix": "logos-nix_1703",
+        "logos-nix": "logos-nix_1704",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6745,7 +6745,7 @@
     },
     "logos-cpp-sdk_162": {
       "inputs": {
-        "logos-nix": "logos-nix_1705",
+        "logos-nix": "logos-nix_1706",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6778,7 +6778,7 @@
     },
     "logos-cpp-sdk_163": {
       "inputs": {
-        "logos-nix": "logos-nix_1714",
+        "logos-nix": "logos-nix_1715",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6812,7 +6812,7 @@
     },
     "logos-cpp-sdk_164": {
       "inputs": {
-        "logos-nix": "logos-nix_1716",
+        "logos-nix": "logos-nix_1717",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6848,7 +6848,7 @@
     },
     "logos-cpp-sdk_165": {
       "inputs": {
-        "logos-nix": "logos-nix_1719",
+        "logos-nix": "logos-nix_1720",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6883,7 +6883,7 @@
     },
     "logos-cpp-sdk_166": {
       "inputs": {
-        "logos-nix": "logos-nix_1747",
+        "logos-nix": "logos-nix_1748",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -6956,7 +6956,7 @@
     "logos-cpp-sdk_168": {
       "inputs": {
         "logos-lidl": "logos-lidl_75",
-        "logos-nix": "logos-nix_1775",
+        "logos-nix": "logos-nix_1776",
         "logos-protocol": "logos-protocol_50",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -6984,7 +6984,7 @@
     },
     "logos-cpp-sdk_169": {
       "inputs": {
-        "logos-nix": "logos-nix_1784",
+        "logos-nix": "logos-nix_1785",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7047,7 +7047,7 @@
     },
     "logos-cpp-sdk_170": {
       "inputs": {
-        "logos-nix": "logos-nix_1791",
+        "logos-nix": "logos-nix_1792",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7080,7 +7080,7 @@
     },
     "logos-cpp-sdk_171": {
       "inputs": {
-        "logos-nix": "logos-nix_1800",
+        "logos-nix": "logos-nix_1801",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7114,7 +7114,7 @@
     },
     "logos-cpp-sdk_172": {
       "inputs": {
-        "logos-nix": "logos-nix_1802",
+        "logos-nix": "logos-nix_1803",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7150,7 +7150,7 @@
     },
     "logos-cpp-sdk_173": {
       "inputs": {
-        "logos-nix": "logos-nix_1805",
+        "logos-nix": "logos-nix_1806",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7185,7 +7185,7 @@
     },
     "logos-cpp-sdk_174": {
       "inputs": {
-        "logos-nix": "logos-nix_1833",
+        "logos-nix": "logos-nix_1834",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7216,7 +7216,7 @@
     },
     "logos-cpp-sdk_175": {
       "inputs": {
-        "logos-nix": "logos-nix_1835",
+        "logos-nix": "logos-nix_1836",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7250,7 +7250,7 @@
     },
     "logos-cpp-sdk_176": {
       "inputs": {
-        "logos-nix": "logos-nix_1844",
+        "logos-nix": "logos-nix_1845",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7285,7 +7285,7 @@
     },
     "logos-cpp-sdk_177": {
       "inputs": {
-        "logos-nix": "logos-nix_1846",
+        "logos-nix": "logos-nix_1847",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7322,7 +7322,7 @@
     },
     "logos-cpp-sdk_178": {
       "inputs": {
-        "logos-nix": "logos-nix_1849",
+        "logos-nix": "logos-nix_1850",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7358,7 +7358,7 @@
     },
     "logos-cpp-sdk_179": {
       "inputs": {
-        "logos-nix": "logos-nix_1877",
+        "logos-nix": "logos-nix_1878",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -7469,7 +7469,7 @@
     "logos-cpp-sdk_181": {
       "inputs": {
         "logos-lidl": "logos-lidl_76",
-        "logos-nix": "logos-nix_1906",
+        "logos-nix": "logos-nix_1907",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11263,7 +11263,7 @@
     },
     "logos-design-system_33": {
       "inputs": {
-        "logos-nix": "logos-nix_1371",
+        "logos-nix": "logos-nix_1372",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11296,7 +11296,7 @@
     },
     "logos-design-system_34": {
       "inputs": {
-        "logos-nix": "logos-nix_1404",
+        "logos-nix": "logos-nix_1405",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11326,7 +11326,7 @@
     },
     "logos-design-system_35": {
       "inputs": {
-        "logos-nix": "logos-nix_1415",
+        "logos-nix": "logos-nix_1416",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11360,7 +11360,7 @@
     },
     "logos-design-system_36": {
       "inputs": {
-        "logos-nix": "logos-nix_1476",
+        "logos-nix": "logos-nix_1477",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11387,7 +11387,7 @@
     },
     "logos-design-system_37": {
       "inputs": {
-        "logos-nix": "logos-nix_1501",
+        "logos-nix": "logos-nix_1502",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11421,7 +11421,7 @@
     },
     "logos-design-system_38": {
       "inputs": {
-        "logos-nix": "logos-nix_1534",
+        "logos-nix": "logos-nix_1535",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11452,7 +11452,7 @@
     },
     "logos-design-system_39": {
       "inputs": {
-        "logos-nix": "logos-nix_1545",
+        "logos-nix": "logos-nix_1546",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -11513,7 +11513,7 @@
     },
     "logos-design-system_40": {
       "inputs": {
-        "logos-nix": "logos-nix_1671",
+        "logos-nix": "logos-nix_1672",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11546,7 +11546,7 @@
     },
     "logos-design-system_41": {
       "inputs": {
-        "logos-nix": "logos-nix_1704",
+        "logos-nix": "logos-nix_1705",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11576,7 +11576,7 @@
     },
     "logos-design-system_42": {
       "inputs": {
-        "logos-nix": "logos-nix_1715",
+        "logos-nix": "logos-nix_1716",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11610,7 +11610,7 @@
     },
     "logos-design-system_43": {
       "inputs": {
-        "logos-nix": "logos-nix_1776",
+        "logos-nix": "logos-nix_1777",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11637,7 +11637,7 @@
     },
     "logos-design-system_44": {
       "inputs": {
-        "logos-nix": "logos-nix_1801",
+        "logos-nix": "logos-nix_1802",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11671,7 +11671,7 @@
     },
     "logos-design-system_45": {
       "inputs": {
-        "logos-nix": "logos-nix_1834",
+        "logos-nix": "logos-nix_1835",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11702,7 +11702,7 @@
     },
     "logos-design-system_46": {
       "inputs": {
-        "logos-nix": "logos-nix_1845",
+        "logos-nix": "logos-nix_1846",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -12826,7 +12826,7 @@
         "logos-capability-module": "logos-capability-module_68",
         "logos-cpp-sdk": "logos-cpp-sdk_132",
         "logos-module": "logos-module_179",
-        "logos-nix": "logos-nix_1377",
+        "logos-nix": "logos-nix_1378",
         "logos-package-manager": "logos-package-manager_66",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -12863,7 +12863,7 @@
         "logos-capability-module": "logos-capability-module_69",
         "logos-cpp-sdk": "logos-cpp-sdk_138",
         "logos-module": "logos-module_186",
-        "logos-nix": "logos-nix_1449",
+        "logos-nix": "logos-nix_1450",
         "logos-package-manager": "logos-package-manager_70",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -12898,7 +12898,7 @@
         "logos-capability-module": "logos-capability-module_71",
         "logos-cpp-sdk": "logos-cpp-sdk_137",
         "logos-module": "logos-module_185",
-        "logos-nix": "logos-nix_1421",
+        "logos-nix": "logos-nix_1422",
         "logos-package-manager": "logos-package-manager_68",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -12940,7 +12940,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_153",
         "logos-module": "logos-module_204",
         "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_1610",
+        "logos-nix": "logos-nix_1611",
         "logos-package-manager": "logos-package-manager_78",
         "logos-protocol": "logos-protocol_42",
         "logos-qt-sdk": "logos-qt-sdk_33",
@@ -12974,7 +12974,7 @@
         "logos-capability-module": "logos-capability-module_75",
         "logos-cpp-sdk": "logos-cpp-sdk_145",
         "logos-module": "logos-module_196",
-        "logos-nix": "logos-nix_1507",
+        "logos-nix": "logos-nix_1508",
         "logos-package-manager": "logos-package-manager_72",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13012,7 +13012,7 @@
         "logos-capability-module": "logos-capability-module_76",
         "logos-cpp-sdk": "logos-cpp-sdk_151",
         "logos-module": "logos-module_203",
-        "logos-nix": "logos-nix_1579",
+        "logos-nix": "logos-nix_1580",
         "logos-package-manager": "logos-package-manager_76",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13048,7 +13048,7 @@
         "logos-capability-module": "logos-capability-module_78",
         "logos-cpp-sdk": "logos-cpp-sdk_150",
         "logos-module": "logos-module_202",
-        "logos-nix": "logos-nix_1551",
+        "logos-nix": "logos-nix_1552",
         "logos-package-manager": "logos-package-manager_74",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13124,7 +13124,7 @@
         "logos-capability-module": "logos-capability-module_82",
         "logos-cpp-sdk": "logos-cpp-sdk_160",
         "logos-module": "logos-module_216",
-        "logos-nix": "logos-nix_1677",
+        "logos-nix": "logos-nix_1678",
         "logos-package-manager": "logos-package-manager_80",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13161,7 +13161,7 @@
         "logos-capability-module": "logos-capability-module_83",
         "logos-cpp-sdk": "logos-cpp-sdk_166",
         "logos-module": "logos-module_223",
-        "logos-nix": "logos-nix_1749",
+        "logos-nix": "logos-nix_1750",
         "logos-package-manager": "logos-package-manager_84",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13196,7 +13196,7 @@
         "logos-capability-module": "logos-capability-module_85",
         "logos-cpp-sdk": "logos-cpp-sdk_165",
         "logos-module": "logos-module_222",
-        "logos-nix": "logos-nix_1721",
+        "logos-nix": "logos-nix_1722",
         "logos-package-manager": "logos-package-manager_82",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13238,7 +13238,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_181",
         "logos-module": "logos-module_241",
         "logos-module-loader": "logos-module-loader_14",
-        "logos-nix": "logos-nix_1910",
+        "logos-nix": "logos-nix_1911",
         "logos-package-manager": "logos-package-manager_92",
         "logos-protocol": "logos-protocol_51",
         "logos-qt-sdk": "logos-qt-sdk_40",
@@ -13272,7 +13272,7 @@
         "logos-capability-module": "logos-capability-module_89",
         "logos-cpp-sdk": "logos-cpp-sdk_173",
         "logos-module": "logos-module_233",
-        "logos-nix": "logos-nix_1807",
+        "logos-nix": "logos-nix_1808",
         "logos-package-manager": "logos-package-manager_86",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13310,7 +13310,7 @@
         "logos-capability-module": "logos-capability-module_90",
         "logos-cpp-sdk": "logos-cpp-sdk_179",
         "logos-module": "logos-module_240",
-        "logos-nix": "logos-nix_1879",
+        "logos-nix": "logos-nix_1880",
         "logos-package-manager": "logos-package-manager_90",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -13346,7 +13346,7 @@
         "logos-capability-module": "logos-capability-module_92",
         "logos-cpp-sdk": "logos-cpp-sdk_178",
         "logos-module": "logos-module_239",
-        "logos-nix": "logos-nix_1851",
+        "logos-nix": "logos-nix_1852",
         "logos-package-manager": "logos-package-manager_88",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -17389,7 +17389,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_127",
         "logos-module": "logos-module_168",
-        "logos-nix": "logos-nix_1345",
+        "logos-nix": "logos-nix_1346",
         "logos-plugin-core": "logos-plugin-core_32",
         "logos-plugin-qt": "logos-plugin-qt_32",
         "logos-protocol": "logos-protocol_38",
@@ -17426,7 +17426,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_128",
         "logos-module": "logos-module_171",
-        "logos-nix": "logos-nix_1354",
+        "logos-nix": "logos-nix_1355",
         "logos-plugin-core": "logos-plugin-core_33",
         "logos-plugin-qt": "logos-plugin-qt_33",
         "logos-protocol": "logos-protocol_39",
@@ -17466,7 +17466,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_129",
         "logos-module": "logos-module_174",
-        "logos-nix": "logos-nix_1363",
+        "logos-nix": "logos-nix_1364",
         "logos-plugin-core": "logos-plugin-core_34",
         "logos-plugin-qt": "logos-plugin-qt_34",
         "logos-standalone-app": "logos-standalone-app_34",
@@ -17505,7 +17505,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_134",
         "logos-module": "logos-module_180",
-        "logos-nix": "logos-nix_1407",
+        "logos-nix": "logos-nix_1408",
         "logos-plugin-core": "logos-plugin-core_35",
         "logos-plugin-qt": "logos-plugin-qt_35",
         "logos-standalone-app": "logos-standalone-app_35",
@@ -17545,7 +17545,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_141",
         "logos-module": "logos-module_188",
-        "logos-nix": "logos-nix_1486",
+        "logos-nix": "logos-nix_1487",
         "logos-plugin-core": "logos-plugin-core_36",
         "logos-plugin-qt": "logos-plugin-qt_36",
         "logos-standalone-app": "logos-standalone-app_36",
@@ -17582,7 +17582,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_142",
         "logos-module": "logos-module_191",
-        "logos-nix": "logos-nix_1493",
+        "logos-nix": "logos-nix_1494",
         "logos-plugin-core": "logos-plugin-core_37",
         "logos-plugin-qt": "logos-plugin-qt_37",
         "logos-standalone-app": "logos-standalone-app_37",
@@ -17622,7 +17622,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_147",
         "logos-module": "logos-module_197",
-        "logos-nix": "logos-nix_1537",
+        "logos-nix": "logos-nix_1538",
         "logos-plugin-core": "logos-plugin-core_38",
         "logos-plugin-qt": "logos-plugin-qt_38",
         "logos-standalone-app": "logos-standalone-app_38",
@@ -17663,7 +17663,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_155",
         "logos-module": "logos-module_205",
-        "logos-nix": "logos-nix_1645",
+        "logos-nix": "logos-nix_1646",
         "logos-plugin-core": "logos-plugin-core_39",
         "logos-plugin-qt": "logos-plugin-qt_39",
         "logos-protocol": "logos-protocol_47",
@@ -17739,7 +17739,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_156",
         "logos-module": "logos-module_208",
-        "logos-nix": "logos-nix_1654",
+        "logos-nix": "logos-nix_1655",
         "logos-plugin-core": "logos-plugin-core_40",
         "logos-plugin-qt": "logos-plugin-qt_40",
         "logos-protocol": "logos-protocol_48",
@@ -17779,7 +17779,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_157",
         "logos-module": "logos-module_211",
-        "logos-nix": "logos-nix_1663",
+        "logos-nix": "logos-nix_1664",
         "logos-plugin-core": "logos-plugin-core_41",
         "logos-plugin-qt": "logos-plugin-qt_41",
         "logos-standalone-app": "logos-standalone-app_41",
@@ -17818,7 +17818,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_162",
         "logos-module": "logos-module_217",
-        "logos-nix": "logos-nix_1707",
+        "logos-nix": "logos-nix_1708",
         "logos-plugin-core": "logos-plugin-core_42",
         "logos-plugin-qt": "logos-plugin-qt_42",
         "logos-standalone-app": "logos-standalone-app_42",
@@ -17858,7 +17858,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_169",
         "logos-module": "logos-module_225",
-        "logos-nix": "logos-nix_1786",
+        "logos-nix": "logos-nix_1787",
         "logos-plugin-core": "logos-plugin-core_43",
         "logos-plugin-qt": "logos-plugin-qt_43",
         "logos-standalone-app": "logos-standalone-app_43",
@@ -17895,7 +17895,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_170",
         "logos-module": "logos-module_228",
-        "logos-nix": "logos-nix_1793",
+        "logos-nix": "logos-nix_1794",
         "logos-plugin-core": "logos-plugin-core_44",
         "logos-plugin-qt": "logos-plugin-qt_44",
         "logos-standalone-app": "logos-standalone-app_44",
@@ -17935,7 +17935,7 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_175",
         "logos-module": "logos-module_234",
-        "logos-nix": "logos-nix_1837",
+        "logos-nix": "logos-nix_1838",
         "logos-plugin-core": "logos-plugin-core_45",
         "logos-plugin-qt": "logos-plugin-qt_45",
         "logos-standalone-app": "logos-standalone-app_45",
@@ -18216,7 +18216,7 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_28",
-        "logos-nix": "logos-nix_1482",
+        "logos-nix": "logos-nix_1483",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -18246,7 +18246,7 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-        "logos-nix": "logos-nix_1609",
+        "logos-nix": "logos-nix_1610",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -18275,7 +18275,7 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_33",
-        "logos-nix": "logos-nix_1782",
+        "logos-nix": "logos-nix_1783",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -18305,7 +18305,7 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
-        "logos-nix": "logos-nix_1909",
+        "logos-nix": "logos-nix_1910",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -20968,7 +20968,7 @@
     },
     "logos-module_168": {
       "inputs": {
-        "logos-nix": "logos-nix_1344",
+        "logos-nix": "logos-nix_1345",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -20994,7 +20994,7 @@
     },
     "logos-module_169": {
       "inputs": {
-        "logos-nix": "logos-nix_1346",
+        "logos-nix": "logos-nix_1347",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21056,7 +21056,7 @@
     },
     "logos-module_170": {
       "inputs": {
-        "logos-nix": "logos-nix_1348",
+        "logos-nix": "logos-nix_1349",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21083,7 +21083,7 @@
     },
     "logos-module_171": {
       "inputs": {
-        "logos-nix": "logos-nix_1353",
+        "logos-nix": "logos-nix_1354",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21112,7 +21112,7 @@
     },
     "logos-module_172": {
       "inputs": {
-        "logos-nix": "logos-nix_1355",
+        "logos-nix": "logos-nix_1356",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21142,7 +21142,7 @@
     },
     "logos-module_173": {
       "inputs": {
-        "logos-nix": "logos-nix_1357",
+        "logos-nix": "logos-nix_1358",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21172,7 +21172,7 @@
     },
     "logos-module_174": {
       "inputs": {
-        "logos-nix": "logos-nix_1362",
+        "logos-nix": "logos-nix_1363",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21204,7 +21204,7 @@
     },
     "logos-module_175": {
       "inputs": {
-        "logos-nix": "logos-nix_1364",
+        "logos-nix": "logos-nix_1365",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21237,7 +21237,7 @@
     },
     "logos-module_176": {
       "inputs": {
-        "logos-nix": "logos-nix_1366",
+        "logos-nix": "logos-nix_1367",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21270,7 +21270,7 @@
     },
     "logos-module_177": {
       "inputs": {
-        "logos-nix": "logos-nix_1368",
+        "logos-nix": "logos-nix_1369",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21304,7 +21304,7 @@
     },
     "logos-module_178": {
       "inputs": {
-        "logos-nix": "logos-nix_1373",
+        "logos-nix": "logos-nix_1374",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21339,7 +21339,7 @@
     },
     "logos-module_179": {
       "inputs": {
-        "logos-nix": "logos-nix_1376",
+        "logos-nix": "logos-nix_1377",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21407,7 +21407,7 @@
     },
     "logos-module_180": {
       "inputs": {
-        "logos-nix": "logos-nix_1406",
+        "logos-nix": "logos-nix_1407",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21440,7 +21440,7 @@
     },
     "logos-module_181": {
       "inputs": {
-        "logos-nix": "logos-nix_1408",
+        "logos-nix": "logos-nix_1409",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21474,7 +21474,7 @@
     },
     "logos-module_182": {
       "inputs": {
-        "logos-nix": "logos-nix_1410",
+        "logos-nix": "logos-nix_1411",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21508,7 +21508,7 @@
     },
     "logos-module_183": {
       "inputs": {
-        "logos-nix": "logos-nix_1412",
+        "logos-nix": "logos-nix_1413",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21543,7 +21543,7 @@
     },
     "logos-module_184": {
       "inputs": {
-        "logos-nix": "logos-nix_1417",
+        "logos-nix": "logos-nix_1418",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21579,7 +21579,7 @@
     },
     "logos-module_185": {
       "inputs": {
-        "logos-nix": "logos-nix_1420",
+        "logos-nix": "logos-nix_1421",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21614,7 +21614,7 @@
     },
     "logos-module_186": {
       "inputs": {
-        "logos-nix": "logos-nix_1448",
+        "logos-nix": "logos-nix_1449",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21645,7 +21645,7 @@
     },
     "logos-module_187": {
       "inputs": {
-        "logos-nix": "logos-nix_1480",
+        "logos-nix": "logos-nix_1481",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21674,7 +21674,7 @@
     },
     "logos-module_188": {
       "inputs": {
-        "logos-nix": "logos-nix_1485",
+        "logos-nix": "logos-nix_1486",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21704,7 +21704,7 @@
     },
     "logos-module_189": {
       "inputs": {
-        "logos-nix": "logos-nix_1487",
+        "logos-nix": "logos-nix_1488",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21765,7 +21765,7 @@
     },
     "logos-module_190": {
       "inputs": {
-        "logos-nix": "logos-nix_1489",
+        "logos-nix": "logos-nix_1490",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21796,7 +21796,7 @@
     },
     "logos-module_191": {
       "inputs": {
-        "logos-nix": "logos-nix_1492",
+        "logos-nix": "logos-nix_1493",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21829,7 +21829,7 @@
     },
     "logos-module_192": {
       "inputs": {
-        "logos-nix": "logos-nix_1494",
+        "logos-nix": "logos-nix_1495",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21863,7 +21863,7 @@
     },
     "logos-module_193": {
       "inputs": {
-        "logos-nix": "logos-nix_1496",
+        "logos-nix": "logos-nix_1497",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21897,7 +21897,7 @@
     },
     "logos-module_194": {
       "inputs": {
-        "logos-nix": "logos-nix_1498",
+        "logos-nix": "logos-nix_1499",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21932,7 +21932,7 @@
     },
     "logos-module_195": {
       "inputs": {
-        "logos-nix": "logos-nix_1503",
+        "logos-nix": "logos-nix_1504",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -21968,7 +21968,7 @@
     },
     "logos-module_196": {
       "inputs": {
-        "logos-nix": "logos-nix_1506",
+        "logos-nix": "logos-nix_1507",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22003,7 +22003,7 @@
     },
     "logos-module_197": {
       "inputs": {
-        "logos-nix": "logos-nix_1536",
+        "logos-nix": "logos-nix_1537",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22037,7 +22037,7 @@
     },
     "logos-module_198": {
       "inputs": {
-        "logos-nix": "logos-nix_1538",
+        "logos-nix": "logos-nix_1539",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22072,7 +22072,7 @@
     },
     "logos-module_199": {
       "inputs": {
-        "logos-nix": "logos-nix_1540",
+        "logos-nix": "logos-nix_1541",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22161,7 +22161,7 @@
     },
     "logos-module_200": {
       "inputs": {
-        "logos-nix": "logos-nix_1542",
+        "logos-nix": "logos-nix_1543",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22197,7 +22197,7 @@
     },
     "logos-module_201": {
       "inputs": {
-        "logos-nix": "logos-nix_1547",
+        "logos-nix": "logos-nix_1548",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22234,7 +22234,7 @@
     },
     "logos-module_202": {
       "inputs": {
-        "logos-nix": "logos-nix_1550",
+        "logos-nix": "logos-nix_1551",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22270,7 +22270,7 @@
     },
     "logos-module_203": {
       "inputs": {
-        "logos-nix": "logos-nix_1578",
+        "logos-nix": "logos-nix_1579",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22302,7 +22302,7 @@
     },
     "logos-module_204": {
       "inputs": {
-        "logos-nix": "logos-nix_1607",
+        "logos-nix": "logos-nix_1608",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22330,7 +22330,7 @@
     },
     "logos-module_205": {
       "inputs": {
-        "logos-nix": "logos-nix_1644",
+        "logos-nix": "logos-nix_1645",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22356,7 +22356,7 @@
     },
     "logos-module_206": {
       "inputs": {
-        "logos-nix": "logos-nix_1646",
+        "logos-nix": "logos-nix_1647",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22383,7 +22383,7 @@
     },
     "logos-module_207": {
       "inputs": {
-        "logos-nix": "logos-nix_1648",
+        "logos-nix": "logos-nix_1649",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22410,7 +22410,7 @@
     },
     "logos-module_208": {
       "inputs": {
-        "logos-nix": "logos-nix_1653",
+        "logos-nix": "logos-nix_1654",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22439,7 +22439,7 @@
     },
     "logos-module_209": {
       "inputs": {
-        "logos-nix": "logos-nix_1655",
+        "logos-nix": "logos-nix_1656",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22498,7 +22498,7 @@
     },
     "logos-module_210": {
       "inputs": {
-        "logos-nix": "logos-nix_1657",
+        "logos-nix": "logos-nix_1658",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22528,7 +22528,7 @@
     },
     "logos-module_211": {
       "inputs": {
-        "logos-nix": "logos-nix_1662",
+        "logos-nix": "logos-nix_1663",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22560,7 +22560,7 @@
     },
     "logos-module_212": {
       "inputs": {
-        "logos-nix": "logos-nix_1664",
+        "logos-nix": "logos-nix_1665",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22593,7 +22593,7 @@
     },
     "logos-module_213": {
       "inputs": {
-        "logos-nix": "logos-nix_1666",
+        "logos-nix": "logos-nix_1667",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22626,7 +22626,7 @@
     },
     "logos-module_214": {
       "inputs": {
-        "logos-nix": "logos-nix_1668",
+        "logos-nix": "logos-nix_1669",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22660,7 +22660,7 @@
     },
     "logos-module_215": {
       "inputs": {
-        "logos-nix": "logos-nix_1673",
+        "logos-nix": "logos-nix_1674",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22695,7 +22695,7 @@
     },
     "logos-module_216": {
       "inputs": {
-        "logos-nix": "logos-nix_1676",
+        "logos-nix": "logos-nix_1677",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22729,7 +22729,7 @@
     },
     "logos-module_217": {
       "inputs": {
-        "logos-nix": "logos-nix_1706",
+        "logos-nix": "logos-nix_1707",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22762,7 +22762,7 @@
     },
     "logos-module_218": {
       "inputs": {
-        "logos-nix": "logos-nix_1708",
+        "logos-nix": "logos-nix_1709",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22796,7 +22796,7 @@
     },
     "logos-module_219": {
       "inputs": {
-        "logos-nix": "logos-nix_1710",
+        "logos-nix": "logos-nix_1711",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22860,7 +22860,7 @@
     },
     "logos-module_220": {
       "inputs": {
-        "logos-nix": "logos-nix_1712",
+        "logos-nix": "logos-nix_1713",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22895,7 +22895,7 @@
     },
     "logos-module_221": {
       "inputs": {
-        "logos-nix": "logos-nix_1717",
+        "logos-nix": "logos-nix_1718",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22931,7 +22931,7 @@
     },
     "logos-module_222": {
       "inputs": {
-        "logos-nix": "logos-nix_1720",
+        "logos-nix": "logos-nix_1721",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22966,7 +22966,7 @@
     },
     "logos-module_223": {
       "inputs": {
-        "logos-nix": "logos-nix_1748",
+        "logos-nix": "logos-nix_1749",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22997,7 +22997,7 @@
     },
     "logos-module_224": {
       "inputs": {
-        "logos-nix": "logos-nix_1780",
+        "logos-nix": "logos-nix_1781",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23026,7 +23026,7 @@
     },
     "logos-module_225": {
       "inputs": {
-        "logos-nix": "logos-nix_1785",
+        "logos-nix": "logos-nix_1786",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23056,7 +23056,7 @@
     },
     "logos-module_226": {
       "inputs": {
-        "logos-nix": "logos-nix_1787",
+        "logos-nix": "logos-nix_1788",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23087,7 +23087,7 @@
     },
     "logos-module_227": {
       "inputs": {
-        "logos-nix": "logos-nix_1789",
+        "logos-nix": "logos-nix_1790",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23118,7 +23118,7 @@
     },
     "logos-module_228": {
       "inputs": {
-        "logos-nix": "logos-nix_1792",
+        "logos-nix": "logos-nix_1793",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23151,7 +23151,7 @@
     },
     "logos-module_229": {
       "inputs": {
-        "logos-nix": "logos-nix_1794",
+        "logos-nix": "logos-nix_1795",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23215,7 +23215,7 @@
     },
     "logos-module_230": {
       "inputs": {
-        "logos-nix": "logos-nix_1796",
+        "logos-nix": "logos-nix_1797",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23249,7 +23249,7 @@
     },
     "logos-module_231": {
       "inputs": {
-        "logos-nix": "logos-nix_1798",
+        "logos-nix": "logos-nix_1799",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23284,7 +23284,7 @@
     },
     "logos-module_232": {
       "inputs": {
-        "logos-nix": "logos-nix_1803",
+        "logos-nix": "logos-nix_1804",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23320,7 +23320,7 @@
     },
     "logos-module_233": {
       "inputs": {
-        "logos-nix": "logos-nix_1806",
+        "logos-nix": "logos-nix_1807",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23355,7 +23355,7 @@
     },
     "logos-module_234": {
       "inputs": {
-        "logos-nix": "logos-nix_1836",
+        "logos-nix": "logos-nix_1837",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23389,7 +23389,7 @@
     },
     "logos-module_235": {
       "inputs": {
-        "logos-nix": "logos-nix_1838",
+        "logos-nix": "logos-nix_1839",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23424,7 +23424,7 @@
     },
     "logos-module_236": {
       "inputs": {
-        "logos-nix": "logos-nix_1840",
+        "logos-nix": "logos-nix_1841",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23459,7 +23459,7 @@
     },
     "logos-module_237": {
       "inputs": {
-        "logos-nix": "logos-nix_1842",
+        "logos-nix": "logos-nix_1843",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23495,7 +23495,7 @@
     },
     "logos-module_238": {
       "inputs": {
-        "logos-nix": "logos-nix_1847",
+        "logos-nix": "logos-nix_1848",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23532,7 +23532,7 @@
     },
     "logos-module_239": {
       "inputs": {
-        "logos-nix": "logos-nix_1850",
+        "logos-nix": "logos-nix_1851",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23600,7 +23600,7 @@
     },
     "logos-module_240": {
       "inputs": {
-        "logos-nix": "logos-nix_1878",
+        "logos-nix": "logos-nix_1879",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -23632,7 +23632,7 @@
     },
     "logos-module_241": {
       "inputs": {
-        "logos-nix": "logos-nix_1907",
+        "logos-nix": "logos-nix_1908",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -33085,11 +33085,11 @@
         "nixpkgs": "nixpkgs_1343"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33103,11 +33103,11 @@
         "nixpkgs": "nixpkgs_1344"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33121,11 +33121,11 @@
         "nixpkgs": "nixpkgs_1345"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33139,11 +33139,11 @@
         "nixpkgs": "nixpkgs_1346"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33157,24 +33157,6 @@
         "nixpkgs": "nixpkgs_1347"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1348": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1348"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -33188,9 +33170,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1349": {
+    "logos-nix_1348": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1349"
+        "nixpkgs": "nixpkgs_1348"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33198,6 +33180,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1349": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1349"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33283,11 +33283,11 @@
         "nixpkgs": "nixpkgs_1353"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33301,11 +33301,11 @@
         "nixpkgs": "nixpkgs_1354"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33319,11 +33319,11 @@
         "nixpkgs": "nixpkgs_1355"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33337,24 +33337,6 @@
         "nixpkgs": "nixpkgs_1356"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1357": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1357"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -33368,9 +33350,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1358": {
+    "logos-nix_1357": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1358"
+        "nixpkgs": "nixpkgs_1357"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33378,6 +33360,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1358": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1358"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33463,11 +33463,11 @@
         "nixpkgs": "nixpkgs_1362"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33481,11 +33481,11 @@
         "nixpkgs": "nixpkgs_1363"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33499,11 +33499,11 @@
         "nixpkgs": "nixpkgs_1364"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33517,11 +33517,11 @@
         "nixpkgs": "nixpkgs_1365"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33535,24 +33535,6 @@
         "nixpkgs": "nixpkgs_1366"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1367": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1367"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -33566,9 +33548,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1368": {
+    "logos-nix_1367": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1368"
+        "nixpkgs": "nixpkgs_1367"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -33576,6 +33558,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1368": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1368"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33625,11 +33625,11 @@
         "nixpkgs": "nixpkgs_1370"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33643,11 +33643,11 @@
         "nixpkgs": "nixpkgs_1371"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33715,24 +33715,6 @@
         "nixpkgs": "nixpkgs_1375"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1376": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1376"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -33746,9 +33728,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1377": {
+    "logos-nix_1376": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1377"
+        "nixpkgs": "nixpkgs_1376"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33756,6 +33738,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1377": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1377"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33787,11 +33787,11 @@
         "nixpkgs": "nixpkgs_1379"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33895,24 +33895,6 @@
         "nixpkgs": "nixpkgs_1384"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1385": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1385"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -33926,9 +33908,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1386": {
+    "logos-nix_1385": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1386"
+        "nixpkgs": "nixpkgs_1385"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33936,6 +33918,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1386": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1386"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33967,11 +33967,11 @@
         "nixpkgs": "nixpkgs_1388"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34021,11 +34021,11 @@
         "nixpkgs": "nixpkgs_1390"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34057,11 +34057,11 @@
         "nixpkgs": "nixpkgs_1392"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34093,11 +34093,11 @@
         "nixpkgs": "nixpkgs_1394"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34129,11 +34129,11 @@
         "nixpkgs": "nixpkgs_1396"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34237,11 +34237,11 @@
         "nixpkgs": "nixpkgs_1400"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34255,11 +34255,11 @@
         "nixpkgs": "nixpkgs_1401"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34291,11 +34291,11 @@
         "nixpkgs": "nixpkgs_1403"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34309,11 +34309,11 @@
         "nixpkgs": "nixpkgs_1404"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34327,11 +34327,11 @@
         "nixpkgs": "nixpkgs_1405"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34345,11 +34345,11 @@
         "nixpkgs": "nixpkgs_1406"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34363,24 +34363,6 @@
         "nixpkgs": "nixpkgs_1407"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1408": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1408"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -34394,9 +34376,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1409": {
+    "logos-nix_1408": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1409"
+        "nixpkgs": "nixpkgs_1408"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -34404,6 +34386,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1409": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1409"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34435,24 +34435,6 @@
         "nixpkgs": "nixpkgs_1410"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1411": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1411"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -34466,9 +34448,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1412": {
+    "logos-nix_1411": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1412"
+        "nixpkgs": "nixpkgs_1411"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -34476,6 +34458,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1412": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1412"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34507,11 +34507,11 @@
         "nixpkgs": "nixpkgs_1414"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34525,11 +34525,11 @@
         "nixpkgs": "nixpkgs_1415"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34597,11 +34597,11 @@
         "nixpkgs": "nixpkgs_1419"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34633,11 +34633,11 @@
         "nixpkgs": "nixpkgs_1420"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34651,11 +34651,11 @@
         "nixpkgs": "nixpkgs_1421"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34687,11 +34687,11 @@
         "nixpkgs": "nixpkgs_1423"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34777,11 +34777,11 @@
         "nixpkgs": "nixpkgs_1428"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34795,11 +34795,11 @@
         "nixpkgs": "nixpkgs_1429"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34831,11 +34831,11 @@
         "nixpkgs": "nixpkgs_1430"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34867,11 +34867,11 @@
         "nixpkgs": "nixpkgs_1432"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34903,11 +34903,11 @@
         "nixpkgs": "nixpkgs_1434"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34939,11 +34939,11 @@
         "nixpkgs": "nixpkgs_1436"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34975,11 +34975,11 @@
         "nixpkgs": "nixpkgs_1438"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35029,11 +35029,11 @@
         "nixpkgs": "nixpkgs_1440"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35101,11 +35101,11 @@
         "nixpkgs": "nixpkgs_1444"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35119,11 +35119,11 @@
         "nixpkgs": "nixpkgs_1445"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35155,24 +35155,6 @@
         "nixpkgs": "nixpkgs_1447"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1448": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1448"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -35186,9 +35168,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1449": {
+    "logos-nix_1448": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1449"
+        "nixpkgs": "nixpkgs_1448"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -35196,6 +35178,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1449": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1449"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35245,11 +35245,11 @@
         "nixpkgs": "nixpkgs_1451"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35335,24 +35335,6 @@
         "nixpkgs": "nixpkgs_1456"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1457": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1457"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -35366,9 +35348,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1458": {
+    "logos-nix_1457": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1458"
+        "nixpkgs": "nixpkgs_1457"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -35376,6 +35358,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1458": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1458"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35425,11 +35425,11 @@
         "nixpkgs": "nixpkgs_1460"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35461,11 +35461,11 @@
         "nixpkgs": "nixpkgs_1462"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35497,11 +35497,11 @@
         "nixpkgs": "nixpkgs_1464"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35533,11 +35533,11 @@
         "nixpkgs": "nixpkgs_1466"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35569,11 +35569,11 @@
         "nixpkgs": "nixpkgs_1468"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35659,11 +35659,11 @@
         "nixpkgs": "nixpkgs_1472"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35677,11 +35677,11 @@
         "nixpkgs": "nixpkgs_1473"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35713,24 +35713,6 @@
         "nixpkgs": "nixpkgs_1475"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1476": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1476"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -35744,9 +35726,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1477": {
+    "logos-nix_1476": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1477"
+        "nixpkgs": "nixpkgs_1476"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -35754,6 +35736,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1477": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1477"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35821,11 +35821,11 @@
         "nixpkgs": "nixpkgs_1480"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35839,11 +35839,11 @@
         "nixpkgs": "nixpkgs_1481"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35911,11 +35911,11 @@
         "nixpkgs": "nixpkgs_1485"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -35929,11 +35929,11 @@
         "nixpkgs": "nixpkgs_1486"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -35947,24 +35947,6 @@
         "nixpkgs": "nixpkgs_1487"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1488": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1488"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -35978,9 +35960,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1489": {
+    "logos-nix_1488": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1489"
+        "nixpkgs": "nixpkgs_1488"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -35988,6 +35970,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1489": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1489"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36019,11 +36019,11 @@
         "nixpkgs": "nixpkgs_1490"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36055,11 +36055,11 @@
         "nixpkgs": "nixpkgs_1492"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36073,11 +36073,11 @@
         "nixpkgs": "nixpkgs_1493"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36091,11 +36091,11 @@
         "nixpkgs": "nixpkgs_1494"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36109,11 +36109,11 @@
         "nixpkgs": "nixpkgs_1495"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36127,24 +36127,6 @@
         "nixpkgs": "nixpkgs_1496"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1497": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1497"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -36158,9 +36140,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1498": {
+    "logos-nix_1497": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1498"
+        "nixpkgs": "nixpkgs_1497"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -36168,6 +36150,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1498": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1498"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36235,11 +36235,11 @@
         "nixpkgs": "nixpkgs_1500"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36253,11 +36253,11 @@
         "nixpkgs": "nixpkgs_1501"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36325,24 +36325,6 @@
         "nixpkgs": "nixpkgs_1505"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1506": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1506"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -36356,9 +36338,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1507": {
+    "logos-nix_1506": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1507"
+        "nixpkgs": "nixpkgs_1506"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -36366,6 +36348,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1507": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1507"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36397,11 +36397,11 @@
         "nixpkgs": "nixpkgs_1509"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36505,24 +36505,6 @@
         "nixpkgs": "nixpkgs_1514"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1515": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1515"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -36536,9 +36518,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1516": {
+    "logos-nix_1515": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1516"
+        "nixpkgs": "nixpkgs_1515"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -36546,6 +36528,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1516": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1516"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36577,11 +36577,11 @@
         "nixpkgs": "nixpkgs_1518"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36631,11 +36631,11 @@
         "nixpkgs": "nixpkgs_1520"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36667,11 +36667,11 @@
         "nixpkgs": "nixpkgs_1522"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36703,11 +36703,11 @@
         "nixpkgs": "nixpkgs_1524"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36739,11 +36739,11 @@
         "nixpkgs": "nixpkgs_1526"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36829,11 +36829,11 @@
         "nixpkgs": "nixpkgs_1530"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36847,11 +36847,11 @@
         "nixpkgs": "nixpkgs_1531"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36883,11 +36883,11 @@
         "nixpkgs": "nixpkgs_1533"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36901,11 +36901,11 @@
         "nixpkgs": "nixpkgs_1534"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36919,11 +36919,11 @@
         "nixpkgs": "nixpkgs_1535"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -36937,11 +36937,11 @@
         "nixpkgs": "nixpkgs_1536"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -36955,24 +36955,6 @@
         "nixpkgs": "nixpkgs_1537"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1538": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1538"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -36986,9 +36968,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1539": {
+    "logos-nix_1538": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1539"
+        "nixpkgs": "nixpkgs_1538"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -36996,6 +36978,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1539": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1539"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37027,24 +37027,6 @@
         "nixpkgs": "nixpkgs_1540"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1541": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1541"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -37058,9 +37040,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1542": {
+    "logos-nix_1541": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1542"
+        "nixpkgs": "nixpkgs_1541"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -37068,6 +37050,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1542": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1542"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37099,11 +37099,11 @@
         "nixpkgs": "nixpkgs_1544"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37117,11 +37117,11 @@
         "nixpkgs": "nixpkgs_1545"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37189,11 +37189,11 @@
         "nixpkgs": "nixpkgs_1549"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37225,11 +37225,11 @@
         "nixpkgs": "nixpkgs_1550"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37243,11 +37243,11 @@
         "nixpkgs": "nixpkgs_1551"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37279,11 +37279,11 @@
         "nixpkgs": "nixpkgs_1553"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37369,11 +37369,11 @@
         "nixpkgs": "nixpkgs_1558"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37387,11 +37387,11 @@
         "nixpkgs": "nixpkgs_1559"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37423,11 +37423,11 @@
         "nixpkgs": "nixpkgs_1560"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37459,11 +37459,11 @@
         "nixpkgs": "nixpkgs_1562"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37495,11 +37495,11 @@
         "nixpkgs": "nixpkgs_1564"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37531,11 +37531,11 @@
         "nixpkgs": "nixpkgs_1566"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37567,11 +37567,11 @@
         "nixpkgs": "nixpkgs_1568"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37621,11 +37621,11 @@
         "nixpkgs": "nixpkgs_1570"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37693,11 +37693,11 @@
         "nixpkgs": "nixpkgs_1574"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37711,11 +37711,11 @@
         "nixpkgs": "nixpkgs_1575"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37747,24 +37747,6 @@
         "nixpkgs": "nixpkgs_1577"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1578": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1578"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -37778,9 +37760,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1579": {
+    "logos-nix_1578": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1579"
+        "nixpkgs": "nixpkgs_1578"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -37788,6 +37770,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1579": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1579"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -37837,11 +37837,11 @@
         "nixpkgs": "nixpkgs_1581"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -37927,24 +37927,6 @@
         "nixpkgs": "nixpkgs_1586"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1587": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1587"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -37958,9 +37940,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1588": {
+    "logos-nix_1587": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1588"
+        "nixpkgs": "nixpkgs_1587"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -37968,6 +37950,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1588": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1588"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38017,11 +38017,11 @@
         "nixpkgs": "nixpkgs_1590"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38053,11 +38053,11 @@
         "nixpkgs": "nixpkgs_1592"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38089,11 +38089,11 @@
         "nixpkgs": "nixpkgs_1594"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38125,11 +38125,11 @@
         "nixpkgs": "nixpkgs_1596"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38161,11 +38161,11 @@
         "nixpkgs": "nixpkgs_1598"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38269,11 +38269,11 @@
         "nixpkgs": "nixpkgs_1602"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38287,11 +38287,11 @@
         "nixpkgs": "nixpkgs_1603"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38323,11 +38323,11 @@
         "nixpkgs": "nixpkgs_1605"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38359,11 +38359,11 @@
         "nixpkgs": "nixpkgs_1607"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38377,11 +38377,11 @@
         "nixpkgs": "nixpkgs_1608"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38467,11 +38467,11 @@
         "nixpkgs": "nixpkgs_1612"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38539,11 +38539,11 @@
         "nixpkgs": "nixpkgs_1616"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38575,11 +38575,11 @@
         "nixpkgs": "nixpkgs_1618"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38593,11 +38593,11 @@
         "nixpkgs": "nixpkgs_1619"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38629,11 +38629,11 @@
         "nixpkgs": "nixpkgs_1620"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38647,11 +38647,11 @@
         "nixpkgs": "nixpkgs_1621"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38683,11 +38683,11 @@
         "nixpkgs": "nixpkgs_1623"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38719,11 +38719,11 @@
         "nixpkgs": "nixpkgs_1625"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38755,11 +38755,11 @@
         "nixpkgs": "nixpkgs_1627"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38791,11 +38791,11 @@
         "nixpkgs": "nixpkgs_1629"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38845,11 +38845,11 @@
         "nixpkgs": "nixpkgs_1631"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38917,11 +38917,11 @@
         "nixpkgs": "nixpkgs_1635"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38935,11 +38935,11 @@
         "nixpkgs": "nixpkgs_1636"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -38971,11 +38971,11 @@
         "nixpkgs": "nixpkgs_1638"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38989,11 +38989,11 @@
         "nixpkgs": "nixpkgs_1639"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39025,11 +39025,11 @@
         "nixpkgs": "nixpkgs_1640"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39043,11 +39043,11 @@
         "nixpkgs": "nixpkgs_1641"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39079,11 +39079,11 @@
         "nixpkgs": "nixpkgs_1643"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39097,11 +39097,11 @@
         "nixpkgs": "nixpkgs_1644"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39115,11 +39115,11 @@
         "nixpkgs": "nixpkgs_1645"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39133,11 +39133,11 @@
         "nixpkgs": "nixpkgs_1646"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39151,24 +39151,6 @@
         "nixpkgs": "nixpkgs_1647"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1648": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1648"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -39182,9 +39164,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1649": {
+    "logos-nix_1648": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1649"
+        "nixpkgs": "nixpkgs_1648"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -39192,6 +39174,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1649": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1649"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39277,11 +39277,11 @@
         "nixpkgs": "nixpkgs_1653"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39295,11 +39295,11 @@
         "nixpkgs": "nixpkgs_1654"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39313,11 +39313,11 @@
         "nixpkgs": "nixpkgs_1655"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39331,24 +39331,6 @@
         "nixpkgs": "nixpkgs_1656"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1657": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1657"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -39362,9 +39344,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1658": {
+    "logos-nix_1657": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1658"
+        "nixpkgs": "nixpkgs_1657"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -39372,6 +39354,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1658": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1658"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39457,11 +39457,11 @@
         "nixpkgs": "nixpkgs_1662"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39475,11 +39475,11 @@
         "nixpkgs": "nixpkgs_1663"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39493,11 +39493,11 @@
         "nixpkgs": "nixpkgs_1664"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39511,11 +39511,11 @@
         "nixpkgs": "nixpkgs_1665"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39529,24 +39529,6 @@
         "nixpkgs": "nixpkgs_1666"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1667": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1667"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -39560,9 +39542,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1668": {
+    "logos-nix_1667": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1668"
+        "nixpkgs": "nixpkgs_1667"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -39570,6 +39552,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1668": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1668"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39619,11 +39619,11 @@
         "nixpkgs": "nixpkgs_1670"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39637,11 +39637,11 @@
         "nixpkgs": "nixpkgs_1671"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39709,24 +39709,6 @@
         "nixpkgs": "nixpkgs_1675"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1676": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1676"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -39740,9 +39722,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1677": {
+    "logos-nix_1676": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1677"
+        "nixpkgs": "nixpkgs_1676"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -39750,6 +39732,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1677": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1677"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39781,11 +39781,11 @@
         "nixpkgs": "nixpkgs_1679"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -39889,24 +39889,6 @@
         "nixpkgs": "nixpkgs_1684"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1685": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1685"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -39920,9 +39902,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1686": {
+    "logos-nix_1685": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1686"
+        "nixpkgs": "nixpkgs_1685"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -39930,6 +39912,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1686": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1686"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -39961,11 +39961,11 @@
         "nixpkgs": "nixpkgs_1688"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40015,11 +40015,11 @@
         "nixpkgs": "nixpkgs_1690"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40051,11 +40051,11 @@
         "nixpkgs": "nixpkgs_1692"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40087,11 +40087,11 @@
         "nixpkgs": "nixpkgs_1694"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40123,11 +40123,11 @@
         "nixpkgs": "nixpkgs_1696"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40231,11 +40231,11 @@
         "nixpkgs": "nixpkgs_1700"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40249,11 +40249,11 @@
         "nixpkgs": "nixpkgs_1701"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40285,11 +40285,11 @@
         "nixpkgs": "nixpkgs_1703"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40303,11 +40303,11 @@
         "nixpkgs": "nixpkgs_1704"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40321,11 +40321,11 @@
         "nixpkgs": "nixpkgs_1705"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40339,11 +40339,11 @@
         "nixpkgs": "nixpkgs_1706"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40357,24 +40357,6 @@
         "nixpkgs": "nixpkgs_1707"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1708": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1708"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -40388,9 +40370,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1709": {
+    "logos-nix_1708": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1709"
+        "nixpkgs": "nixpkgs_1708"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -40398,6 +40380,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1709": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1709"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40429,24 +40429,6 @@
         "nixpkgs": "nixpkgs_1710"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1711": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1711"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -40460,9 +40442,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1712": {
+    "logos-nix_1711": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1712"
+        "nixpkgs": "nixpkgs_1711"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -40470,6 +40452,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1712": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1712"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40501,11 +40501,11 @@
         "nixpkgs": "nixpkgs_1714"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40519,11 +40519,11 @@
         "nixpkgs": "nixpkgs_1715"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40591,11 +40591,11 @@
         "nixpkgs": "nixpkgs_1719"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40627,11 +40627,11 @@
         "nixpkgs": "nixpkgs_1720"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40645,11 +40645,11 @@
         "nixpkgs": "nixpkgs_1721"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40681,11 +40681,11 @@
         "nixpkgs": "nixpkgs_1723"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40771,11 +40771,11 @@
         "nixpkgs": "nixpkgs_1728"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40789,11 +40789,11 @@
         "nixpkgs": "nixpkgs_1729"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40825,11 +40825,11 @@
         "nixpkgs": "nixpkgs_1730"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40861,11 +40861,11 @@
         "nixpkgs": "nixpkgs_1732"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40897,11 +40897,11 @@
         "nixpkgs": "nixpkgs_1734"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -40933,11 +40933,11 @@
         "nixpkgs": "nixpkgs_1736"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -40969,11 +40969,11 @@
         "nixpkgs": "nixpkgs_1738"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41023,11 +41023,11 @@
         "nixpkgs": "nixpkgs_1740"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41095,11 +41095,11 @@
         "nixpkgs": "nixpkgs_1744"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41113,11 +41113,11 @@
         "nixpkgs": "nixpkgs_1745"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41149,24 +41149,6 @@
         "nixpkgs": "nixpkgs_1747"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1748": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1748"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -41180,9 +41162,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1749": {
+    "logos-nix_1748": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1749"
+        "nixpkgs": "nixpkgs_1748"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -41190,6 +41172,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1749": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1749"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41239,11 +41239,11 @@
         "nixpkgs": "nixpkgs_1751"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41329,24 +41329,6 @@
         "nixpkgs": "nixpkgs_1756"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1757": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1757"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -41360,9 +41342,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1758": {
+    "logos-nix_1757": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1758"
+        "nixpkgs": "nixpkgs_1757"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -41370,6 +41352,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1758": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1758"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41419,11 +41419,11 @@
         "nixpkgs": "nixpkgs_1760"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41455,11 +41455,11 @@
         "nixpkgs": "nixpkgs_1762"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41491,11 +41491,11 @@
         "nixpkgs": "nixpkgs_1764"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41527,11 +41527,11 @@
         "nixpkgs": "nixpkgs_1766"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41563,11 +41563,11 @@
         "nixpkgs": "nixpkgs_1768"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41653,11 +41653,11 @@
         "nixpkgs": "nixpkgs_1772"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41671,11 +41671,11 @@
         "nixpkgs": "nixpkgs_1773"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41707,24 +41707,6 @@
         "nixpkgs": "nixpkgs_1775"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1776": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1776"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -41738,9 +41720,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1777": {
+    "logos-nix_1776": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1777"
+        "nixpkgs": "nixpkgs_1776"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -41748,6 +41730,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1777": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1777"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41815,11 +41815,11 @@
         "nixpkgs": "nixpkgs_1780"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41833,11 +41833,11 @@
         "nixpkgs": "nixpkgs_1781"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41905,11 +41905,11 @@
         "nixpkgs": "nixpkgs_1785"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -41923,11 +41923,11 @@
         "nixpkgs": "nixpkgs_1786"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -41941,24 +41941,6 @@
         "nixpkgs": "nixpkgs_1787"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1788": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1788"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -41972,9 +41954,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1789": {
+    "logos-nix_1788": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1789"
+        "nixpkgs": "nixpkgs_1788"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -41982,6 +41964,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1789": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1789"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42013,11 +42013,11 @@
         "nixpkgs": "nixpkgs_1790"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42049,11 +42049,11 @@
         "nixpkgs": "nixpkgs_1792"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42067,11 +42067,11 @@
         "nixpkgs": "nixpkgs_1793"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42085,11 +42085,11 @@
         "nixpkgs": "nixpkgs_1794"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42103,11 +42103,11 @@
         "nixpkgs": "nixpkgs_1795"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42121,24 +42121,6 @@
         "nixpkgs": "nixpkgs_1796"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1797": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1797"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -42152,9 +42134,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1798": {
+    "logos-nix_1797": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1798"
+        "nixpkgs": "nixpkgs_1797"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -42162,6 +42144,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1798": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1798"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42229,11 +42229,11 @@
         "nixpkgs": "nixpkgs_1800"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42247,11 +42247,11 @@
         "nixpkgs": "nixpkgs_1801"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42319,24 +42319,6 @@
         "nixpkgs": "nixpkgs_1805"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1806": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1806"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -42350,9 +42332,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1807": {
+    "logos-nix_1806": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1807"
+        "nixpkgs": "nixpkgs_1806"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -42360,6 +42342,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1807": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1807"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42391,11 +42391,11 @@
         "nixpkgs": "nixpkgs_1809"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42499,24 +42499,6 @@
         "nixpkgs": "nixpkgs_1814"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1815": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1815"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -42530,9 +42512,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1816": {
+    "logos-nix_1815": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1816"
+        "nixpkgs": "nixpkgs_1815"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -42540,6 +42522,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1816": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1816"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42571,11 +42571,11 @@
         "nixpkgs": "nixpkgs_1818"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42625,11 +42625,11 @@
         "nixpkgs": "nixpkgs_1820"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42661,11 +42661,11 @@
         "nixpkgs": "nixpkgs_1822"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42697,11 +42697,11 @@
         "nixpkgs": "nixpkgs_1824"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42733,11 +42733,11 @@
         "nixpkgs": "nixpkgs_1826"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42823,11 +42823,11 @@
         "nixpkgs": "nixpkgs_1830"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42841,11 +42841,11 @@
         "nixpkgs": "nixpkgs_1831"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42877,11 +42877,11 @@
         "nixpkgs": "nixpkgs_1833"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42895,11 +42895,11 @@
         "nixpkgs": "nixpkgs_1834"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42913,11 +42913,11 @@
         "nixpkgs": "nixpkgs_1835"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -42931,11 +42931,11 @@
         "nixpkgs": "nixpkgs_1836"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -42949,24 +42949,6 @@
         "nixpkgs": "nixpkgs_1837"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1838": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1838"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -42980,9 +42962,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1839": {
+    "logos-nix_1838": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1839"
+        "nixpkgs": "nixpkgs_1838"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -42990,6 +42972,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1839": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1839"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43021,24 +43021,6 @@
         "nixpkgs": "nixpkgs_1840"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1841": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1841"
-      },
-      "locked": {
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -43052,9 +43034,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1842": {
+    "logos-nix_1841": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1842"
+        "nixpkgs": "nixpkgs_1841"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -43062,6 +43044,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1842": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1842"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43093,11 +43093,11 @@
         "nixpkgs": "nixpkgs_1844"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43111,11 +43111,11 @@
         "nixpkgs": "nixpkgs_1845"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43183,11 +43183,11 @@
         "nixpkgs": "nixpkgs_1849"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43219,11 +43219,11 @@
         "nixpkgs": "nixpkgs_1850"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43237,11 +43237,11 @@
         "nixpkgs": "nixpkgs_1851"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43273,11 +43273,11 @@
         "nixpkgs": "nixpkgs_1853"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43363,11 +43363,11 @@
         "nixpkgs": "nixpkgs_1858"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43381,11 +43381,11 @@
         "nixpkgs": "nixpkgs_1859"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43417,11 +43417,11 @@
         "nixpkgs": "nixpkgs_1860"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43453,11 +43453,11 @@
         "nixpkgs": "nixpkgs_1862"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43489,11 +43489,11 @@
         "nixpkgs": "nixpkgs_1864"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43525,11 +43525,11 @@
         "nixpkgs": "nixpkgs_1866"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43561,11 +43561,11 @@
         "nixpkgs": "nixpkgs_1868"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43615,11 +43615,11 @@
         "nixpkgs": "nixpkgs_1870"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43687,11 +43687,11 @@
         "nixpkgs": "nixpkgs_1874"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43705,11 +43705,11 @@
         "nixpkgs": "nixpkgs_1875"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43741,24 +43741,6 @@
         "nixpkgs": "nixpkgs_1877"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1878": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1878"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -43772,9 +43754,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1879": {
+    "logos-nix_1878": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1879"
+        "nixpkgs": "nixpkgs_1878"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -43782,6 +43764,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1879": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1879"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -43831,11 +43831,11 @@
         "nixpkgs": "nixpkgs_1881"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -43921,24 +43921,6 @@
         "nixpkgs": "nixpkgs_1886"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_1887": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_1887"
-      },
-      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -43952,9 +43934,9 @@
         "type": "github"
       }
     },
-    "logos-nix_1888": {
+    "logos-nix_1887": {
       "inputs": {
-        "nixpkgs": "nixpkgs_1888"
+        "nixpkgs": "nixpkgs_1887"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -43962,6 +43944,24 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1888": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1888"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44011,11 +44011,11 @@
         "nixpkgs": "nixpkgs_1890"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44047,11 +44047,11 @@
         "nixpkgs": "nixpkgs_1892"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44083,11 +44083,11 @@
         "nixpkgs": "nixpkgs_1894"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44119,11 +44119,11 @@
         "nixpkgs": "nixpkgs_1896"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44155,11 +44155,11 @@
         "nixpkgs": "nixpkgs_1898"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44263,11 +44263,11 @@
         "nixpkgs": "nixpkgs_1902"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44281,11 +44281,11 @@
         "nixpkgs": "nixpkgs_1903"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44317,11 +44317,11 @@
         "nixpkgs": "nixpkgs_1905"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44353,11 +44353,11 @@
         "nixpkgs": "nixpkgs_1907"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44371,11 +44371,11 @@
         "nixpkgs": "nixpkgs_1908"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44461,11 +44461,11 @@
         "nixpkgs": "nixpkgs_1912"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44533,11 +44533,11 @@
         "nixpkgs": "nixpkgs_1916"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44569,11 +44569,11 @@
         "nixpkgs": "nixpkgs_1918"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44587,11 +44587,11 @@
         "nixpkgs": "nixpkgs_1919"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44623,11 +44623,11 @@
         "nixpkgs": "nixpkgs_1920"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44641,11 +44641,11 @@
         "nixpkgs": "nixpkgs_1921"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44677,11 +44677,11 @@
         "nixpkgs": "nixpkgs_1923"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44713,11 +44713,11 @@
         "nixpkgs": "nixpkgs_1925"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44749,11 +44749,11 @@
         "nixpkgs": "nixpkgs_1927"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44785,11 +44785,11 @@
         "nixpkgs": "nixpkgs_1929"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44839,11 +44839,11 @@
         "nixpkgs": "nixpkgs_1931"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44911,11 +44911,11 @@
         "nixpkgs": "nixpkgs_1935"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44929,11 +44929,11 @@
         "nixpkgs": "nixpkgs_1936"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -44965,11 +44965,11 @@
         "nixpkgs": "nixpkgs_1938"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -44983,11 +44983,11 @@
         "nixpkgs": "nixpkgs_1939"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -45091,11 +45091,11 @@
         "nixpkgs": "nixpkgs_1944"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -45127,11 +45127,11 @@
         "nixpkgs": "nixpkgs_1946"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -45163,11 +45163,11 @@
         "nixpkgs": "nixpkgs_1948"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -45217,11 +45217,11 @@
         "nixpkgs": "nixpkgs_1950"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -45289,11 +45289,11 @@
         "nixpkgs": "nixpkgs_1954"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -45307,11 +45307,11 @@
         "nixpkgs": "nixpkgs_1955"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -45341,6 +45341,24 @@
     "logos-nix_1957": {
       "inputs": {
         "nixpkgs": "nixpkgs_1957"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_1958": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_1958"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -61460,11 +61478,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782484430,
-        "narHash": "sha256-gm+SLNULJn1BHMKOP0aOFkX6T/I20ZlzzatB/OhM6AI=",
+        "lastModified": 1784207645,
+        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "1e843e72bd7debedc2fd5a295684574189231df7",
+        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
         "type": "github"
       },
       "original": {
@@ -61479,11 +61497,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1782499393,
-        "narHash": "sha256-WcLd0zCD/R9zG7EKpFXPXhuuyldufycsd62WhoUYluI=",
+        "lastModified": 1784209035,
+        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "e6289af5ef9dc3ff27752b4475708ccc8d865261",
+        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
         "type": "github"
       },
       "original": {
@@ -61494,8 +61512,8 @@
     },
     "logos-package-downloader_2": {
       "inputs": {
-        "logos-nix": "logos-nix_1638",
-        "logos-package": "logos-package_196",
+        "logos-nix": "logos-nix_1639",
+        "logos-package": "logos-package_197",
         "nix-bundle-appimage": "nix-bundle-appimage_81",
         "nix-bundle-dir": "nix-bundle-dir_276",
         "nixpkgs": [
@@ -61507,11 +61525,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782484430,
-        "narHash": "sha256-gm+SLNULJn1BHMKOP0aOFkX6T/I20ZlzzatB/OhM6AI=",
+        "lastModified": 1784207645,
+        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "1e843e72bd7debedc2fd5a295684574189231df7",
+        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
         "type": "github"
       },
       "original": {
@@ -61562,11 +61580,11 @@
         "logos-package-manager": "logos-package-manager_51"
       },
       "locked": {
-        "lastModified": 1782499400,
-        "narHash": "sha256-JTA3QDUXFNPLgJkKPc4huWzQxTb5eZcVew31pljXKv8=",
+        "lastModified": 1784208334,
+        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "128f543564acdb09ebf4c27574eca5ba88e2297e",
+        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
         "type": "github"
       },
       "original": {
@@ -61578,15 +61596,16 @@
     "logos-package-manager-ui": {
       "inputs": {
         "logos-module-builder": "logos-module-builder_25",
+        "logos-package": "logos-package_161",
         "package_downloader": "package_downloader",
         "package_manager": "package_manager"
       },
       "locked": {
-        "lastModified": 1782502279,
-        "narHash": "sha256-fM7nSX+pUrRP0Qwgr4a9kZ235gN4xNJHEyOM21gwQBo=",
+        "lastModified": 1784209970,
+        "narHash": "sha256-dKtBwEpFOuAVqzmsqqb7szkEyhtIPI38qAJdvRbyi00=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "bb9d016350b9c5b191d3d596600f160c8d0d01e1",
+        "rev": "33f5ba06dff624c722083711e48aeed6cb2ad4b4",
         "type": "github"
       },
       "original": {
@@ -62550,11 +62569,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782500909,
-        "narHash": "sha256-NMhvbYnDc/NhykUtgQTySC7BmXujDjdM9BK3wTZ+c8o=",
+        "lastModified": 1784207525,
+        "narHash": "sha256-D1sVtUEcHjqUyYV0qEP+ORo4g7mzThz0cuHw+Taiwyg=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "205d6bb295c43e9432aef367dd32dac82e39bddf",
+        "rev": "202af6fa0f0f4493bc59c8a609dff9326f78a18d",
         "type": "github"
       },
       "original": {
@@ -63129,11 +63148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134133,
-        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
+        "lastModified": 1784207525,
+        "narHash": "sha256-D1sVtUEcHjqUyYV0qEP+ORo4g7mzThz0cuHw+Taiwyg=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
+        "rev": "202af6fa0f0f4493bc59c8a609dff9326f78a18d",
         "type": "github"
       },
       "original": {
@@ -63659,8 +63678,8 @@
     },
     "logos-package-manager_66": {
       "inputs": {
-        "logos-nix": "logos-nix_1378",
-        "logos-package": "logos-package_161",
+        "logos-nix": "logos-nix_1379",
+        "logos-package": "logos-package_162",
         "nix-bundle-appimage": "nix-bundle-appimage_67",
         "nix-bundle-dir": "nix-bundle-dir_227",
         "nixpkgs": [
@@ -63696,8 +63715,8 @@
     },
     "logos-package-manager_67": {
       "inputs": {
-        "logos-nix": "logos-nix_1395",
-        "logos-package": "logos-package_164",
+        "logos-nix": "logos-nix_1396",
+        "logos-package": "logos-package_165",
         "nix-bundle-appimage": "nix-bundle-appimage_68",
         "nix-bundle-dir": "nix-bundle-dir_231",
         "nixpkgs": [
@@ -63732,8 +63751,8 @@
     },
     "logos-package-manager_68": {
       "inputs": {
-        "logos-nix": "logos-nix_1422",
-        "logos-package": "logos-package_166",
+        "logos-nix": "logos-nix_1423",
+        "logos-package": "logos-package_167",
         "nix-bundle-appimage": "nix-bundle-appimage_69",
         "nix-bundle-dir": "nix-bundle-dir_234",
         "nixpkgs": [
@@ -63770,8 +63789,8 @@
     },
     "logos-package-manager_69": {
       "inputs": {
-        "logos-nix": "logos-nix_1439",
-        "logos-package": "logos-package_169",
+        "logos-nix": "logos-nix_1440",
+        "logos-package": "logos-package_170",
         "nix-bundle-appimage": "nix-bundle-appimage_70",
         "nix-bundle-dir": "nix-bundle-dir_238",
         "nixpkgs": [
@@ -63844,8 +63863,8 @@
     },
     "logos-package-manager_70": {
       "inputs": {
-        "logos-nix": "logos-nix_1450",
-        "logos-package": "logos-package_171",
+        "logos-nix": "logos-nix_1451",
+        "logos-package": "logos-package_172",
         "nix-bundle-appimage": "nix-bundle-appimage_71",
         "nix-bundle-dir": "nix-bundle-dir_241",
         "nixpkgs": [
@@ -63878,8 +63897,8 @@
     },
     "logos-package-manager_71": {
       "inputs": {
-        "logos-nix": "logos-nix_1467",
-        "logos-package": "logos-package_174",
+        "logos-nix": "logos-nix_1468",
+        "logos-package": "logos-package_175",
         "nix-bundle-appimage": "nix-bundle-appimage_72",
         "nix-bundle-dir": "nix-bundle-dir_245",
         "nixpkgs": [
@@ -63911,8 +63930,8 @@
     },
     "logos-package-manager_72": {
       "inputs": {
-        "logos-nix": "logos-nix_1508",
-        "logos-package": "logos-package_176",
+        "logos-nix": "logos-nix_1509",
+        "logos-package": "logos-package_177",
         "nix-bundle-appimage": "nix-bundle-appimage_73",
         "nix-bundle-dir": "nix-bundle-dir_248",
         "nixpkgs": [
@@ -63949,8 +63968,8 @@
     },
     "logos-package-manager_73": {
       "inputs": {
-        "logos-nix": "logos-nix_1525",
-        "logos-package": "logos-package_179",
+        "logos-nix": "logos-nix_1526",
+        "logos-package": "logos-package_180",
         "nix-bundle-appimage": "nix-bundle-appimage_74",
         "nix-bundle-dir": "nix-bundle-dir_252",
         "nixpkgs": [
@@ -63986,8 +64005,8 @@
     },
     "logos-package-manager_74": {
       "inputs": {
-        "logos-nix": "logos-nix_1552",
-        "logos-package": "logos-package_181",
+        "logos-nix": "logos-nix_1553",
+        "logos-package": "logos-package_182",
         "nix-bundle-appimage": "nix-bundle-appimage_75",
         "nix-bundle-dir": "nix-bundle-dir_255",
         "nixpkgs": [
@@ -64025,8 +64044,8 @@
     },
     "logos-package-manager_75": {
       "inputs": {
-        "logos-nix": "logos-nix_1569",
-        "logos-package": "logos-package_184",
+        "logos-nix": "logos-nix_1570",
+        "logos-package": "logos-package_185",
         "nix-bundle-appimage": "nix-bundle-appimage_76",
         "nix-bundle-dir": "nix-bundle-dir_259",
         "nixpkgs": [
@@ -64063,8 +64082,8 @@
     },
     "logos-package-manager_76": {
       "inputs": {
-        "logos-nix": "logos-nix_1580",
-        "logos-package": "logos-package_186",
+        "logos-nix": "logos-nix_1581",
+        "logos-package": "logos-package_187",
         "nix-bundle-appimage": "nix-bundle-appimage_77",
         "nix-bundle-dir": "nix-bundle-dir_262",
         "nixpkgs": [
@@ -64098,8 +64117,8 @@
     },
     "logos-package-manager_77": {
       "inputs": {
-        "logos-nix": "logos-nix_1597",
-        "logos-package": "logos-package_189",
+        "logos-nix": "logos-nix_1598",
+        "logos-package": "logos-package_190",
         "nix-bundle-appimage": "nix-bundle-appimage_78",
         "nix-bundle-dir": "nix-bundle-dir_266",
         "nixpkgs": [
@@ -64132,8 +64151,8 @@
     },
     "logos-package-manager_78": {
       "inputs": {
-        "logos-nix": "logos-nix_1611",
-        "logos-package": "logos-package_191",
+        "logos-nix": "logos-nix_1612",
+        "logos-package": "logos-package_192",
         "nix-bundle-appimage": "nix-bundle-appimage_79",
         "nix-bundle-dir": "nix-bundle-dir_269",
         "nixpkgs": [
@@ -64163,8 +64182,8 @@
     },
     "logos-package-manager_79": {
       "inputs": {
-        "logos-nix": "logos-nix_1630",
-        "logos-package": "logos-package_194",
+        "logos-nix": "logos-nix_1631",
+        "logos-package": "logos-package_195",
         "nix-bundle-appimage": "nix-bundle-appimage_80",
         "nix-bundle-dir": "nix-bundle-dir_273",
         "nixpkgs": [
@@ -64229,8 +64248,8 @@
     },
     "logos-package-manager_80": {
       "inputs": {
-        "logos-nix": "logos-nix_1678",
-        "logos-package": "logos-package_197",
+        "logos-nix": "logos-nix_1679",
+        "logos-package": "logos-package_198",
         "nix-bundle-appimage": "nix-bundle-appimage_82",
         "nix-bundle-dir": "nix-bundle-dir_278",
         "nixpkgs": [
@@ -64266,8 +64285,8 @@
     },
     "logos-package-manager_81": {
       "inputs": {
-        "logos-nix": "logos-nix_1695",
-        "logos-package": "logos-package_200",
+        "logos-nix": "logos-nix_1696",
+        "logos-package": "logos-package_201",
         "nix-bundle-appimage": "nix-bundle-appimage_83",
         "nix-bundle-dir": "nix-bundle-dir_282",
         "nixpkgs": [
@@ -64302,8 +64321,8 @@
     },
     "logos-package-manager_82": {
       "inputs": {
-        "logos-nix": "logos-nix_1722",
-        "logos-package": "logos-package_202",
+        "logos-nix": "logos-nix_1723",
+        "logos-package": "logos-package_203",
         "nix-bundle-appimage": "nix-bundle-appimage_84",
         "nix-bundle-dir": "nix-bundle-dir_285",
         "nixpkgs": [
@@ -64340,8 +64359,8 @@
     },
     "logos-package-manager_83": {
       "inputs": {
-        "logos-nix": "logos-nix_1739",
-        "logos-package": "logos-package_205",
+        "logos-nix": "logos-nix_1740",
+        "logos-package": "logos-package_206",
         "nix-bundle-appimage": "nix-bundle-appimage_85",
         "nix-bundle-dir": "nix-bundle-dir_289",
         "nixpkgs": [
@@ -64377,8 +64396,8 @@
     },
     "logos-package-manager_84": {
       "inputs": {
-        "logos-nix": "logos-nix_1750",
-        "logos-package": "logos-package_207",
+        "logos-nix": "logos-nix_1751",
+        "logos-package": "logos-package_208",
         "nix-bundle-appimage": "nix-bundle-appimage_86",
         "nix-bundle-dir": "nix-bundle-dir_292",
         "nixpkgs": [
@@ -64411,8 +64430,8 @@
     },
     "logos-package-manager_85": {
       "inputs": {
-        "logos-nix": "logos-nix_1767",
-        "logos-package": "logos-package_210",
+        "logos-nix": "logos-nix_1768",
+        "logos-package": "logos-package_211",
         "nix-bundle-appimage": "nix-bundle-appimage_87",
         "nix-bundle-dir": "nix-bundle-dir_296",
         "nixpkgs": [
@@ -64444,8 +64463,8 @@
     },
     "logos-package-manager_86": {
       "inputs": {
-        "logos-nix": "logos-nix_1808",
-        "logos-package": "logos-package_212",
+        "logos-nix": "logos-nix_1809",
+        "logos-package": "logos-package_213",
         "nix-bundle-appimage": "nix-bundle-appimage_88",
         "nix-bundle-dir": "nix-bundle-dir_299",
         "nixpkgs": [
@@ -64482,8 +64501,8 @@
     },
     "logos-package-manager_87": {
       "inputs": {
-        "logos-nix": "logos-nix_1825",
-        "logos-package": "logos-package_215",
+        "logos-nix": "logos-nix_1826",
+        "logos-package": "logos-package_216",
         "nix-bundle-appimage": "nix-bundle-appimage_89",
         "nix-bundle-dir": "nix-bundle-dir_303",
         "nixpkgs": [
@@ -64519,8 +64538,8 @@
     },
     "logos-package-manager_88": {
       "inputs": {
-        "logos-nix": "logos-nix_1852",
-        "logos-package": "logos-package_217",
+        "logos-nix": "logos-nix_1853",
+        "logos-package": "logos-package_218",
         "nix-bundle-appimage": "nix-bundle-appimage_90",
         "nix-bundle-dir": "nix-bundle-dir_306",
         "nixpkgs": [
@@ -64558,8 +64577,8 @@
     },
     "logos-package-manager_89": {
       "inputs": {
-        "logos-nix": "logos-nix_1869",
-        "logos-package": "logos-package_220",
+        "logos-nix": "logos-nix_1870",
+        "logos-package": "logos-package_221",
         "nix-bundle-appimage": "nix-bundle-appimage_91",
         "nix-bundle-dir": "nix-bundle-dir_310",
         "nixpkgs": [
@@ -64634,8 +64653,8 @@
     },
     "logos-package-manager_90": {
       "inputs": {
-        "logos-nix": "logos-nix_1880",
-        "logos-package": "logos-package_222",
+        "logos-nix": "logos-nix_1881",
+        "logos-package": "logos-package_223",
         "nix-bundle-appimage": "nix-bundle-appimage_92",
         "nix-bundle-dir": "nix-bundle-dir_313",
         "nixpkgs": [
@@ -64669,8 +64688,8 @@
     },
     "logos-package-manager_91": {
       "inputs": {
-        "logos-nix": "logos-nix_1897",
-        "logos-package": "logos-package_225",
+        "logos-nix": "logos-nix_1898",
+        "logos-package": "logos-package_226",
         "nix-bundle-appimage": "nix-bundle-appimage_93",
         "nix-bundle-dir": "nix-bundle-dir_317",
         "nixpkgs": [
@@ -64703,8 +64722,8 @@
     },
     "logos-package-manager_92": {
       "inputs": {
-        "logos-nix": "logos-nix_1911",
-        "logos-package": "logos-package_227",
+        "logos-nix": "logos-nix_1912",
+        "logos-package": "logos-package_228",
         "nix-bundle-appimage": "nix-bundle-appimage_94",
         "nix-bundle-dir": "nix-bundle-dir_320",
         "nixpkgs": [
@@ -64734,8 +64753,8 @@
     },
     "logos-package-manager_93": {
       "inputs": {
-        "logos-nix": "logos-nix_1930",
-        "logos-package": "logos-package_230",
+        "logos-nix": "logos-nix_1931",
+        "logos-package": "logos-package_231",
         "nix-bundle-appimage": "nix-bundle-appimage_95",
         "nix-bundle-dir": "nix-bundle-dir_324",
         "nixpkgs": [
@@ -64764,8 +64783,8 @@
     },
     "logos-package-manager_94": {
       "inputs": {
-        "logos-nix": "logos-nix_1938",
-        "logos-package": "logos-package_232",
+        "logos-nix": "logos-nix_1939",
+        "logos-package": "logos-package_233",
         "nix-bundle-appimage": "nix-bundle-appimage_96",
         "nix-bundle-dir": "nix-bundle-dir_327",
         "nixpkgs": [
@@ -64777,11 +64796,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782134133,
-        "narHash": "sha256-65w2mEijAjUPVntS3kUKZygjRkZoj7dgCYtk8lD5jL8=",
+        "lastModified": 1784207525,
+        "narHash": "sha256-D1sVtUEcHjqUyYV0qEP+ORo4g7mzThz0cuHw+Taiwyg=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "4871ed198d6e35f198af15c93afd184aa36788e0",
+        "rev": "202af6fa0f0f4493bc59c8a609dff9326f78a18d",
         "type": "github"
       },
       "original": {
@@ -64792,8 +64811,8 @@
     },
     "logos-package-manager_95": {
       "inputs": {
-        "logos-nix": "logos-nix_1949",
-        "logos-package": "logos-package_233",
+        "logos-nix": "logos-nix_1950",
+        "logos-package": "logos-package_234",
         "nix-bundle-appimage": "nix-bundle-appimage_98",
         "nix-bundle-dir": "nix-bundle-dir_331",
         "nixpkgs": [
@@ -65709,11 +65728,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -66968,7 +66987,31 @@
     },
     "logos-package_161": {
       "inputs": {
-        "logos-nix": "logos-nix_1379",
+        "logos-nix": "logos-nix_1343",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_162": {
+      "inputs": {
+        "logos-nix": "logos-nix_1380",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67001,43 +67044,9 @@
         "type": "github"
       }
     },
-    "logos-package_162": {
-      "inputs": {
-        "logos-nix": "logos-nix_1388",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_163": {
       "inputs": {
-        "logos-nix": "logos-nix_1392",
+        "logos-nix": "logos-nix_1389",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67048,6 +67057,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -67070,7 +67080,40 @@
     },
     "logos-package_164": {
       "inputs": {
-        "logos-nix": "logos-nix_1396",
+        "logos-nix": "logos-nix_1393",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_165": {
+      "inputs": {
+        "logos-nix": "logos-nix_1397",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67083,40 +67126,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_165": {
-      "inputs": {
-        "logos-nix": "logos-nix_1401",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -67138,7 +67147,41 @@
     },
     "logos-package_166": {
       "inputs": {
-        "logos-nix": "logos-nix_1423",
+        "logos-nix": "logos-nix_1402",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_167": {
+      "inputs": {
+        "logos-nix": "logos-nix_1424",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67172,44 +67215,9 @@
         "type": "github"
       }
     },
-    "logos-package_167": {
-      "inputs": {
-        "logos-nix": "logos-nix_1432",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_168": {
       "inputs": {
-        "logos-nix": "logos-nix_1436",
+        "logos-nix": "logos-nix_1433",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67221,6 +67229,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -67243,7 +67252,7 @@
     },
     "logos-package_169": {
       "inputs": {
-        "logos-nix": "logos-nix_1440",
+        "logos-nix": "logos-nix_1437",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67255,19 +67264,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -67312,7 +67320,42 @@
     },
     "logos-package_170": {
       "inputs": {
-        "logos-nix": "logos-nix_1445",
+        "logos-nix": "logos-nix_1441",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_171": {
+      "inputs": {
+        "logos-nix": "logos-nix_1446",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67345,9 +67388,9 @@
         "type": "github"
       }
     },
-    "logos-package_171": {
+    "logos-package_172": {
       "inputs": {
-        "logos-nix": "logos-nix_1451",
+        "logos-nix": "logos-nix_1452",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67377,9 +67420,9 @@
         "type": "github"
       }
     },
-    "logos-package_172": {
+    "logos-package_173": {
       "inputs": {
-        "logos-nix": "logos-nix_1460",
+        "logos-nix": "logos-nix_1461",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67408,9 +67451,9 @@
         "type": "github"
       }
     },
-    "logos-package_173": {
+    "logos-package_174": {
       "inputs": {
-        "logos-nix": "logos-nix_1464",
+        "logos-nix": "logos-nix_1465",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67438,9 +67481,9 @@
         "type": "github"
       }
     },
-    "logos-package_174": {
+    "logos-package_175": {
       "inputs": {
-        "logos-nix": "logos-nix_1468",
+        "logos-nix": "logos-nix_1469",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67450,37 +67493,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_175": {
-      "inputs": {
-        "logos-nix": "logos-nix_1473",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -67502,7 +67514,38 @@
     },
     "logos-package_176": {
       "inputs": {
-        "logos-nix": "logos-nix_1509",
+        "logos-nix": "logos-nix_1474",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_177": {
+      "inputs": {
+        "logos-nix": "logos-nix_1510",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67536,44 +67579,9 @@
         "type": "github"
       }
     },
-    "logos-package_177": {
-      "inputs": {
-        "logos-nix": "logos-nix_1518",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_178": {
       "inputs": {
-        "logos-nix": "logos-nix_1522",
+        "logos-nix": "logos-nix_1519",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67585,6 +67593,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -67607,7 +67616,7 @@
     },
     "logos-package_179": {
       "inputs": {
-        "logos-nix": "logos-nix_1526",
+        "logos-nix": "logos-nix_1523",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67619,19 +67628,18 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -67675,7 +67683,42 @@
     },
     "logos-package_180": {
       "inputs": {
-        "logos-nix": "logos-nix_1531",
+        "logos-nix": "logos-nix_1527",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_181": {
+      "inputs": {
+        "logos-nix": "logos-nix_1532",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67708,9 +67751,9 @@
         "type": "github"
       }
     },
-    "logos-package_181": {
+    "logos-package_182": {
       "inputs": {
-        "logos-nix": "logos-nix_1553",
+        "logos-nix": "logos-nix_1554",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67745,45 +67788,9 @@
         "type": "github"
       }
     },
-    "logos-package_182": {
-      "inputs": {
-        "logos-nix": "logos-nix_1562",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_183": {
       "inputs": {
-        "logos-nix": "logos-nix_1566",
+        "logos-nix": "logos-nix_1563",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67796,6 +67803,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -67818,7 +67826,42 @@
     },
     "logos-package_184": {
       "inputs": {
-        "logos-nix": "logos-nix_1570",
+        "logos-nix": "logos-nix_1567",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_185": {
+      "inputs": {
+        "logos-nix": "logos-nix_1571",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67833,42 +67876,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_185": {
-      "inputs": {
-        "logos-nix": "logos-nix_1575",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -67890,7 +67897,43 @@
     },
     "logos-package_186": {
       "inputs": {
-        "logos-nix": "logos-nix_1581",
+        "logos-nix": "logos-nix_1576",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_187": {
+      "inputs": {
+        "logos-nix": "logos-nix_1582",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67921,41 +67964,9 @@
         "type": "github"
       }
     },
-    "logos-package_187": {
-      "inputs": {
-        "logos-nix": "logos-nix_1590",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_188": {
       "inputs": {
-        "logos-nix": "logos-nix_1594",
+        "logos-nix": "logos-nix_1591",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67964,6 +67975,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -67986,7 +67998,7 @@
     },
     "logos-package_189": {
       "inputs": {
-        "logos-nix": "logos-nix_1598",
+        "logos-nix": "logos-nix_1595",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -67995,19 +68007,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
         "type": "github"
       },
       "original": {
@@ -68052,7 +68063,7 @@
     },
     "logos-package_190": {
       "inputs": {
-        "logos-nix": "logos-nix_1603",
+        "logos-nix": "logos-nix_1599",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68062,7 +68073,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -68084,7 +68095,39 @@
     },
     "logos-package_191": {
       "inputs": {
-        "logos-nix": "logos-nix_1612",
+        "logos-nix": "logos-nix_1604",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_192": {
+      "inputs": {
+        "logos-nix": "logos-nix_1613",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68111,9 +68154,9 @@
         "type": "github"
       }
     },
-    "logos-package_192": {
+    "logos-package_193": {
       "inputs": {
-        "logos-nix": "logos-nix_1623",
+        "logos-nix": "logos-nix_1624",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68139,9 +68182,9 @@
         "type": "github"
       }
     },
-    "logos-package_193": {
+    "logos-package_194": {
       "inputs": {
-        "logos-nix": "logos-nix_1627",
+        "logos-nix": "logos-nix_1628",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68166,9 +68209,9 @@
         "type": "github"
       }
     },
-    "logos-package_194": {
+    "logos-package_195": {
       "inputs": {
-        "logos-nix": "logos-nix_1631",
+        "logos-nix": "logos-nix_1632",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68194,9 +68237,9 @@
         "type": "github"
       }
     },
-    "logos-package_195": {
+    "logos-package_196": {
       "inputs": {
-        "logos-nix": "logos-nix_1636",
+        "logos-nix": "logos-nix_1637",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68222,9 +68265,9 @@
         "type": "github"
       }
     },
-    "logos-package_196": {
+    "logos-package_197": {
       "inputs": {
-        "logos-nix": "logos-nix_1639",
+        "logos-nix": "logos-nix_1640",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -68235,11 +68278,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782153303,
-        "narHash": "sha256-h1ltzc34iMkXduTm/41Tma1chBXZolKJhamUqz1vH6w=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "53336d37e4efb7c8e8243347ab77ab78705214c9",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -68248,9 +68291,9 @@
         "type": "github"
       }
     },
-    "logos-package_197": {
+    "logos-package_198": {
       "inputs": {
-        "logos-nix": "logos-nix_1679",
+        "logos-nix": "logos-nix_1680",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68283,43 +68326,9 @@
         "type": "github"
       }
     },
-    "logos-package_198": {
-      "inputs": {
-        "logos-nix": "logos-nix_1688",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_199": {
       "inputs": {
-        "logos-nix": "logos-nix_1692",
+        "logos-nix": "logos-nix_1689",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68330,6 +68339,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -68419,7 +68429,40 @@
     },
     "logos-package_200": {
       "inputs": {
-        "logos-nix": "logos-nix_1696",
+        "logos-nix": "logos-nix_1693",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_201": {
+      "inputs": {
+        "logos-nix": "logos-nix_1697",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68432,40 +68475,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_201": {
-      "inputs": {
-        "logos-nix": "logos-nix_1701",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -68487,7 +68496,41 @@
     },
     "logos-package_202": {
       "inputs": {
-        "logos-nix": "logos-nix_1723",
+        "logos-nix": "logos-nix_1702",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_203": {
+      "inputs": {
+        "logos-nix": "logos-nix_1724",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68521,44 +68564,9 @@
         "type": "github"
       }
     },
-    "logos-package_203": {
-      "inputs": {
-        "logos-nix": "logos-nix_1732",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_204": {
       "inputs": {
-        "logos-nix": "logos-nix_1736",
+        "logos-nix": "logos-nix_1733",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68570,6 +68578,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -68592,7 +68601,41 @@
     },
     "logos-package_205": {
       "inputs": {
-        "logos-nix": "logos-nix_1740",
+        "logos-nix": "logos-nix_1737",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_206": {
+      "inputs": {
+        "logos-nix": "logos-nix_1741",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68606,41 +68649,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_206": {
-      "inputs": {
-        "logos-nix": "logos-nix_1745",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -68662,7 +68670,42 @@
     },
     "logos-package_207": {
       "inputs": {
-        "logos-nix": "logos-nix_1751",
+        "logos-nix": "logos-nix_1746",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_208": {
+      "inputs": {
+        "logos-nix": "logos-nix_1752",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68692,9 +68735,9 @@
         "type": "github"
       }
     },
-    "logos-package_208": {
+    "logos-package_209": {
       "inputs": {
-        "logos-nix": "logos-nix_1760",
+        "logos-nix": "logos-nix_1761",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68715,36 +68758,6 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_209": {
-      "inputs": {
-        "logos-nix": "logos-nix_1764",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781872378,
-        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -68791,7 +68804,7 @@
     },
     "logos-package_210": {
       "inputs": {
-        "logos-nix": "logos-nix_1768",
+        "logos-nix": "logos-nix_1765",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68799,19 +68812,18 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -68822,7 +68834,7 @@
     },
     "logos-package_211": {
       "inputs": {
-        "logos-nix": "logos-nix_1773",
+        "logos-nix": "logos-nix_1769",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68831,7 +68843,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -68853,7 +68865,38 @@
     },
     "logos-package_212": {
       "inputs": {
-        "logos-nix": "logos-nix_1809",
+        "logos-nix": "logos-nix_1774",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_213": {
+      "inputs": {
+        "logos-nix": "logos-nix_1810",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68887,44 +68930,9 @@
         "type": "github"
       }
     },
-    "logos-package_213": {
-      "inputs": {
-        "logos-nix": "logos-nix_1818",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_214": {
       "inputs": {
-        "logos-nix": "logos-nix_1822",
+        "logos-nix": "logos-nix_1819",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68936,6 +68944,7 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -68958,7 +68967,41 @@
     },
     "logos-package_215": {
       "inputs": {
-        "logos-nix": "logos-nix_1826",
+        "logos-nix": "logos-nix_1823",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_216": {
+      "inputs": {
+        "logos-nix": "logos-nix_1827",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -68972,41 +69015,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_216": {
-      "inputs": {
-        "logos-nix": "logos-nix_1831",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -69028,7 +69036,42 @@
     },
     "logos-package_217": {
       "inputs": {
-        "logos-nix": "logos-nix_1853",
+        "logos-nix": "logos-nix_1832",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_218": {
+      "inputs": {
+        "logos-nix": "logos-nix_1854",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69063,45 +69106,9 @@
         "type": "github"
       }
     },
-    "logos-package_218": {
-      "inputs": {
-        "logos-nix": "logos-nix_1862",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_219": {
       "inputs": {
-        "logos-nix": "logos-nix_1866",
+        "logos-nix": "logos-nix_1863",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69114,6 +69121,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -69171,7 +69179,42 @@
     },
     "logos-package_220": {
       "inputs": {
-        "logos-nix": "logos-nix_1870",
+        "logos-nix": "logos-nix_1867",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_221": {
+      "inputs": {
+        "logos-nix": "logos-nix_1871",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69186,42 +69229,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775835037,
-        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_221": {
-      "inputs": {
-        "logos-nix": "logos-nix_1875",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -69243,7 +69250,43 @@
     },
     "logos-package_222": {
       "inputs": {
-        "logos-nix": "logos-nix_1881",
+        "logos-nix": "logos-nix_1876",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775835037,
+        "narHash": "sha256-Cti0DhkzyLQs98BSzcHWMLtGXpa3n+R+5upfSw6vKdQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ff93a0df15ceab255f27687d22d962ea2737efbe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_223": {
+      "inputs": {
+        "logos-nix": "logos-nix_1882",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69274,41 +69317,9 @@
         "type": "github"
       }
     },
-    "logos-package_223": {
-      "inputs": {
-        "logos-nix": "logos-nix_1890",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777575342,
-        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
     "logos-package_224": {
       "inputs": {
-        "logos-nix": "logos-nix_1894",
+        "logos-nix": "logos-nix_1891",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69317,6 +69328,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -69339,7 +69351,38 @@
     },
     "logos-package_225": {
       "inputs": {
-        "logos-nix": "logos-nix_1898",
+        "logos-nix": "logos-nix_1895",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777575342,
+        "narHash": "sha256-l/tL39ZVNz3nWpE9zWpC/kg11QHSQJ2HHp3W3yv1pNI=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_226": {
+      "inputs": {
+        "logos-nix": "logos-nix_1899",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69369,9 +69412,9 @@
         "type": "github"
       }
     },
-    "logos-package_226": {
+    "logos-package_227": {
       "inputs": {
-        "logos-nix": "logos-nix_1903",
+        "logos-nix": "logos-nix_1904",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69401,9 +69444,9 @@
         "type": "github"
       }
     },
-    "logos-package_227": {
+    "logos-package_228": {
       "inputs": {
-        "logos-nix": "logos-nix_1912",
+        "logos-nix": "logos-nix_1913",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69430,9 +69473,9 @@
         "type": "github"
       }
     },
-    "logos-package_228": {
+    "logos-package_229": {
       "inputs": {
-        "logos-nix": "logos-nix_1923",
+        "logos-nix": "logos-nix_1924",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69450,33 +69493,6 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "118ccc4efd04eb0c4d541be8db7f1075e014ac39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_229": {
-      "inputs": {
-        "logos-nix": "logos-nix_1927",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781872378,
-        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
         "type": "github"
       },
       "original": {
@@ -69521,7 +69537,34 @@
     },
     "logos-package_230": {
       "inputs": {
-        "logos-nix": "logos-nix_1931",
+        "logos-nix": "logos-nix_1928",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781872378,
+        "narHash": "sha256-ZHh+krtTbn6Qt7Hm3+shrhAAGCFa7FXt8ajYqx+Nt1o=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "ab885df3641e9adb61ff16e42d3e6f63b24db8f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_231": {
+      "inputs": {
+        "logos-nix": "logos-nix_1932",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69547,9 +69590,9 @@
         "type": "github"
       }
     },
-    "logos-package_231": {
+    "logos-package_232": {
       "inputs": {
-        "logos-nix": "logos-nix_1936",
+        "logos-nix": "logos-nix_1937",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69575,9 +69618,9 @@
         "type": "github"
       }
     },
-    "logos-package_232": {
+    "logos-package_233": {
       "inputs": {
-        "logos-nix": "logos-nix_1939",
+        "logos-nix": "logos-nix_1940",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -69588,11 +69631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -69601,9 +69644,9 @@
         "type": "github"
       }
     },
-    "logos-package_233": {
+    "logos-package_234": {
       "inputs": {
-        "logos-nix": "logos-nix_1950",
+        "logos-nix": "logos-nix_1951",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -69626,9 +69669,9 @@
         "type": "github"
       }
     },
-    "logos-package_234": {
+    "logos-package_235": {
       "inputs": {
-        "logos-nix": "logos-nix_1955",
+        "logos-nix": "logos-nix_1956",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -70599,11 +70642,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782153303,
-        "narHash": "sha256-h1ltzc34iMkXduTm/41Tma1chBXZolKJhamUqz1vH6w=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "53336d37e4efb7c8e8243347ab77ab78705214c9",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -71846,11 +71889,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782153303,
-        "narHash": "sha256-h1ltzc34iMkXduTm/41Tma1chBXZolKJhamUqz1vH6w=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "53336d37e4efb7c8e8243347ab77ab78705214c9",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -71870,11 +71913,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873979,
-        "narHash": "sha256-Z5XUSB9wfdrmQhG/0fehJeBd9CjrlIEeO+mKDhE46H4=",
+        "lastModified": 1784140006,
+        "narHash": "sha256-Pcpku7qHRkDgEiWfFRJ/4dCF7m4MzS138dwv8PgmlNU=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "c207525d30f48620696668c38486884bad5384bc",
+        "rev": "8d4236f9453bce8b44dfd2f85a5006af993b7ed2",
         "type": "github"
       },
       "original": {
@@ -73024,7 +73067,7 @@
     "logos-plugin-core_32": {
       "inputs": {
         "logos-module": "logos-module_169",
-        "logos-nix": "logos-nix_1347",
+        "logos-nix": "logos-nix_1348",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73051,7 +73094,7 @@
     "logos-plugin-core_33": {
       "inputs": {
         "logos-module": "logos-module_172",
-        "logos-nix": "logos-nix_1356",
+        "logos-nix": "logos-nix_1357",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73081,7 +73124,7 @@
     "logos-plugin-core_34": {
       "inputs": {
         "logos-module": "logos-module_175",
-        "logos-nix": "logos-nix_1365",
+        "logos-nix": "logos-nix_1366",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73114,7 +73157,7 @@
     "logos-plugin-core_35": {
       "inputs": {
         "logos-module": "logos-module_181",
-        "logos-nix": "logos-nix_1409",
+        "logos-nix": "logos-nix_1410",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73148,7 +73191,7 @@
     "logos-plugin-core_36": {
       "inputs": {
         "logos-module": "logos-module_189",
-        "logos-nix": "logos-nix_1488",
+        "logos-nix": "logos-nix_1489",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73179,7 +73222,7 @@
     "logos-plugin-core_37": {
       "inputs": {
         "logos-module": "logos-module_192",
-        "logos-nix": "logos-nix_1495",
+        "logos-nix": "logos-nix_1496",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73213,7 +73256,7 @@
     "logos-plugin-core_38": {
       "inputs": {
         "logos-module": "logos-module_198",
-        "logos-nix": "logos-nix_1539",
+        "logos-nix": "logos-nix_1540",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -73248,7 +73291,7 @@
     "logos-plugin-core_39": {
       "inputs": {
         "logos-module": "logos-module_206",
-        "logos-nix": "logos-nix_1647",
+        "logos-nix": "logos-nix_1648",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73308,7 +73351,7 @@
     "logos-plugin-core_40": {
       "inputs": {
         "logos-module": "logos-module_209",
-        "logos-nix": "logos-nix_1656",
+        "logos-nix": "logos-nix_1657",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73338,7 +73381,7 @@
     "logos-plugin-core_41": {
       "inputs": {
         "logos-module": "logos-module_212",
-        "logos-nix": "logos-nix_1665",
+        "logos-nix": "logos-nix_1666",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73371,7 +73414,7 @@
     "logos-plugin-core_42": {
       "inputs": {
         "logos-module": "logos-module_218",
-        "logos-nix": "logos-nix_1709",
+        "logos-nix": "logos-nix_1710",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73405,7 +73448,7 @@
     "logos-plugin-core_43": {
       "inputs": {
         "logos-module": "logos-module_226",
-        "logos-nix": "logos-nix_1788",
+        "logos-nix": "logos-nix_1789",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73436,7 +73479,7 @@
     "logos-plugin-core_44": {
       "inputs": {
         "logos-module": "logos-module_229",
-        "logos-nix": "logos-nix_1795",
+        "logos-nix": "logos-nix_1796",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -73470,7 +73513,7 @@
     "logos-plugin-core_45": {
       "inputs": {
         "logos-module": "logos-module_235",
-        "logos-nix": "logos-nix_1839",
+        "logos-nix": "logos-nix_1840",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74428,7 +74471,7 @@
     "logos-plugin-qt_32": {
       "inputs": {
         "logos-module": "logos-module_170",
-        "logos-nix": "logos-nix_1349",
+        "logos-nix": "logos-nix_1350",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74455,7 +74498,7 @@
     "logos-plugin-qt_33": {
       "inputs": {
         "logos-module": "logos-module_173",
-        "logos-nix": "logos-nix_1358",
+        "logos-nix": "logos-nix_1359",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74485,7 +74528,7 @@
     "logos-plugin-qt_34": {
       "inputs": {
         "logos-module": "logos-module_176",
-        "logos-nix": "logos-nix_1367",
+        "logos-nix": "logos-nix_1368",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74518,7 +74561,7 @@
     "logos-plugin-qt_35": {
       "inputs": {
         "logos-module": "logos-module_182",
-        "logos-nix": "logos-nix_1411",
+        "logos-nix": "logos-nix_1412",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74552,7 +74595,7 @@
     "logos-plugin-qt_36": {
       "inputs": {
         "logos-module": "logos-module_190",
-        "logos-nix": "logos-nix_1490",
+        "logos-nix": "logos-nix_1491",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74583,7 +74626,7 @@
     "logos-plugin-qt_37": {
       "inputs": {
         "logos-module": "logos-module_193",
-        "logos-nix": "logos-nix_1497",
+        "logos-nix": "logos-nix_1498",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74617,7 +74660,7 @@
     "logos-plugin-qt_38": {
       "inputs": {
         "logos-module": "logos-module_199",
-        "logos-nix": "logos-nix_1541",
+        "logos-nix": "logos-nix_1542",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -74652,7 +74695,7 @@
     "logos-plugin-qt_39": {
       "inputs": {
         "logos-module": "logos-module_207",
-        "logos-nix": "logos-nix_1649",
+        "logos-nix": "logos-nix_1650",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74712,7 +74755,7 @@
     "logos-plugin-qt_40": {
       "inputs": {
         "logos-module": "logos-module_210",
-        "logos-nix": "logos-nix_1658",
+        "logos-nix": "logos-nix_1659",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74742,7 +74785,7 @@
     "logos-plugin-qt_41": {
       "inputs": {
         "logos-module": "logos-module_213",
-        "logos-nix": "logos-nix_1667",
+        "logos-nix": "logos-nix_1668",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74775,7 +74818,7 @@
     "logos-plugin-qt_42": {
       "inputs": {
         "logos-module": "logos-module_219",
-        "logos-nix": "logos-nix_1711",
+        "logos-nix": "logos-nix_1712",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74809,7 +74852,7 @@
     "logos-plugin-qt_43": {
       "inputs": {
         "logos-module": "logos-module_227",
-        "logos-nix": "logos-nix_1790",
+        "logos-nix": "logos-nix_1791",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74840,7 +74883,7 @@
     "logos-plugin-qt_44": {
       "inputs": {
         "logos-module": "logos-module_230",
-        "logos-nix": "logos-nix_1797",
+        "logos-nix": "logos-nix_1798",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -74874,7 +74917,7 @@
     "logos-plugin-qt_45": {
       "inputs": {
         "logos-module": "logos-module_236",
-        "logos-nix": "logos-nix_1841",
+        "logos-nix": "logos-nix_1842",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -75990,7 +76033,7 @@
     },
     "logos-protocol_38": {
       "inputs": {
-        "logos-nix": "logos-nix_1350",
+        "logos-nix": "logos-nix_1351",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -76016,7 +76059,7 @@
     },
     "logos-protocol_39": {
       "inputs": {
-        "logos-nix": "logos-nix_1359",
+        "logos-nix": "logos-nix_1360",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -76150,7 +76193,7 @@
     },
     "logos-protocol_42": {
       "inputs": {
-        "logos-nix": "logos-nix_1616",
+        "logos-nix": "logos-nix_1617",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -76310,7 +76353,7 @@
     },
     "logos-protocol_47": {
       "inputs": {
-        "logos-nix": "logos-nix_1650",
+        "logos-nix": "logos-nix_1651",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -76336,7 +76379,7 @@
     },
     "logos-protocol_48": {
       "inputs": {
-        "logos-nix": "logos-nix_1659",
+        "logos-nix": "logos-nix_1660",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -76464,7 +76507,7 @@
     },
     "logos-protocol_51": {
       "inputs": {
-        "logos-nix": "logos-nix_1916",
+        "logos-nix": "logos-nix_1917",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77556,7 +77599,7 @@
     },
     "logos-qt-mcp_32": {
       "inputs": {
-        "logos-nix": "logos-nix_1385",
+        "logos-nix": "logos-nix_1386",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77588,7 +77631,7 @@
     },
     "logos-qt-mcp_33": {
       "inputs": {
-        "logos-nix": "logos-nix_1429",
+        "logos-nix": "logos-nix_1430",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77621,7 +77664,7 @@
     },
     "logos-qt-mcp_34": {
       "inputs": {
-        "logos-nix": "logos-nix_1457",
+        "logos-nix": "logos-nix_1458",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77651,7 +77694,7 @@
     },
     "logos-qt-mcp_35": {
       "inputs": {
-        "logos-nix": "logos-nix_1515",
+        "logos-nix": "logos-nix_1516",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77684,7 +77727,7 @@
     },
     "logos-qt-mcp_36": {
       "inputs": {
-        "logos-nix": "logos-nix_1559",
+        "logos-nix": "logos-nix_1560",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77718,7 +77761,7 @@
     },
     "logos-qt-mcp_37": {
       "inputs": {
-        "logos-nix": "logos-nix_1587",
+        "logos-nix": "logos-nix_1588",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77749,7 +77792,7 @@
     },
     "logos-qt-mcp_38": {
       "inputs": {
-        "logos-nix": "logos-nix_1620",
+        "logos-nix": "logos-nix_1621",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -77776,7 +77819,7 @@
     },
     "logos-qt-mcp_39": {
       "inputs": {
-        "logos-nix": "logos-nix_1685",
+        "logos-nix": "logos-nix_1686",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77840,7 +77883,7 @@
     },
     "logos-qt-mcp_40": {
       "inputs": {
-        "logos-nix": "logos-nix_1729",
+        "logos-nix": "logos-nix_1730",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77873,7 +77916,7 @@
     },
     "logos-qt-mcp_41": {
       "inputs": {
-        "logos-nix": "logos-nix_1757",
+        "logos-nix": "logos-nix_1758",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77903,7 +77946,7 @@
     },
     "logos-qt-mcp_42": {
       "inputs": {
-        "logos-nix": "logos-nix_1815",
+        "logos-nix": "logos-nix_1816",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77936,7 +77979,7 @@
     },
     "logos-qt-mcp_43": {
       "inputs": {
-        "logos-nix": "logos-nix_1859",
+        "logos-nix": "logos-nix_1860",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -77970,7 +78013,7 @@
     },
     "logos-qt-mcp_44": {
       "inputs": {
-        "logos-nix": "logos-nix_1887",
+        "logos-nix": "logos-nix_1888",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -78001,7 +78044,7 @@
     },
     "logos-qt-mcp_45": {
       "inputs": {
-        "logos-nix": "logos-nix_1920",
+        "logos-nix": "logos-nix_1921",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -78028,7 +78071,7 @@
     },
     "logos-qt-mcp_46": {
       "inputs": {
-        "logos-nix": "logos-nix_1943",
+        "logos-nix": "logos-nix_1944",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -79222,7 +79265,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_57",
-        "logos-nix": "logos-nix_1351",
+        "logos-nix": "logos-nix_1352",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -79264,7 +79307,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_60",
-        "logos-nix": "logos-nix_1360",
+        "logos-nix": "logos-nix_1361",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -79368,7 +79411,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_64",
-        "logos-nix": "logos-nix_1617",
+        "logos-nix": "logos-nix_1618",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -79553,7 +79596,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_70",
-        "logos-nix": "logos-nix_1651",
+        "logos-nix": "logos-nix_1652",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -79595,7 +79638,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_73",
-        "logos-nix": "logos-nix_1660",
+        "logos-nix": "logos-nix_1661",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -79741,7 +79784,7 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_77",
-        "logos-nix": "logos-nix_1917",
+        "logos-nix": "logos-nix_1918",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -81777,7 +81820,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_140",
         "logos-design-system": "logos-design-system_36",
         "logos-liblogos": "logos-liblogos_36",
-        "logos-nix": "logos-nix_1619",
+        "logos-nix": "logos-nix_1620",
         "logos-protocol": "logos-protocol_43",
         "logos-qt-mcp": "logos-qt-mcp_38",
         "logos-qt-sdk": "logos-qt-sdk_34",
@@ -81812,7 +81855,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_133",
         "logos-design-system": "logos-design-system_34",
         "logos-liblogos": "logos-liblogos_34",
-        "logos-nix": "logos-nix_1456",
+        "logos-nix": "logos-nix_1457",
         "logos-qt-mcp": "logos-qt-mcp_34",
         "logos-view-module-runtime": "logos-view-module-runtime_34",
         "nix-bundle-lgx": "nix-bundle-lgx_100",
@@ -81848,7 +81891,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_130",
         "logos-design-system": "logos-design-system_33",
         "logos-liblogos": "logos-liblogos_33",
-        "logos-nix": "logos-nix_1384",
+        "logos-nix": "logos-nix_1385",
         "logos-qt-mcp": "logos-qt-mcp_32",
         "logos-view-module-runtime": "logos-view-module-runtime_32",
         "nix-bundle-lgx": "nix-bundle-lgx_94",
@@ -81887,7 +81930,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_135",
         "logos-design-system": "logos-design-system_35",
         "logos-liblogos": "logos-liblogos_35",
-        "logos-nix": "logos-nix_1428",
+        "logos-nix": "logos-nix_1429",
         "logos-qt-mcp": "logos-qt-mcp_33",
         "logos-view-module-runtime": "logos-view-module-runtime_33",
         "nix-bundle-lgx": "nix-bundle-lgx_97",
@@ -81927,7 +81970,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_146",
         "logos-design-system": "logos-design-system_38",
         "logos-liblogos": "logos-liblogos_38",
-        "logos-nix": "logos-nix_1586",
+        "logos-nix": "logos-nix_1587",
         "logos-qt-mcp": "logos-qt-mcp_37",
         "logos-view-module-runtime": "logos-view-module-runtime_37",
         "nix-bundle-lgx": "nix-bundle-lgx_109",
@@ -81964,7 +82007,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_143",
         "logos-design-system": "logos-design-system_37",
         "logos-liblogos": "logos-liblogos_37",
-        "logos-nix": "logos-nix_1514",
+        "logos-nix": "logos-nix_1515",
         "logos-qt-mcp": "logos-qt-mcp_35",
         "logos-view-module-runtime": "logos-view-module-runtime_35",
         "nix-bundle-lgx": "nix-bundle-lgx_103",
@@ -82004,7 +82047,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_148",
         "logos-design-system": "logos-design-system_39",
         "logos-liblogos": "logos-liblogos_39",
-        "logos-nix": "logos-nix_1558",
+        "logos-nix": "logos-nix_1559",
         "logos-qt-mcp": "logos-qt-mcp_36",
         "logos-view-module-runtime": "logos-view-module-runtime_36",
         "nix-bundle-lgx": "nix-bundle-lgx_106",
@@ -82045,7 +82088,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_168",
         "logos-design-system": "logos-design-system_43",
         "logos-liblogos": "logos-liblogos_43",
-        "logos-nix": "logos-nix_1919",
+        "logos-nix": "logos-nix_1920",
         "logos-protocol": "logos-protocol_52",
         "logos-qt-mcp": "logos-qt-mcp_45",
         "logos-qt-sdk": "logos-qt-sdk_41",
@@ -82119,7 +82162,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_161",
         "logos-design-system": "logos-design-system_41",
         "logos-liblogos": "logos-liblogos_41",
-        "logos-nix": "logos-nix_1756",
+        "logos-nix": "logos-nix_1757",
         "logos-qt-mcp": "logos-qt-mcp_41",
         "logos-view-module-runtime": "logos-view-module-runtime_41",
         "nix-bundle-lgx": "nix-bundle-lgx_121",
@@ -82155,7 +82198,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_158",
         "logos-design-system": "logos-design-system_40",
         "logos-liblogos": "logos-liblogos_40",
-        "logos-nix": "logos-nix_1684",
+        "logos-nix": "logos-nix_1685",
         "logos-qt-mcp": "logos-qt-mcp_39",
         "logos-view-module-runtime": "logos-view-module-runtime_39",
         "nix-bundle-lgx": "nix-bundle-lgx_115",
@@ -82194,7 +82237,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_163",
         "logos-design-system": "logos-design-system_42",
         "logos-liblogos": "logos-liblogos_42",
-        "logos-nix": "logos-nix_1728",
+        "logos-nix": "logos-nix_1729",
         "logos-qt-mcp": "logos-qt-mcp_40",
         "logos-view-module-runtime": "logos-view-module-runtime_40",
         "nix-bundle-lgx": "nix-bundle-lgx_118",
@@ -82234,7 +82277,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_174",
         "logos-design-system": "logos-design-system_45",
         "logos-liblogos": "logos-liblogos_45",
-        "logos-nix": "logos-nix_1886",
+        "logos-nix": "logos-nix_1887",
         "logos-qt-mcp": "logos-qt-mcp_44",
         "logos-view-module-runtime": "logos-view-module-runtime_44",
         "nix-bundle-lgx": "nix-bundle-lgx_130",
@@ -82271,7 +82314,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_171",
         "logos-design-system": "logos-design-system_44",
         "logos-liblogos": "logos-liblogos_44",
-        "logos-nix": "logos-nix_1814",
+        "logos-nix": "logos-nix_1815",
         "logos-qt-mcp": "logos-qt-mcp_42",
         "logos-view-module-runtime": "logos-view-module-runtime_42",
         "nix-bundle-lgx": "nix-bundle-lgx_124",
@@ -82311,7 +82354,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_176",
         "logos-design-system": "logos-design-system_46",
         "logos-liblogos": "logos-liblogos_46",
-        "logos-nix": "logos-nix_1858",
+        "logos-nix": "logos-nix_1859",
         "logos-qt-mcp": "logos-qt-mcp_43",
         "logos-view-module-runtime": "logos-view-module-runtime_43",
         "nix-bundle-lgx": "nix-bundle-lgx_127",
@@ -83552,7 +83595,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1390",
+        "logos-nix": "logos-nix_1391",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -83597,7 +83640,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1434",
+        "logos-nix": "logos-nix_1435",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -83639,7 +83682,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1462",
+        "logos-nix": "logos-nix_1463",
         "logos-protocol": "logos-protocol_40",
         "logos-qt-sdk": "logos-qt-sdk_32",
         "nixpkgs": [
@@ -83683,7 +83726,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1520",
+        "logos-nix": "logos-nix_1521",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -83730,7 +83773,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1564",
+        "logos-nix": "logos-nix_1565",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -83774,7 +83817,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1592",
+        "logos-nix": "logos-nix_1593",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -83810,7 +83853,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1625",
+        "logos-nix": "logos-nix_1626",
         "logos-protocol": "logos-protocol_46",
         "logos-qt-sdk": "logos-qt-sdk_36",
         "nixpkgs": [
@@ -83850,7 +83893,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1690",
+        "logos-nix": "logos-nix_1691",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -83939,7 +83982,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1734",
+        "logos-nix": "logos-nix_1735",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -83981,7 +84024,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1762",
+        "logos-nix": "logos-nix_1763",
         "logos-protocol": "logos-protocol_49",
         "logos-qt-sdk": "logos-qt-sdk_39",
         "nixpkgs": [
@@ -84025,7 +84068,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1820",
+        "logos-nix": "logos-nix_1821",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -84072,7 +84115,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1864",
+        "logos-nix": "logos-nix_1865",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -84116,7 +84159,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1892",
+        "logos-nix": "logos-nix_1893",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -84152,7 +84195,7 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1925",
+        "logos-nix": "logos-nix_1926",
         "logos-protocol": "logos-protocol_55",
         "logos-qt-sdk": "logos-qt-sdk_43",
         "nixpkgs": [
@@ -85343,7 +85386,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1386",
+        "logos-nix": "logos-nix_1387",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85389,7 +85432,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1430",
+        "logos-nix": "logos-nix_1431",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85423,7 +85466,7 @@
     "logos-view-module-runtime_34": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_139",
-        "logos-nix": "logos-nix_1458",
+        "logos-nix": "logos-nix_1459",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85467,7 +85510,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1516",
+        "logos-nix": "logos-nix_1517",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85515,7 +85558,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1560",
+        "logos-nix": "logos-nix_1561",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85550,7 +85593,7 @@
     "logos-view-module-runtime_37": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_152",
-        "logos-nix": "logos-nix_1588",
+        "logos-nix": "logos-nix_1589",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -85582,7 +85625,7 @@
     "logos-view-module-runtime_38": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_154",
-        "logos-nix": "logos-nix_1621",
+        "logos-nix": "logos-nix_1622",
         "logos-protocol": "logos-protocol_45",
         "logos-qt-sdk": "logos-qt-sdk_35",
         "nixpkgs": [
@@ -85624,7 +85667,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1686",
+        "logos-nix": "logos-nix_1687",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85715,7 +85758,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1730",
+        "logos-nix": "logos-nix_1731",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85749,7 +85792,7 @@
     "logos-view-module-runtime_41": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_167",
-        "logos-nix": "logos-nix_1758",
+        "logos-nix": "logos-nix_1759",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85793,7 +85836,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1816",
+        "logos-nix": "logos-nix_1817",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85841,7 +85884,7 @@
           "logos-standalone-app",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1860",
+        "logos-nix": "logos-nix_1861",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85876,7 +85919,7 @@
     "logos-view-module-runtime_44": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_180",
-        "logos-nix": "logos-nix_1888",
+        "logos-nix": "logos-nix_1889",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -85908,7 +85951,7 @@
     "logos-view-module-runtime_45": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_182",
-        "logos-nix": "logos-nix_1921",
+        "logos-nix": "logos-nix_1922",
         "logos-protocol": "logos-protocol_54",
         "logos-qt-sdk": "logos-qt-sdk_42",
         "nixpkgs": [
@@ -85940,7 +85983,7 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_1944",
+        "logos-nix": "logos-nix_1945",
         "logos-protocol": "logos-protocol_57",
         "logos-qt-sdk": "logos-qt-sdk_45",
         "nixpkgs": [
@@ -88212,7 +88255,7 @@
     },
     "nix-bundle-appimage_67": {
       "inputs": {
-        "logos-nix": "logos-nix_1380",
+        "logos-nix": "logos-nix_1381",
         "nix-bundle-dir": "nix-bundle-dir_226",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88248,7 +88291,7 @@
     },
     "nix-bundle-appimage_68": {
       "inputs": {
-        "logos-nix": "logos-nix_1397",
+        "logos-nix": "logos-nix_1398",
         "nix-bundle-dir": "nix-bundle-dir_230",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88283,7 +88326,7 @@
     },
     "nix-bundle-appimage_69": {
       "inputs": {
-        "logos-nix": "logos-nix_1424",
+        "logos-nix": "logos-nix_1425",
         "nix-bundle-dir": "nix-bundle-dir_233",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88356,7 +88399,7 @@
     },
     "nix-bundle-appimage_70": {
       "inputs": {
-        "logos-nix": "logos-nix_1441",
+        "logos-nix": "logos-nix_1442",
         "nix-bundle-dir": "nix-bundle-dir_237",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88392,7 +88435,7 @@
     },
     "nix-bundle-appimage_71": {
       "inputs": {
-        "logos-nix": "logos-nix_1452",
+        "logos-nix": "logos-nix_1453",
         "nix-bundle-dir": "nix-bundle-dir_240",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88425,7 +88468,7 @@
     },
     "nix-bundle-appimage_72": {
       "inputs": {
-        "logos-nix": "logos-nix_1469",
+        "logos-nix": "logos-nix_1470",
         "nix-bundle-dir": "nix-bundle-dir_244",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88457,7 +88500,7 @@
     },
     "nix-bundle-appimage_73": {
       "inputs": {
-        "logos-nix": "logos-nix_1510",
+        "logos-nix": "logos-nix_1511",
         "nix-bundle-dir": "nix-bundle-dir_247",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88494,7 +88537,7 @@
     },
     "nix-bundle-appimage_74": {
       "inputs": {
-        "logos-nix": "logos-nix_1527",
+        "logos-nix": "logos-nix_1528",
         "nix-bundle-dir": "nix-bundle-dir_251",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88530,7 +88573,7 @@
     },
     "nix-bundle-appimage_75": {
       "inputs": {
-        "logos-nix": "logos-nix_1554",
+        "logos-nix": "logos-nix_1555",
         "nix-bundle-dir": "nix-bundle-dir_254",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88568,7 +88611,7 @@
     },
     "nix-bundle-appimage_76": {
       "inputs": {
-        "logos-nix": "logos-nix_1571",
+        "logos-nix": "logos-nix_1572",
         "nix-bundle-dir": "nix-bundle-dir_258",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88605,7 +88648,7 @@
     },
     "nix-bundle-appimage_77": {
       "inputs": {
-        "logos-nix": "logos-nix_1582",
+        "logos-nix": "logos-nix_1583",
         "nix-bundle-dir": "nix-bundle-dir_261",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88639,7 +88682,7 @@
     },
     "nix-bundle-appimage_78": {
       "inputs": {
-        "logos-nix": "logos-nix_1599",
+        "logos-nix": "logos-nix_1600",
         "nix-bundle-dir": "nix-bundle-dir_265",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88672,7 +88715,7 @@
     },
     "nix-bundle-appimage_79": {
       "inputs": {
-        "logos-nix": "logos-nix_1613",
+        "logos-nix": "logos-nix_1614",
         "nix-bundle-dir": "nix-bundle-dir_268",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88737,7 +88780,7 @@
     },
     "nix-bundle-appimage_80": {
       "inputs": {
-        "logos-nix": "logos-nix_1632",
+        "logos-nix": "logos-nix_1633",
         "nix-bundle-dir": "nix-bundle-dir_272",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88766,7 +88809,7 @@
     },
     "nix-bundle-appimage_81": {
       "inputs": {
-        "logos-nix": "logos-nix_1640",
+        "logos-nix": "logos-nix_1641",
         "nix-bundle-dir": "nix-bundle-dir_275",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88793,7 +88836,7 @@
     },
     "nix-bundle-appimage_82": {
       "inputs": {
-        "logos-nix": "logos-nix_1680",
+        "logos-nix": "logos-nix_1681",
         "nix-bundle-dir": "nix-bundle-dir_277",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88829,7 +88872,7 @@
     },
     "nix-bundle-appimage_83": {
       "inputs": {
-        "logos-nix": "logos-nix_1697",
+        "logos-nix": "logos-nix_1698",
         "nix-bundle-dir": "nix-bundle-dir_281",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88864,7 +88907,7 @@
     },
     "nix-bundle-appimage_84": {
       "inputs": {
-        "logos-nix": "logos-nix_1724",
+        "logos-nix": "logos-nix_1725",
         "nix-bundle-dir": "nix-bundle-dir_284",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88901,7 +88944,7 @@
     },
     "nix-bundle-appimage_85": {
       "inputs": {
-        "logos-nix": "logos-nix_1741",
+        "logos-nix": "logos-nix_1742",
         "nix-bundle-dir": "nix-bundle-dir_288",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88937,7 +88980,7 @@
     },
     "nix-bundle-appimage_86": {
       "inputs": {
-        "logos-nix": "logos-nix_1752",
+        "logos-nix": "logos-nix_1753",
         "nix-bundle-dir": "nix-bundle-dir_291",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -88970,7 +89013,7 @@
     },
     "nix-bundle-appimage_87": {
       "inputs": {
-        "logos-nix": "logos-nix_1769",
+        "logos-nix": "logos-nix_1770",
         "nix-bundle-dir": "nix-bundle-dir_295",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89002,7 +89045,7 @@
     },
     "nix-bundle-appimage_88": {
       "inputs": {
-        "logos-nix": "logos-nix_1810",
+        "logos-nix": "logos-nix_1811",
         "nix-bundle-dir": "nix-bundle-dir_298",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89039,7 +89082,7 @@
     },
     "nix-bundle-appimage_89": {
       "inputs": {
-        "logos-nix": "logos-nix_1827",
+        "logos-nix": "logos-nix_1828",
         "nix-bundle-dir": "nix-bundle-dir_302",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89112,7 +89155,7 @@
     },
     "nix-bundle-appimage_90": {
       "inputs": {
-        "logos-nix": "logos-nix_1854",
+        "logos-nix": "logos-nix_1855",
         "nix-bundle-dir": "nix-bundle-dir_305",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89150,7 +89193,7 @@
     },
     "nix-bundle-appimage_91": {
       "inputs": {
-        "logos-nix": "logos-nix_1871",
+        "logos-nix": "logos-nix_1872",
         "nix-bundle-dir": "nix-bundle-dir_309",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89187,7 +89230,7 @@
     },
     "nix-bundle-appimage_92": {
       "inputs": {
-        "logos-nix": "logos-nix_1882",
+        "logos-nix": "logos-nix_1883",
         "nix-bundle-dir": "nix-bundle-dir_312",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89221,7 +89264,7 @@
     },
     "nix-bundle-appimage_93": {
       "inputs": {
-        "logos-nix": "logos-nix_1899",
+        "logos-nix": "logos-nix_1900",
         "nix-bundle-dir": "nix-bundle-dir_316",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89254,7 +89297,7 @@
     },
     "nix-bundle-appimage_94": {
       "inputs": {
-        "logos-nix": "logos-nix_1913",
+        "logos-nix": "logos-nix_1914",
         "nix-bundle-dir": "nix-bundle-dir_319",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89284,7 +89327,7 @@
     },
     "nix-bundle-appimage_95": {
       "inputs": {
-        "logos-nix": "logos-nix_1932",
+        "logos-nix": "logos-nix_1933",
         "nix-bundle-dir": "nix-bundle-dir_323",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89313,7 +89356,7 @@
     },
     "nix-bundle-appimage_96": {
       "inputs": {
-        "logos-nix": "logos-nix_1940",
+        "logos-nix": "logos-nix_1941",
         "nix-bundle-dir": "nix-bundle-dir_326",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -89340,7 +89383,7 @@
     },
     "nix-bundle-appimage_97": {
       "inputs": {
-        "logos-nix": "logos-nix_1945",
+        "logos-nix": "logos-nix_1946",
         "nix-bundle-dir": "nix-bundle-dir_328",
         "nixpkgs": [
           "nix-bundle-appimage",
@@ -89364,7 +89407,7 @@
     },
     "nix-bundle-appimage_98": {
       "inputs": {
-        "logos-nix": "logos-nix_1951",
+        "logos-nix": "logos-nix_1952",
         "nix-bundle-dir": "nix-bundle-dir_330",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -93817,7 +93860,7 @@
     },
     "nix-bundle-dir_226": {
       "inputs": {
-        "logos-nix": "logos-nix_1381",
+        "logos-nix": "logos-nix_1382",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -93851,7 +93894,7 @@
     },
     "nix-bundle-dir_227": {
       "inputs": {
-        "logos-nix": "logos-nix_1382",
+        "logos-nix": "logos-nix_1383",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -93886,7 +93929,7 @@
     },
     "nix-bundle-dir_228": {
       "inputs": {
-        "logos-nix": "logos-nix_1389",
+        "logos-nix": "logos-nix_1390",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -93920,7 +93963,7 @@
     },
     "nix-bundle-dir_229": {
       "inputs": {
-        "logos-nix": "logos-nix_1393",
+        "logos-nix": "logos-nix_1394",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -93988,7 +94031,7 @@
     },
     "nix-bundle-dir_230": {
       "inputs": {
-        "logos-nix": "logos-nix_1398",
+        "logos-nix": "logos-nix_1399",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94021,7 +94064,7 @@
     },
     "nix-bundle-dir_231": {
       "inputs": {
-        "logos-nix": "logos-nix_1399",
+        "logos-nix": "logos-nix_1400",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94055,7 +94098,7 @@
     },
     "nix-bundle-dir_232": {
       "inputs": {
-        "logos-nix": "logos-nix_1402",
+        "logos-nix": "logos-nix_1403",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94089,7 +94132,7 @@
     },
     "nix-bundle-dir_233": {
       "inputs": {
-        "logos-nix": "logos-nix_1425",
+        "logos-nix": "logos-nix_1426",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94124,7 +94167,7 @@
     },
     "nix-bundle-dir_234": {
       "inputs": {
-        "logos-nix": "logos-nix_1426",
+        "logos-nix": "logos-nix_1427",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94160,7 +94203,7 @@
     },
     "nix-bundle-dir_235": {
       "inputs": {
-        "logos-nix": "logos-nix_1433",
+        "logos-nix": "logos-nix_1434",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94195,7 +94238,7 @@
     },
     "nix-bundle-dir_236": {
       "inputs": {
-        "logos-nix": "logos-nix_1437",
+        "logos-nix": "logos-nix_1438",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94229,7 +94272,7 @@
     },
     "nix-bundle-dir_237": {
       "inputs": {
-        "logos-nix": "logos-nix_1442",
+        "logos-nix": "logos-nix_1443",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94263,7 +94306,7 @@
     },
     "nix-bundle-dir_238": {
       "inputs": {
-        "logos-nix": "logos-nix_1443",
+        "logos-nix": "logos-nix_1444",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94298,7 +94341,7 @@
     },
     "nix-bundle-dir_239": {
       "inputs": {
-        "logos-nix": "logos-nix_1446",
+        "logos-nix": "logos-nix_1447",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94367,7 +94410,7 @@
     },
     "nix-bundle-dir_240": {
       "inputs": {
-        "logos-nix": "logos-nix_1453",
+        "logos-nix": "logos-nix_1454",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94398,7 +94441,7 @@
     },
     "nix-bundle-dir_241": {
       "inputs": {
-        "logos-nix": "logos-nix_1454",
+        "logos-nix": "logos-nix_1455",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94430,7 +94473,7 @@
     },
     "nix-bundle-dir_242": {
       "inputs": {
-        "logos-nix": "logos-nix_1461",
+        "logos-nix": "logos-nix_1462",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94461,7 +94504,7 @@
     },
     "nix-bundle-dir_243": {
       "inputs": {
-        "logos-nix": "logos-nix_1465",
+        "logos-nix": "logos-nix_1466",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94491,7 +94534,7 @@
     },
     "nix-bundle-dir_244": {
       "inputs": {
-        "logos-nix": "logos-nix_1470",
+        "logos-nix": "logos-nix_1471",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94521,7 +94564,7 @@
     },
     "nix-bundle-dir_245": {
       "inputs": {
-        "logos-nix": "logos-nix_1471",
+        "logos-nix": "logos-nix_1472",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94552,7 +94595,7 @@
     },
     "nix-bundle-dir_246": {
       "inputs": {
-        "logos-nix": "logos-nix_1474",
+        "logos-nix": "logos-nix_1475",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94583,7 +94626,7 @@
     },
     "nix-bundle-dir_247": {
       "inputs": {
-        "logos-nix": "logos-nix_1511",
+        "logos-nix": "logos-nix_1512",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94618,7 +94661,7 @@
     },
     "nix-bundle-dir_248": {
       "inputs": {
-        "logos-nix": "logos-nix_1512",
+        "logos-nix": "logos-nix_1513",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94654,7 +94697,7 @@
     },
     "nix-bundle-dir_249": {
       "inputs": {
-        "logos-nix": "logos-nix_1519",
+        "logos-nix": "logos-nix_1520",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94722,7 +94765,7 @@
     },
     "nix-bundle-dir_250": {
       "inputs": {
-        "logos-nix": "logos-nix_1523",
+        "logos-nix": "logos-nix_1524",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94756,7 +94799,7 @@
     },
     "nix-bundle-dir_251": {
       "inputs": {
-        "logos-nix": "logos-nix_1528",
+        "logos-nix": "logos-nix_1529",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94790,7 +94833,7 @@
     },
     "nix-bundle-dir_252": {
       "inputs": {
-        "logos-nix": "logos-nix_1529",
+        "logos-nix": "logos-nix_1530",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94825,7 +94868,7 @@
     },
     "nix-bundle-dir_253": {
       "inputs": {
-        "logos-nix": "logos-nix_1532",
+        "logos-nix": "logos-nix_1533",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94860,7 +94903,7 @@
     },
     "nix-bundle-dir_254": {
       "inputs": {
-        "logos-nix": "logos-nix_1555",
+        "logos-nix": "logos-nix_1556",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94896,7 +94939,7 @@
     },
     "nix-bundle-dir_255": {
       "inputs": {
-        "logos-nix": "logos-nix_1556",
+        "logos-nix": "logos-nix_1557",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94933,7 +94976,7 @@
     },
     "nix-bundle-dir_256": {
       "inputs": {
-        "logos-nix": "logos-nix_1563",
+        "logos-nix": "logos-nix_1564",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -94969,7 +95012,7 @@
     },
     "nix-bundle-dir_257": {
       "inputs": {
-        "logos-nix": "logos-nix_1567",
+        "logos-nix": "logos-nix_1568",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95004,7 +95047,7 @@
     },
     "nix-bundle-dir_258": {
       "inputs": {
-        "logos-nix": "logos-nix_1572",
+        "logos-nix": "logos-nix_1573",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95039,7 +95082,7 @@
     },
     "nix-bundle-dir_259": {
       "inputs": {
-        "logos-nix": "logos-nix_1573",
+        "logos-nix": "logos-nix_1574",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95108,7 +95151,7 @@
     },
     "nix-bundle-dir_260": {
       "inputs": {
-        "logos-nix": "logos-nix_1576",
+        "logos-nix": "logos-nix_1577",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95144,7 +95187,7 @@
     },
     "nix-bundle-dir_261": {
       "inputs": {
-        "logos-nix": "logos-nix_1583",
+        "logos-nix": "logos-nix_1584",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95176,7 +95219,7 @@
     },
     "nix-bundle-dir_262": {
       "inputs": {
-        "logos-nix": "logos-nix_1584",
+        "logos-nix": "logos-nix_1585",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95209,7 +95252,7 @@
     },
     "nix-bundle-dir_263": {
       "inputs": {
-        "logos-nix": "logos-nix_1591",
+        "logos-nix": "logos-nix_1592",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95241,7 +95284,7 @@
     },
     "nix-bundle-dir_264": {
       "inputs": {
-        "logos-nix": "logos-nix_1595",
+        "logos-nix": "logos-nix_1596",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95272,7 +95315,7 @@
     },
     "nix-bundle-dir_265": {
       "inputs": {
-        "logos-nix": "logos-nix_1600",
+        "logos-nix": "logos-nix_1601",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95303,7 +95346,7 @@
     },
     "nix-bundle-dir_266": {
       "inputs": {
-        "logos-nix": "logos-nix_1601",
+        "logos-nix": "logos-nix_1602",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95335,7 +95378,7 @@
     },
     "nix-bundle-dir_267": {
       "inputs": {
-        "logos-nix": "logos-nix_1604",
+        "logos-nix": "logos-nix_1605",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95367,7 +95410,7 @@
     },
     "nix-bundle-dir_268": {
       "inputs": {
-        "logos-nix": "logos-nix_1614",
+        "logos-nix": "logos-nix_1615",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95395,7 +95438,7 @@
     },
     "nix-bundle-dir_269": {
       "inputs": {
-        "logos-nix": "logos-nix_1615",
+        "logos-nix": "logos-nix_1616",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95458,7 +95501,7 @@
     },
     "nix-bundle-dir_270": {
       "inputs": {
-        "logos-nix": "logos-nix_1624",
+        "logos-nix": "logos-nix_1625",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95486,7 +95529,7 @@
     },
     "nix-bundle-dir_271": {
       "inputs": {
-        "logos-nix": "logos-nix_1628",
+        "logos-nix": "logos-nix_1629",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95513,7 +95556,7 @@
     },
     "nix-bundle-dir_272": {
       "inputs": {
-        "logos-nix": "logos-nix_1633",
+        "logos-nix": "logos-nix_1634",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95540,7 +95583,7 @@
     },
     "nix-bundle-dir_273": {
       "inputs": {
-        "logos-nix": "logos-nix_1634",
+        "logos-nix": "logos-nix_1635",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95568,7 +95611,7 @@
     },
     "nix-bundle-dir_274": {
       "inputs": {
-        "logos-nix": "logos-nix_1637",
+        "logos-nix": "logos-nix_1638",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95596,7 +95639,7 @@
     },
     "nix-bundle-dir_275": {
       "inputs": {
-        "logos-nix": "logos-nix_1641",
+        "logos-nix": "logos-nix_1642",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95621,7 +95664,7 @@
     },
     "nix-bundle-dir_276": {
       "inputs": {
-        "logos-nix": "logos-nix_1642",
+        "logos-nix": "logos-nix_1643",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -95647,7 +95690,7 @@
     },
     "nix-bundle-dir_277": {
       "inputs": {
-        "logos-nix": "logos-nix_1681",
+        "logos-nix": "logos-nix_1682",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95681,7 +95724,7 @@
     },
     "nix-bundle-dir_278": {
       "inputs": {
-        "logos-nix": "logos-nix_1682",
+        "logos-nix": "logos-nix_1683",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95716,7 +95759,7 @@
     },
     "nix-bundle-dir_279": {
       "inputs": {
-        "logos-nix": "logos-nix_1689",
+        "logos-nix": "logos-nix_1690",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95784,7 +95827,7 @@
     },
     "nix-bundle-dir_280": {
       "inputs": {
-        "logos-nix": "logos-nix_1693",
+        "logos-nix": "logos-nix_1694",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95817,7 +95860,7 @@
     },
     "nix-bundle-dir_281": {
       "inputs": {
-        "logos-nix": "logos-nix_1698",
+        "logos-nix": "logos-nix_1699",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95850,7 +95893,7 @@
     },
     "nix-bundle-dir_282": {
       "inputs": {
-        "logos-nix": "logos-nix_1699",
+        "logos-nix": "logos-nix_1700",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95884,7 +95927,7 @@
     },
     "nix-bundle-dir_283": {
       "inputs": {
-        "logos-nix": "logos-nix_1702",
+        "logos-nix": "logos-nix_1703",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95918,7 +95961,7 @@
     },
     "nix-bundle-dir_284": {
       "inputs": {
-        "logos-nix": "logos-nix_1725",
+        "logos-nix": "logos-nix_1726",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95953,7 +95996,7 @@
     },
     "nix-bundle-dir_285": {
       "inputs": {
-        "logos-nix": "logos-nix_1726",
+        "logos-nix": "logos-nix_1727",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -95989,7 +96032,7 @@
     },
     "nix-bundle-dir_286": {
       "inputs": {
-        "logos-nix": "logos-nix_1733",
+        "logos-nix": "logos-nix_1734",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96024,7 +96067,7 @@
     },
     "nix-bundle-dir_287": {
       "inputs": {
-        "logos-nix": "logos-nix_1737",
+        "logos-nix": "logos-nix_1738",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96058,7 +96101,7 @@
     },
     "nix-bundle-dir_288": {
       "inputs": {
-        "logos-nix": "logos-nix_1742",
+        "logos-nix": "logos-nix_1743",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96092,7 +96135,7 @@
     },
     "nix-bundle-dir_289": {
       "inputs": {
-        "logos-nix": "logos-nix_1743",
+        "logos-nix": "logos-nix_1744",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96162,7 +96205,7 @@
     },
     "nix-bundle-dir_290": {
       "inputs": {
-        "logos-nix": "logos-nix_1746",
+        "logos-nix": "logos-nix_1747",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96197,7 +96240,7 @@
     },
     "nix-bundle-dir_291": {
       "inputs": {
-        "logos-nix": "logos-nix_1753",
+        "logos-nix": "logos-nix_1754",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96228,7 +96271,7 @@
     },
     "nix-bundle-dir_292": {
       "inputs": {
-        "logos-nix": "logos-nix_1754",
+        "logos-nix": "logos-nix_1755",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96260,7 +96303,7 @@
     },
     "nix-bundle-dir_293": {
       "inputs": {
-        "logos-nix": "logos-nix_1761",
+        "logos-nix": "logos-nix_1762",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96291,7 +96334,7 @@
     },
     "nix-bundle-dir_294": {
       "inputs": {
-        "logos-nix": "logos-nix_1765",
+        "logos-nix": "logos-nix_1766",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96321,7 +96364,7 @@
     },
     "nix-bundle-dir_295": {
       "inputs": {
-        "logos-nix": "logos-nix_1770",
+        "logos-nix": "logos-nix_1771",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96351,7 +96394,7 @@
     },
     "nix-bundle-dir_296": {
       "inputs": {
-        "logos-nix": "logos-nix_1771",
+        "logos-nix": "logos-nix_1772",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96382,7 +96425,7 @@
     },
     "nix-bundle-dir_297": {
       "inputs": {
-        "logos-nix": "logos-nix_1774",
+        "logos-nix": "logos-nix_1775",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96413,7 +96456,7 @@
     },
     "nix-bundle-dir_298": {
       "inputs": {
-        "logos-nix": "logos-nix_1811",
+        "logos-nix": "logos-nix_1812",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96448,7 +96491,7 @@
     },
     "nix-bundle-dir_299": {
       "inputs": {
-        "logos-nix": "logos-nix_1812",
+        "logos-nix": "logos-nix_1813",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96553,7 +96596,7 @@
     },
     "nix-bundle-dir_300": {
       "inputs": {
-        "logos-nix": "logos-nix_1819",
+        "logos-nix": "logos-nix_1820",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96588,7 +96631,7 @@
     },
     "nix-bundle-dir_301": {
       "inputs": {
-        "logos-nix": "logos-nix_1823",
+        "logos-nix": "logos-nix_1824",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96622,7 +96665,7 @@
     },
     "nix-bundle-dir_302": {
       "inputs": {
-        "logos-nix": "logos-nix_1828",
+        "logos-nix": "logos-nix_1829",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96656,7 +96699,7 @@
     },
     "nix-bundle-dir_303": {
       "inputs": {
-        "logos-nix": "logos-nix_1829",
+        "logos-nix": "logos-nix_1830",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96691,7 +96734,7 @@
     },
     "nix-bundle-dir_304": {
       "inputs": {
-        "logos-nix": "logos-nix_1832",
+        "logos-nix": "logos-nix_1833",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96726,7 +96769,7 @@
     },
     "nix-bundle-dir_305": {
       "inputs": {
-        "logos-nix": "logos-nix_1855",
+        "logos-nix": "logos-nix_1856",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96762,7 +96805,7 @@
     },
     "nix-bundle-dir_306": {
       "inputs": {
-        "logos-nix": "logos-nix_1856",
+        "logos-nix": "logos-nix_1857",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96799,7 +96842,7 @@
     },
     "nix-bundle-dir_307": {
       "inputs": {
-        "logos-nix": "logos-nix_1863",
+        "logos-nix": "logos-nix_1864",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96835,7 +96878,7 @@
     },
     "nix-bundle-dir_308": {
       "inputs": {
-        "logos-nix": "logos-nix_1867",
+        "logos-nix": "logos-nix_1868",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96870,7 +96913,7 @@
     },
     "nix-bundle-dir_309": {
       "inputs": {
-        "logos-nix": "logos-nix_1872",
+        "logos-nix": "logos-nix_1873",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96940,7 +96983,7 @@
     },
     "nix-bundle-dir_310": {
       "inputs": {
-        "logos-nix": "logos-nix_1873",
+        "logos-nix": "logos-nix_1874",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -96976,7 +97019,7 @@
     },
     "nix-bundle-dir_311": {
       "inputs": {
-        "logos-nix": "logos-nix_1876",
+        "logos-nix": "logos-nix_1877",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97012,7 +97055,7 @@
     },
     "nix-bundle-dir_312": {
       "inputs": {
-        "logos-nix": "logos-nix_1883",
+        "logos-nix": "logos-nix_1884",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97044,7 +97087,7 @@
     },
     "nix-bundle-dir_313": {
       "inputs": {
-        "logos-nix": "logos-nix_1884",
+        "logos-nix": "logos-nix_1885",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97077,7 +97120,7 @@
     },
     "nix-bundle-dir_314": {
       "inputs": {
-        "logos-nix": "logos-nix_1891",
+        "logos-nix": "logos-nix_1892",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97109,7 +97152,7 @@
     },
     "nix-bundle-dir_315": {
       "inputs": {
-        "logos-nix": "logos-nix_1895",
+        "logos-nix": "logos-nix_1896",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97140,7 +97183,7 @@
     },
     "nix-bundle-dir_316": {
       "inputs": {
-        "logos-nix": "logos-nix_1900",
+        "logos-nix": "logos-nix_1901",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97171,7 +97214,7 @@
     },
     "nix-bundle-dir_317": {
       "inputs": {
-        "logos-nix": "logos-nix_1901",
+        "logos-nix": "logos-nix_1902",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97203,7 +97246,7 @@
     },
     "nix-bundle-dir_318": {
       "inputs": {
-        "logos-nix": "logos-nix_1904",
+        "logos-nix": "logos-nix_1905",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97235,7 +97278,7 @@
     },
     "nix-bundle-dir_319": {
       "inputs": {
-        "logos-nix": "logos-nix_1914",
+        "logos-nix": "logos-nix_1915",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97297,7 +97340,7 @@
     },
     "nix-bundle-dir_320": {
       "inputs": {
-        "logos-nix": "logos-nix_1915",
+        "logos-nix": "logos-nix_1916",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97326,7 +97369,7 @@
     },
     "nix-bundle-dir_321": {
       "inputs": {
-        "logos-nix": "logos-nix_1924",
+        "logos-nix": "logos-nix_1925",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97354,7 +97397,7 @@
     },
     "nix-bundle-dir_322": {
       "inputs": {
-        "logos-nix": "logos-nix_1928",
+        "logos-nix": "logos-nix_1929",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97381,7 +97424,7 @@
     },
     "nix-bundle-dir_323": {
       "inputs": {
-        "logos-nix": "logos-nix_1933",
+        "logos-nix": "logos-nix_1934",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97408,7 +97451,7 @@
     },
     "nix-bundle-dir_324": {
       "inputs": {
-        "logos-nix": "logos-nix_1934",
+        "logos-nix": "logos-nix_1935",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97436,7 +97479,7 @@
     },
     "nix-bundle-dir_325": {
       "inputs": {
-        "logos-nix": "logos-nix_1937",
+        "logos-nix": "logos-nix_1938",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97464,7 +97507,7 @@
     },
     "nix-bundle-dir_326": {
       "inputs": {
-        "logos-nix": "logos-nix_1941",
+        "logos-nix": "logos-nix_1942",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97489,7 +97532,7 @@
     },
     "nix-bundle-dir_327": {
       "inputs": {
-        "logos-nix": "logos-nix_1942",
+        "logos-nix": "logos-nix_1943",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -97515,7 +97558,7 @@
     },
     "nix-bundle-dir_328": {
       "inputs": {
-        "logos-nix": "logos-nix_1946",
+        "logos-nix": "logos-nix_1947",
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -97537,7 +97580,7 @@
     },
     "nix-bundle-dir_329": {
       "inputs": {
-        "logos-nix": "logos-nix_1947",
+        "logos-nix": "logos-nix_1948",
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -97594,7 +97637,7 @@
     },
     "nix-bundle-dir_330": {
       "inputs": {
-        "logos-nix": "logos-nix_1952",
+        "logos-nix": "logos-nix_1953",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -97618,7 +97661,7 @@
     },
     "nix-bundle-dir_331": {
       "inputs": {
-        "logos-nix": "logos-nix_1953",
+        "logos-nix": "logos-nix_1954",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -97643,7 +97686,7 @@
     },
     "nix-bundle-dir_332": {
       "inputs": {
-        "logos-nix": "logos-nix_1956",
+        "logos-nix": "logos-nix_1957",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -99970,8 +100013,8 @@
     },
     "nix-bundle-lgx_100": {
       "inputs": {
-        "logos-nix": "logos-nix_1459",
-        "logos-package": "logos-package_172",
+        "logos-nix": "logos-nix_1460",
+        "logos-package": "logos-package_173",
         "nix-bundle-dir": "nix-bundle-dir_242",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100002,8 +100045,8 @@
     },
     "nix-bundle-lgx_101": {
       "inputs": {
-        "logos-nix": "logos-nix_1463",
-        "logos-package": "logos-package_173",
+        "logos-nix": "logos-nix_1464",
+        "logos-package": "logos-package_174",
         "nix-bundle-dir": "nix-bundle-dir_243",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100033,8 +100076,8 @@
     },
     "nix-bundle-lgx_102": {
       "inputs": {
-        "logos-nix": "logos-nix_1472",
-        "logos-package": "logos-package_175",
+        "logos-nix": "logos-nix_1473",
+        "logos-package": "logos-package_176",
         "nix-bundle-dir": "nix-bundle-dir_246",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100065,8 +100108,8 @@
     },
     "nix-bundle-lgx_103": {
       "inputs": {
-        "logos-nix": "logos-nix_1517",
-        "logos-package": "logos-package_177",
+        "logos-nix": "logos-nix_1518",
+        "logos-package": "logos-package_178",
         "nix-bundle-dir": "nix-bundle-dir_249",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100100,8 +100143,8 @@
     },
     "nix-bundle-lgx_104": {
       "inputs": {
-        "logos-nix": "logos-nix_1521",
-        "logos-package": "logos-package_178",
+        "logos-nix": "logos-nix_1522",
+        "logos-package": "logos-package_179",
         "nix-bundle-dir": "nix-bundle-dir_250",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100135,8 +100178,8 @@
     },
     "nix-bundle-lgx_105": {
       "inputs": {
-        "logos-nix": "logos-nix_1530",
-        "logos-package": "logos-package_180",
+        "logos-nix": "logos-nix_1531",
+        "logos-package": "logos-package_181",
         "nix-bundle-dir": "nix-bundle-dir_253",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100171,8 +100214,8 @@
     },
     "nix-bundle-lgx_106": {
       "inputs": {
-        "logos-nix": "logos-nix_1561",
-        "logos-package": "logos-package_182",
+        "logos-nix": "logos-nix_1562",
+        "logos-package": "logos-package_183",
         "nix-bundle-dir": "nix-bundle-dir_256",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100207,8 +100250,8 @@
     },
     "nix-bundle-lgx_107": {
       "inputs": {
-        "logos-nix": "logos-nix_1565",
-        "logos-package": "logos-package_183",
+        "logos-nix": "logos-nix_1566",
+        "logos-package": "logos-package_184",
         "nix-bundle-dir": "nix-bundle-dir_257",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100243,8 +100286,8 @@
     },
     "nix-bundle-lgx_108": {
       "inputs": {
-        "logos-nix": "logos-nix_1574",
-        "logos-package": "logos-package_185",
+        "logos-nix": "logos-nix_1575",
+        "logos-package": "logos-package_186",
         "nix-bundle-dir": "nix-bundle-dir_260",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100280,8 +100323,8 @@
     },
     "nix-bundle-lgx_109": {
       "inputs": {
-        "logos-nix": "logos-nix_1589",
-        "logos-package": "logos-package_187",
+        "logos-nix": "logos-nix_1590",
+        "logos-package": "logos-package_188",
         "nix-bundle-dir": "nix-bundle-dir_263",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100347,8 +100390,8 @@
     },
     "nix-bundle-lgx_110": {
       "inputs": {
-        "logos-nix": "logos-nix_1593",
-        "logos-package": "logos-package_188",
+        "logos-nix": "logos-nix_1594",
+        "logos-package": "logos-package_189",
         "nix-bundle-dir": "nix-bundle-dir_264",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100379,8 +100422,8 @@
     },
     "nix-bundle-lgx_111": {
       "inputs": {
-        "logos-nix": "logos-nix_1602",
-        "logos-package": "logos-package_190",
+        "logos-nix": "logos-nix_1603",
+        "logos-package": "logos-package_191",
         "nix-bundle-dir": "nix-bundle-dir_267",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100412,8 +100455,8 @@
     },
     "nix-bundle-lgx_112": {
       "inputs": {
-        "logos-nix": "logos-nix_1622",
-        "logos-package": "logos-package_192",
+        "logos-nix": "logos-nix_1623",
+        "logos-package": "logos-package_193",
         "nix-bundle-dir": "nix-bundle-dir_270",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100441,8 +100484,8 @@
     },
     "nix-bundle-lgx_113": {
       "inputs": {
-        "logos-nix": "logos-nix_1626",
-        "logos-package": "logos-package_193",
+        "logos-nix": "logos-nix_1627",
+        "logos-package": "logos-package_194",
         "nix-bundle-dir": "nix-bundle-dir_271",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100469,8 +100512,8 @@
     },
     "nix-bundle-lgx_114": {
       "inputs": {
-        "logos-nix": "logos-nix_1635",
-        "logos-package": "logos-package_195",
+        "logos-nix": "logos-nix_1636",
+        "logos-package": "logos-package_196",
         "nix-bundle-dir": "nix-bundle-dir_274",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100498,8 +100541,8 @@
     },
     "nix-bundle-lgx_115": {
       "inputs": {
-        "logos-nix": "logos-nix_1687",
-        "logos-package": "logos-package_198",
+        "logos-nix": "logos-nix_1688",
+        "logos-package": "logos-package_199",
         "nix-bundle-dir": "nix-bundle-dir_279",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100532,8 +100575,8 @@
     },
     "nix-bundle-lgx_116": {
       "inputs": {
-        "logos-nix": "logos-nix_1691",
-        "logos-package": "logos-package_199",
+        "logos-nix": "logos-nix_1692",
+        "logos-package": "logos-package_200",
         "nix-bundle-dir": "nix-bundle-dir_280",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100566,8 +100609,8 @@
     },
     "nix-bundle-lgx_117": {
       "inputs": {
-        "logos-nix": "logos-nix_1700",
-        "logos-package": "logos-package_201",
+        "logos-nix": "logos-nix_1701",
+        "logos-package": "logos-package_202",
         "nix-bundle-dir": "nix-bundle-dir_283",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100601,8 +100644,8 @@
     },
     "nix-bundle-lgx_118": {
       "inputs": {
-        "logos-nix": "logos-nix_1731",
-        "logos-package": "logos-package_203",
+        "logos-nix": "logos-nix_1732",
+        "logos-package": "logos-package_204",
         "nix-bundle-dir": "nix-bundle-dir_286",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100636,8 +100679,8 @@
     },
     "nix-bundle-lgx_119": {
       "inputs": {
-        "logos-nix": "logos-nix_1735",
-        "logos-package": "logos-package_204",
+        "logos-nix": "logos-nix_1736",
+        "logos-package": "logos-package_205",
         "nix-bundle-dir": "nix-bundle-dir_287",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100706,8 +100749,8 @@
     },
     "nix-bundle-lgx_120": {
       "inputs": {
-        "logos-nix": "logos-nix_1744",
-        "logos-package": "logos-package_206",
+        "logos-nix": "logos-nix_1745",
+        "logos-package": "logos-package_207",
         "nix-bundle-dir": "nix-bundle-dir_290",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100742,8 +100785,8 @@
     },
     "nix-bundle-lgx_121": {
       "inputs": {
-        "logos-nix": "logos-nix_1759",
-        "logos-package": "logos-package_208",
+        "logos-nix": "logos-nix_1760",
+        "logos-package": "logos-package_209",
         "nix-bundle-dir": "nix-bundle-dir_293",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100774,8 +100817,8 @@
     },
     "nix-bundle-lgx_122": {
       "inputs": {
-        "logos-nix": "logos-nix_1763",
-        "logos-package": "logos-package_209",
+        "logos-nix": "logos-nix_1764",
+        "logos-package": "logos-package_210",
         "nix-bundle-dir": "nix-bundle-dir_294",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100805,8 +100848,8 @@
     },
     "nix-bundle-lgx_123": {
       "inputs": {
-        "logos-nix": "logos-nix_1772",
-        "logos-package": "logos-package_211",
+        "logos-nix": "logos-nix_1773",
+        "logos-package": "logos-package_212",
         "nix-bundle-dir": "nix-bundle-dir_297",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100837,8 +100880,8 @@
     },
     "nix-bundle-lgx_124": {
       "inputs": {
-        "logos-nix": "logos-nix_1817",
-        "logos-package": "logos-package_213",
+        "logos-nix": "logos-nix_1818",
+        "logos-package": "logos-package_214",
         "nix-bundle-dir": "nix-bundle-dir_300",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100872,8 +100915,8 @@
     },
     "nix-bundle-lgx_125": {
       "inputs": {
-        "logos-nix": "logos-nix_1821",
-        "logos-package": "logos-package_214",
+        "logos-nix": "logos-nix_1822",
+        "logos-package": "logos-package_215",
         "nix-bundle-dir": "nix-bundle-dir_301",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100907,8 +100950,8 @@
     },
     "nix-bundle-lgx_126": {
       "inputs": {
-        "logos-nix": "logos-nix_1830",
-        "logos-package": "logos-package_216",
+        "logos-nix": "logos-nix_1831",
+        "logos-package": "logos-package_217",
         "nix-bundle-dir": "nix-bundle-dir_304",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100943,8 +100986,8 @@
     },
     "nix-bundle-lgx_127": {
       "inputs": {
-        "logos-nix": "logos-nix_1861",
-        "logos-package": "logos-package_218",
+        "logos-nix": "logos-nix_1862",
+        "logos-package": "logos-package_219",
         "nix-bundle-dir": "nix-bundle-dir_307",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -100979,8 +101022,8 @@
     },
     "nix-bundle-lgx_128": {
       "inputs": {
-        "logos-nix": "logos-nix_1865",
-        "logos-package": "logos-package_219",
+        "logos-nix": "logos-nix_1866",
+        "logos-package": "logos-package_220",
         "nix-bundle-dir": "nix-bundle-dir_308",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101015,8 +101058,8 @@
     },
     "nix-bundle-lgx_129": {
       "inputs": {
-        "logos-nix": "logos-nix_1874",
-        "logos-package": "logos-package_221",
+        "logos-nix": "logos-nix_1875",
+        "logos-package": "logos-package_222",
         "nix-bundle-dir": "nix-bundle-dir_311",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101087,8 +101130,8 @@
     },
     "nix-bundle-lgx_130": {
       "inputs": {
-        "logos-nix": "logos-nix_1889",
-        "logos-package": "logos-package_223",
+        "logos-nix": "logos-nix_1890",
+        "logos-package": "logos-package_224",
         "nix-bundle-dir": "nix-bundle-dir_314",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101120,8 +101163,8 @@
     },
     "nix-bundle-lgx_131": {
       "inputs": {
-        "logos-nix": "logos-nix_1893",
-        "logos-package": "logos-package_224",
+        "logos-nix": "logos-nix_1894",
+        "logos-package": "logos-package_225",
         "nix-bundle-dir": "nix-bundle-dir_315",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101152,8 +101195,8 @@
     },
     "nix-bundle-lgx_132": {
       "inputs": {
-        "logos-nix": "logos-nix_1902",
-        "logos-package": "logos-package_226",
+        "logos-nix": "logos-nix_1903",
+        "logos-package": "logos-package_227",
         "nix-bundle-dir": "nix-bundle-dir_318",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101185,8 +101228,8 @@
     },
     "nix-bundle-lgx_133": {
       "inputs": {
-        "logos-nix": "logos-nix_1922",
-        "logos-package": "logos-package_228",
+        "logos-nix": "logos-nix_1923",
+        "logos-package": "logos-package_229",
         "nix-bundle-dir": "nix-bundle-dir_321",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101214,8 +101257,8 @@
     },
     "nix-bundle-lgx_134": {
       "inputs": {
-        "logos-nix": "logos-nix_1926",
-        "logos-package": "logos-package_229",
+        "logos-nix": "logos-nix_1927",
+        "logos-package": "logos-package_230",
         "nix-bundle-dir": "nix-bundle-dir_322",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101242,8 +101285,8 @@
     },
     "nix-bundle-lgx_135": {
       "inputs": {
-        "logos-nix": "logos-nix_1935",
-        "logos-package": "logos-package_231",
+        "logos-nix": "logos-nix_1936",
+        "logos-package": "logos-package_232",
         "nix-bundle-dir": "nix-bundle-dir_325",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -101271,8 +101314,8 @@
     },
     "nix-bundle-lgx_136": {
       "inputs": {
-        "logos-nix": "logos-nix_1954",
-        "logos-package": "logos-package_234",
+        "logos-nix": "logos-nix_1955",
+        "logos-package": "logos-package_235",
         "nix-bundle-dir": "nix-bundle-dir_332",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -104131,8 +104174,8 @@
     },
     "nix-bundle-lgx_94": {
       "inputs": {
-        "logos-nix": "logos-nix_1387",
-        "logos-package": "logos-package_162",
+        "logos-nix": "logos-nix_1388",
+        "logos-package": "logos-package_163",
         "nix-bundle-dir": "nix-bundle-dir_228",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -104165,8 +104208,8 @@
     },
     "nix-bundle-lgx_95": {
       "inputs": {
-        "logos-nix": "logos-nix_1391",
-        "logos-package": "logos-package_163",
+        "logos-nix": "logos-nix_1392",
+        "logos-package": "logos-package_164",
         "nix-bundle-dir": "nix-bundle-dir_229",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -104199,8 +104242,8 @@
     },
     "nix-bundle-lgx_96": {
       "inputs": {
-        "logos-nix": "logos-nix_1400",
-        "logos-package": "logos-package_165",
+        "logos-nix": "logos-nix_1401",
+        "logos-package": "logos-package_166",
         "nix-bundle-dir": "nix-bundle-dir_232",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -104234,8 +104277,8 @@
     },
     "nix-bundle-lgx_97": {
       "inputs": {
-        "logos-nix": "logos-nix_1431",
-        "logos-package": "logos-package_167",
+        "logos-nix": "logos-nix_1432",
+        "logos-package": "logos-package_168",
         "nix-bundle-dir": "nix-bundle-dir_235",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -104269,8 +104312,8 @@
     },
     "nix-bundle-lgx_98": {
       "inputs": {
-        "logos-nix": "logos-nix_1435",
-        "logos-package": "logos-package_168",
+        "logos-nix": "logos-nix_1436",
+        "logos-package": "logos-package_169",
         "nix-bundle-dir": "nix-bundle-dir_236",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -104304,8 +104347,8 @@
     },
     "nix-bundle-lgx_99": {
       "inputs": {
-        "logos-nix": "logos-nix_1444",
-        "logos-package": "logos-package_170",
+        "logos-nix": "logos-nix_1445",
+        "logos-package": "logos-package_171",
         "nix-bundle-dir": "nix-bundle-dir_239",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -105137,7 +105180,7 @@
     },
     "nix-bundle-logos-module-install_32": {
       "inputs": {
-        "logos-nix": "logos-nix_1394",
+        "logos-nix": "logos-nix_1395",
         "logos-package-manager": "logos-package-manager_67",
         "nix-bundle-lgx": "nix-bundle-lgx_96",
         "nixpkgs": [
@@ -105171,7 +105214,7 @@
     },
     "nix-bundle-logos-module-install_33": {
       "inputs": {
-        "logos-nix": "logos-nix_1438",
+        "logos-nix": "logos-nix_1439",
         "logos-package-manager": "logos-package-manager_69",
         "nix-bundle-lgx": "nix-bundle-lgx_99",
         "nixpkgs": [
@@ -105206,7 +105249,7 @@
     },
     "nix-bundle-logos-module-install_34": {
       "inputs": {
-        "logos-nix": "logos-nix_1466",
+        "logos-nix": "logos-nix_1467",
         "logos-package-manager": "logos-package-manager_71",
         "nix-bundle-lgx": "nix-bundle-lgx_102",
         "nixpkgs": [
@@ -105237,7 +105280,7 @@
     },
     "nix-bundle-logos-module-install_35": {
       "inputs": {
-        "logos-nix": "logos-nix_1524",
+        "logos-nix": "logos-nix_1525",
         "logos-package-manager": "logos-package-manager_73",
         "nix-bundle-lgx": "nix-bundle-lgx_105",
         "nixpkgs": [
@@ -105272,7 +105315,7 @@
     },
     "nix-bundle-logos-module-install_36": {
       "inputs": {
-        "logos-nix": "logos-nix_1568",
+        "logos-nix": "logos-nix_1569",
         "logos-package-manager": "logos-package-manager_75",
         "nix-bundle-lgx": "nix-bundle-lgx_108",
         "nixpkgs": [
@@ -105308,7 +105351,7 @@
     },
     "nix-bundle-logos-module-install_37": {
       "inputs": {
-        "logos-nix": "logos-nix_1596",
+        "logos-nix": "logos-nix_1597",
         "logos-package-manager": "logos-package-manager_77",
         "nix-bundle-lgx": "nix-bundle-lgx_111",
         "nixpkgs": [
@@ -105340,7 +105383,7 @@
     },
     "nix-bundle-logos-module-install_38": {
       "inputs": {
-        "logos-nix": "logos-nix_1629",
+        "logos-nix": "logos-nix_1630",
         "logos-package-manager": "logos-package-manager_79",
         "nix-bundle-lgx": "nix-bundle-lgx_114",
         "nixpkgs": [
@@ -105368,7 +105411,7 @@
     },
     "nix-bundle-logos-module-install_39": {
       "inputs": {
-        "logos-nix": "logos-nix_1694",
+        "logos-nix": "logos-nix_1695",
         "logos-package-manager": "logos-package-manager_81",
         "nix-bundle-lgx": "nix-bundle-lgx_117",
         "nixpkgs": [
@@ -105436,7 +105479,7 @@
     },
     "nix-bundle-logos-module-install_40": {
       "inputs": {
-        "logos-nix": "logos-nix_1738",
+        "logos-nix": "logos-nix_1739",
         "logos-package-manager": "logos-package-manager_83",
         "nix-bundle-lgx": "nix-bundle-lgx_120",
         "nixpkgs": [
@@ -105471,7 +105514,7 @@
     },
     "nix-bundle-logos-module-install_41": {
       "inputs": {
-        "logos-nix": "logos-nix_1766",
+        "logos-nix": "logos-nix_1767",
         "logos-package-manager": "logos-package-manager_85",
         "nix-bundle-lgx": "nix-bundle-lgx_123",
         "nixpkgs": [
@@ -105502,7 +105545,7 @@
     },
     "nix-bundle-logos-module-install_42": {
       "inputs": {
-        "logos-nix": "logos-nix_1824",
+        "logos-nix": "logos-nix_1825",
         "logos-package-manager": "logos-package-manager_87",
         "nix-bundle-lgx": "nix-bundle-lgx_126",
         "nixpkgs": [
@@ -105537,7 +105580,7 @@
     },
     "nix-bundle-logos-module-install_43": {
       "inputs": {
-        "logos-nix": "logos-nix_1868",
+        "logos-nix": "logos-nix_1869",
         "logos-package-manager": "logos-package-manager_89",
         "nix-bundle-lgx": "nix-bundle-lgx_129",
         "nixpkgs": [
@@ -105573,7 +105616,7 @@
     },
     "nix-bundle-logos-module-install_44": {
       "inputs": {
-        "logos-nix": "logos-nix_1896",
+        "logos-nix": "logos-nix_1897",
         "logos-package-manager": "logos-package-manager_91",
         "nix-bundle-lgx": "nix-bundle-lgx_132",
         "nixpkgs": [
@@ -105605,7 +105648,7 @@
     },
     "nix-bundle-logos-module-install_45": {
       "inputs": {
-        "logos-nix": "logos-nix_1929",
+        "logos-nix": "logos-nix_1930",
         "logos-package-manager": "logos-package-manager_93",
         "nix-bundle-lgx": "nix-bundle-lgx_135",
         "nixpkgs": [
@@ -105633,7 +105676,7 @@
     },
     "nix-bundle-logos-module-install_46": {
       "inputs": {
-        "logos-nix": "logos-nix_1948",
+        "logos-nix": "logos-nix_1949",
         "logos-package-manager": "logos-package-manager_95",
         "nix-bundle-lgx": "nix-bundle-lgx_136",
         "nixpkgs": [
@@ -105814,7 +105857,7 @@
     },
     "nix-bundle-macos-app": {
       "inputs": {
-        "logos-nix": "logos-nix_1957",
+        "logos-nix": "logos-nix_1958",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -122876,6 +122919,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_1958": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_196": {
       "locked": {
         "lastModified": 1759036355,
@@ -137154,11 +137213,11 @@
         "logos-package-downloader": "logos-package-downloader_2"
       },
       "locked": {
-        "lastModified": 1782499393,
-        "narHash": "sha256-WcLd0zCD/R9zG7EKpFXPXhuuyldufycsd62WhoUYluI=",
+        "lastModified": 1784209035,
+        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "e6289af5ef9dc3ff27752b4475708ccc8d865261",
+        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
         "type": "github"
       },
       "original": {
@@ -137173,11 +137232,11 @@
         "logos-package-manager": "logos-package-manager_94"
       },
       "locked": {
-        "lastModified": 1782499400,
-        "narHash": "sha256-JTA3QDUXFNPLgJkKPc4huWzQxTb5eZcVew31pljXKv8=",
+        "lastModified": 1784208334,
+        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "128f543564acdb09ebf4c27574eca5ba88e2297e",
+        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
         "type": "github"
       },
       "original": {
@@ -138009,7 +138068,7 @@
     },
     "process-stats_33": {
       "inputs": {
-        "logos-nix": "logos-nix_1383",
+        "logos-nix": "logos-nix_1384",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138043,7 +138102,7 @@
     },
     "process-stats_34": {
       "inputs": {
-        "logos-nix": "logos-nix_1427",
+        "logos-nix": "logos-nix_1428",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138078,7 +138137,7 @@
     },
     "process-stats_35": {
       "inputs": {
-        "logos-nix": "logos-nix_1455",
+        "logos-nix": "logos-nix_1456",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138109,7 +138168,7 @@
     },
     "process-stats_36": {
       "inputs": {
-        "logos-nix": "logos-nix_1513",
+        "logos-nix": "logos-nix_1514",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138144,7 +138203,7 @@
     },
     "process-stats_37": {
       "inputs": {
-        "logos-nix": "logos-nix_1557",
+        "logos-nix": "logos-nix_1558",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138180,7 +138239,7 @@
     },
     "process-stats_38": {
       "inputs": {
-        "logos-nix": "logos-nix_1585",
+        "logos-nix": "logos-nix_1586",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138212,7 +138271,7 @@
     },
     "process-stats_39": {
       "inputs": {
-        "logos-nix": "logos-nix_1618",
+        "logos-nix": "logos-nix_1619",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -138274,7 +138333,7 @@
     },
     "process-stats_40": {
       "inputs": {
-        "logos-nix": "logos-nix_1683",
+        "logos-nix": "logos-nix_1684",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138308,7 +138367,7 @@
     },
     "process-stats_41": {
       "inputs": {
-        "logos-nix": "logos-nix_1727",
+        "logos-nix": "logos-nix_1728",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138343,7 +138402,7 @@
     },
     "process-stats_42": {
       "inputs": {
-        "logos-nix": "logos-nix_1755",
+        "logos-nix": "logos-nix_1756",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138374,7 +138433,7 @@
     },
     "process-stats_43": {
       "inputs": {
-        "logos-nix": "logos-nix_1813",
+        "logos-nix": "logos-nix_1814",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138409,7 +138468,7 @@
     },
     "process-stats_44": {
       "inputs": {
-        "logos-nix": "logos-nix_1857",
+        "logos-nix": "logos-nix_1858",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138445,7 +138504,7 @@
     },
     "process-stats_45": {
       "inputs": {
-        "logos-nix": "logos-nix_1885",
+        "logos-nix": "logos-nix_1886",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -138477,7 +138536,7 @@
     },
     "process-stats_46": {
       "inputs": {
-        "logos-nix": "logos-nix_1918",
+        "logos-nix": "logos-nix_1919",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",

--- a/flake.nix
+++ b/flake.nix
@@ -102,6 +102,11 @@
         logosPackageManagerModuleLibPortable = logos-package-manager-module.packages.${system}.lib-portable;
         logosCapabilityModule = logos-capability-module.packages.${system}.default;
         logosPackageLib = logos-package.packages.${system}.lib;
+        # Headers-only output (include/ with logos/semver.hpp + semver/, no
+        # library). main_ui's AppsModel includes the shared semver comparator;
+        # it links nothing from lgx, so the headers output keeps liblgx out of
+        # the app entirely.
+        logosPackageHeaders = logos-package.packages.${system}.headers;
         logosPackageManagerUI = logos-package-manager-ui.packages.${system}.default;
         logosDesignSystem = logos-design-system.packages.${system}.default;
         logosViewModuleRuntime = logos-view-module-runtime.packages.${system}.default;
@@ -116,7 +121,7 @@
       });
     in
     {
-      packages = forAllSystems ({ pkgs, system, logosSdk, logosProtocolPkg, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageManagerUI, logosCapabilityModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
+      packages = forAllSystems ({ pkgs, system, logosSdk, logosProtocolPkg, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
         let
           # Common configuration
           common = import ./nix/default.nix {
@@ -126,13 +131,13 @@
 
           # Plugin packages (development builds)
           mainUIPlugin = import ./nix/main-ui.nix {
-            inherit pkgs common src logosSdk logosProtocolPkg logosQtSdk logosModule logosPackageManagerModule logosPackageDownloaderModule logosLiblogos logosViewModuleRuntime buildInfo;
+            inherit pkgs common src logosSdk logosProtocolPkg logosQtSdk logosModule logosPackageManagerModule logosPackageDownloaderModule logosPackageHeaders logosLiblogos logosViewModuleRuntime buildInfo;
           };
           packageManagerUIPlugin = logosPackageManagerUI;
 
           # Plugin packages (distributed builds for DMG/AppImage)
           mainUIPluginDistributed = import ./nix/main-ui.nix {
-            inherit pkgs common src logosSdk logosProtocolPkg logosQtSdk logosModule logosPackageManagerModule logosPackageDownloaderModule logosLiblogos logosViewModuleRuntime buildInfo;
+            inherit pkgs common src logosSdk logosProtocolPkg logosQtSdk logosModule logosPackageManagerModule logosPackageDownloaderModule logosPackageHeaders logosLiblogos logosViewModuleRuntime buildInfo;
             distributed = true;
           };
 

--- a/nix/main-ui.nix
+++ b/nix/main-ui.nix
@@ -1,5 +1,5 @@
 # Builds the main UI plugin
-{ pkgs, common, src, logosSdk, logosProtocolPkg, logosQtSdk, logosModule, logosPackageManagerModule, logosPackageDownloaderModule, logosLiblogos, logosViewModuleRuntime, buildInfo, distributed ? false }:
+{ pkgs, common, src, logosSdk, logosProtocolPkg, logosQtSdk, logosModule, logosPackageManagerModule, logosPackageDownloaderModule, logosPackageHeaders, logosLiblogos, logosViewModuleRuntime, buildInfo, distributed ? false }:
 
 let
   buildInfoHeader = import ./build-info.nix { inherit pkgs buildInfo; };
@@ -59,6 +59,13 @@ pkgs.stdenv.mkDerivation {
     else
       echo "Warning: No include directory found in logos-package-downloader-module"
     fi
+
+    # Stage the shared semver headers (logos/semver.hpp + its <semver/semver.hpp>)
+    # so AppsModel can use logos::semver::compare. generated_code is already on
+    # main_ui's include path. Headers only — nothing here links liblgx.
+    echo "Copying shared semver headers from logos-package..."
+    cp -r "${logosPackageHeaders}/include/logos"  ./src/generated_code/
+    cp -r "${logosPackageHeaders}/include/semver" ./src/generated_code/
 
     # Run logos-cpp-generator with metadata.json and --general-only flag
     echo "Running logos-cpp-generator (general-only) for main_ui..."

--- a/src/AppsModel.cpp
+++ b/src/AppsModel.cpp
@@ -2,6 +2,8 @@
 
 #include "InstallRegistry.h"
 
+#include <logos/semver.hpp>
+
 #include <QSet>
 
 namespace {
@@ -115,18 +117,17 @@ QStringList AppsModel::categories() const
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
+// Three-way version compare. Returns -1 / 0 / +1.
+//
+// Delegates to the shared semver implementation in logos-package — the same
+// code lgx, lgpm, lgpd and the package-manager UI use. It used to split on '.'
+// and QString::toInt() each component (dropping the `ok` flag), so
+// "0-rc1".toInt() silently yielded 0 and every pre-release compared EQUAL to
+// its own release: an installed 1.0.0-rc.1 against an available 1.0.0 showed no
+// Upgrade, and 1.0.0-rc.2 vs 1.0.0-rc.10 compared equal.
 static int versionCmp(const QString& a, const QString& b)
 {
-    const QStringList aParts = a.split('.');
-    const QStringList bParts = b.split('.');
-    const int n = std::max(aParts.size(), bParts.size());
-    for (int i = 0; i < n; ++i) {
-        const int av = (i < aParts.size()) ? aParts[i].toInt() : 0;
-        const int bv = (i < bParts.size()) ? bParts[i].toInt() : 0;
-        if (av < bv) return -1;
-        if (av > bv) return  1;
-    }
-    return 0;
+    return logos::semver::compare(a.toStdString(), b.toStdString());
 }
 
 void AppsModel::recomputeInstallStatus(Row& r)


### PR DESCRIPTION
Extends the semver-unification chain into the app shell. **Depends on logos-co/logos-package#30** (the shared implementation).

## The bug

`AppsModel::versionCmp` was a **seventh** copy of the same broken comparator — `split('.')` + `QString::toInt()` per component:

```cpp
const int av = (i < aParts.size()) ? aParts[i].toInt() : 0;   // "0-rc1".toInt() -> 0
```

`toInt()` drops its `ok` out-param, so `"0-rc1"` silently becomes `0` and every pre-release compares **equal to its own release**. This comparator drives `recomputeInstallStatus` — the **Upgrade / Downgrade / DifferentHash** decision behind every row in the app manager. So an installed `1.0.0-rc.1` against an available `1.0.0` showed *no upgrade*, and `1.0.0-rc.2` vs `1.0.0-rc.10` compared equal.

(basecamp also reads `versions.first()` as "latest", but that array is now precedence-sorted upstream by the downloader fix, so that half is already correct once the chain lands.)

## The fix

`versionCmp` now delegates to `logos::semver::compare` from logos-package — the same code lgx, lgpm, lgpd and the package-manager UI use.

`main_ui` stages the shared headers (`logos/semver.hpp` and its `<semver/semver.hpp>`) into `generated_code`, which is already on its include path — reusing the exact seam that already stages the module API headers. It **links nothing** from lgx, so no `liblgx`/ICU/libsodium enters the app:

```
$ otool -L result/.../main_ui.dylib | grep -iE 'lgx|sodium|icu'
(no output)
```

It takes logos-package's `headers` output (include-only) rather than `lib` for exactly that reason.

## Chain

Re-pins the chain inputs basecamp consumes directly — `logos-package` (also required for the `headers` output to exist), `logos-package-manager` (#25), and `logos-package-manager-ui` (#51) — at their branch heads so CI can build. **Re-pin to `master` as the chain merges.** The `-module` inputs aren't in the chain; they get the fix via the workspace `follows` and their own later re-pins.

Verified locally: `nix build .#main-ui-plugin` compiles `AppsModel` against the shared comparator and links clean.

Merge order: logos-package#30 → package-manager#25 / package-downloader#17 → package-manager-ui#51 / **this** → modules-release-tool#4 → workspace#93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)