### PR TITLE
fix: pinned dependency version no longer reverts in the app manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61478,11 +61478,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784207645,
-        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
+        "lastModified": 1784226863,
+        "narHash": "sha256-4B+UmgnZTIY3tvXSHtFAVaiGzHYm7Lmo/LaYrt4BinM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
+        "rev": "8d5128b2195bb8bdebb3f623fa2026b0546203dc",
         "type": "github"
       },
       "original": {
@@ -61497,11 +61497,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1784209035,
-        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
+        "lastModified": 1784227209,
+        "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
+        "rev": "6b8790ecebb56091c088da69b6a0faa18dcb2ce1",
         "type": "github"
       },
       "original": {
@@ -61525,11 +61525,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784207645,
-        "narHash": "sha256-FEq/vi4ejVFmltUFl6SuP7WwKgy7JgZULekYcUWmUKE=",
+        "lastModified": 1784226863,
+        "narHash": "sha256-4B+UmgnZTIY3tvXSHtFAVaiGzHYm7Lmo/LaYrt4BinM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "736f8ebcf06f754a58e80bde0a51645070418573",
+        "rev": "8d5128b2195bb8bdebb3f623fa2026b0546203dc",
         "type": "github"
       },
       "original": {
@@ -61601,11 +61601,11 @@
         "package_manager": "package_manager"
       },
       "locked": {
-        "lastModified": 1784209970,
-        "narHash": "sha256-dKtBwEpFOuAVqzmsqqb7szkEyhtIPI38qAJdvRbyi00=",
+        "lastModified": 1784228871,
+        "narHash": "sha256-leggO85j92xnwDaqYCdrglk8GYuaA5ybPzqhAQtYe54=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "33f5ba06dff624c722083711e48aeed6cb2ad4b4",
+        "rev": "2ae69fdab4f143c1dc15f1e489aeb4b015e25f1a",
         "type": "github"
       },
       "original": {
@@ -137213,11 +137213,11 @@
         "logos-package-downloader": "logos-package-downloader_2"
       },
       "locked": {
-        "lastModified": 1784209035,
-        "narHash": "sha256-rc3SHfjZDOAyFhr1ILXQtUoGP4ffKsURBFhSDJOq6Z4=",
+        "lastModified": 1784227209,
+        "narHash": "sha256-BK6oygfnpxFxWJr2AGJ9ldIDwAg4rvwFdFAyEOziTMY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "02fcb4abd85fe2eef26094dd3cb46ed5585867c8",
+        "rev": "6b8790ecebb56091c088da69b6a0faa18dcb2ce1",
         "type": "github"
       },
       "original": {

--- a/src/AppsModel.cpp
+++ b/src/AppsModel.cpp
@@ -426,14 +426,25 @@ void AppsModel::setInstallRegistry(InstallRegistry* installRegistry)
 void AppsModel::setResolverOverlay(const QList<ResolverRow>& rows)
 {
     clearResolverOverlay();
+    // A package can appear in the overlay more than once — as a user-pinned
+    // top-level entry AND as a transitive dependency of another pinned package
+    // (resolved to the newest catalog version). Both map to the SAME row via
+    // rowOf(name, repo), so without a guard the transitive copy overwrites the
+    // pin and the version dropdown snaps back to the newest release. An explicit
+    // top-level entry is authoritative: once one has written a row, a later
+    // non-top-level duplicate of the same package must not clobber it.
+    // (Defensive — the resolver also no longer emits that duplicate.)
+    QSet<int> pinnedRows;
     for (const ResolverRow& src : rows) {
         const int idx = rowOf(src.name, src.repositoryUrl);
         if (idx < 0) continue;
+        if (!src.isTopLevel && pinnedRows.contains(idx)) continue;
         Row& r = m_rows[idx];
         r.action        = src.action;
         r.toVersion     = src.toVersion;
         r.isTopLevel    = src.isTopLevel;
         r.resolverError = src.resolverError;
+        if (src.isTopLevel) pinnedRows.insert(idx);
         const QModelIndex mi = index(idx);
         emit dataChanged(mi, mi,
             {ActionRole, ToVersionRole, IsTopLevelRole, ResolverErrorRole});

--- a/src/PackageCoordinator.cpp
+++ b/src/PackageCoordinator.cpp
@@ -1522,7 +1522,7 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
     // Default IPC deadline (20s) is too tight when the catalog blob is many
     // MB or the user is on a slow connection
     constexpr int kDownloadIpcDeadlineMs = 5 * 60 * 1000;
-    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson,
+    logos.package_downloader.downloadResolvedDependenciesAsync(depsJson, QString(),
         [self, name](QVariantList results) {
             if (!self) return;
             if (!results.isEmpty())


### PR DESCRIPTION
Fixes reported issue 2. **Depends on logos-co/logos-package-downloader-module#17** (re-pinned here; carries the resolver dedup).

## The bug

In the Add Application dialog, the version dropdown for a required **module** snapped back to the newest release no matter what the user picked — while a UI app's dropdown stuck. The module is both a user-pinned top-level entry and a transitive dep of the app; the resolver emitted it twice (pin + newest), both mapping to the same `AppsModel` row via `rowOf(name,repo)`, and `setResolverOverlay` let the newest copy overwrite the pin.

## The fix

`setResolverOverlay` now treats a top-level (pinned) entry as authoritative: once one has written a row, a non-top-level duplicate of the same package can't clobber it, in any order. This pairs with the downloader resolver fix (which stops emitting the duplicate at the source) — belt-and-suspenders, per the chosen approach.

Also re-pins `logos-package-downloader-module` for its 2-arg `downloadResolvedDependencies` (the install call passes an empty installed set, matching the existing preview call).

**Independent of the semver PR #257** — different functions in `AppsModel.cpp` (`setResolverOverlay` vs `versionCmp`), based on master; the two rebase cleanly.

> Note: the overlay logic isn't unit-tested here because the repo's `.#unit-tests` target (`apps_model_test.cpp`) doesn't currently compile against `AppsModel` (`setInstallStage` doesn't exist) and CI runs `.#integration-test` instead, so the file is silently broken. Flagged separately. The fix is verified via `nix build .#main-ui-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)