### PR TITLE
feat: single install/upgrade confirmation dialog with dep-change list

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61580,11 +61580,11 @@
         "logos-package-manager": "logos-package-manager_51"
       },
       "locked": {
-        "lastModified": 1784208334,
-        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
+        "lastModified": 1784232744,
+        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
+        "rev": "411ea1135780741acd243564c33840bc838729f7",
         "type": "github"
       },
       "original": {
@@ -61601,11 +61601,11 @@
         "package_manager": "package_manager"
       },
       "locked": {
-        "lastModified": 1784228871,
-        "narHash": "sha256-leggO85j92xnwDaqYCdrglk8GYuaA5ybPzqhAQtYe54=",
+        "lastModified": 1784236061,
+        "narHash": "sha256-jMCKsnHu+9bnN+929Gu1tKzfbXAtJa3l5Xi+9E4ozms=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "2ae69fdab4f143c1dc15f1e489aeb4b015e25f1a",
+        "rev": "f77ebaf13b5694bb62a8277b28834ac215b3df71",
         "type": "github"
       },
       "original": {
@@ -137232,11 +137232,11 @@
         "logos-package-manager": "logos-package-manager_94"
       },
       "locked": {
-        "lastModified": 1784208334,
-        "narHash": "sha256-3aA1n6M1P41nMgeZmZ/s72WOY87FrxFSOIGJ4c4NfM8=",
+        "lastModified": 1784232744,
+        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "439b580b115718a3b2e1637f2816b8ea6ea7decc",
+        "rev": "411ea1135780741acd243564c33840bc838729f7",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -61601,11 +61601,11 @@
         "package_manager": "package_manager"
       },
       "locked": {
-        "lastModified": 1784236061,
-        "narHash": "sha256-jMCKsnHu+9bnN+929Gu1tKzfbXAtJa3l5Xi+9E4ozms=",
+        "lastModified": 1784255860,
+        "narHash": "sha256-TOPzyWVL2IaJpY5VSNzpElmrPqyMqSAyI2EW3sBBvY0=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "f77ebaf13b5694bb62a8277b28834ac215b3df71",
+        "rev": "442243d5cc1cad5dc693917dacf68bfb0115b4e0",
         "type": "github"
       },
       "original": {
@@ -137232,11 +137232,11 @@
         "logos-package-manager": "logos-package-manager_94"
       },
       "locked": {
-        "lastModified": 1784232744,
-        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
+        "lastModified": 1784254343,
+        "narHash": "sha256-3+JOesTqQsSy2y0EYphzQXSL5c4TDnzT4lzPF32xO0E=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "411ea1135780741acd243564c33840bc838729f7",
+        "rev": "cad6bab044d09eb54fe9a8efb20ed94694eb44ff",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -61580,11 +61580,11 @@
         "logos-package-manager": "logos-package-manager_51"
       },
       "locked": {
-        "lastModified": 1784232744,
-        "narHash": "sha256-f6txL+Wnlxx5eTdu5klr8qtzvPy49dFtNo30qd74PtQ=",
+        "lastModified": 1784254343,
+        "narHash": "sha256-3+JOesTqQsSy2y0EYphzQXSL5c4TDnzT4lzPF32xO0E=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "411ea1135780741acd243564c33840bc838729f7",
+        "rev": "cad6bab044d09eb54fe9a8efb20ed94694eb44ff",
         "type": "github"
       },
       "original": {

--- a/src/Basecamp/Shell/ConfirmationDialog.qml
+++ b/src/Basecamp/Shell/ConfirmationDialog.qml
@@ -50,8 +50,9 @@ import Logos.Theme
 //
 // The dialog is controlled by calling `openWith(mode, name, items)` for the
 // one-list modes, `openWithTwoLists(mode, name, items, loadedItems)` for
-// uninstallCascade, `openWithUpgrade(name, version, upgradeMode, installedDeps, loadedDeps)`
-// for upgradeCascade, or `openWithMetadata(metadata)` for installConfirm.
+// uninstallCascade, `openWithUpgrade(name, version, upgradeMode, installedDeps, loadedDeps, depChanges)`
+// for upgradeCascade, `openWithInstallGate(name, version, depChanges)` for the
+// catalog install gate, or `openWithMetadata(metadata)` for installConfirm.
 // Backend wiring listens for continueClicked/cancelClicked and calls the
 // appropriate slot with `name`.
 Dialog {

--- a/src/Basecamp/Shell/ConfirmationDialog.qml
+++ b/src/Basecamp/Shell/ConfirmationDialog.qml
@@ -7,7 +7,7 @@ import Logos.Theme
 
 // Reusable dialog for dependency-aware confirmation / informational prompts.
 //
-// Five display variants, selected via `mode`:
+// Six display variants, selected via `mode`:
 //  - "missingDeps"    — informational; user tried to load a plugin whose
 //                       dependencies aren't installed. Primary action is a
 //                       "Continue" that closes the dialog (the primary
@@ -39,6 +39,14 @@ import Logos.Theme
 //                       file. Renders package metadata (name, version, type,
 //                       signature status). For upgrades, shows the installed
 //                       version alongside the new version.
+//  - "installGate"    — confirmation before a fresh catalog install initiated
+//                       by another UI (package_manager_ui), routed through the
+//                       module's requestInstall gate. Leads with the package +
+//                       target version and lists the resolved transitive
+//                       `depChanges`. No dependent-impact lists (a fresh
+//                       install unloads nothing). Confirm/Cancel flow through
+//                       continueClicked / cancelClicked → confirmInstallGate /
+//                       cancelInstallGate.
 //
 // The dialog is controlled by calling `openWith(mode, name, items)` for the
 // one-list modes, `openWithTwoLists(mode, name, items, loadedItems)` for
@@ -67,6 +75,15 @@ Dialog {
     //   0 = Upgrade, 1 = Downgrade, 2 = Sidegrade (Reinstall).
     property string upgradeTargetVersion: ""
     property int upgradeModeKind: 0
+
+    // Transitive dependency changes for the upgradeCascade + installGate modes.
+    // Each entry: { name, action: "install"|"upgrade"|"downgrade",
+    //               fromVersion, toVersion, repository }. Resolved by the
+    //               initiator (package_manager_ui) and passed through the
+    //               module's beforeUpgrade / beforeInstall gate so this single
+    //               dialog lists exactly what else will change. Empty = nothing
+    //               else needs to change.
+    property var depChanges: []
 
     property var displayNameLookup: function(name) { return name; }
 
@@ -127,13 +144,31 @@ Dialog {
     // the same cascade semantics) but the title + body line lead with
     // the target version and the UpgradeMode so the user sees the full
     // operation, not just "Uninstall and Unload Dependents?".
-    function openWithUpgrade(name_, version_, upgradeMode_, installedDeps_, loadedDeps_) {
+    function openWithUpgrade(name_, version_, upgradeMode_, installedDeps_, loadedDeps_, depChanges_) {
         root.mode = "upgradeCascade";
         root.moduleName = name_ || "";
         root.upgradeTargetVersion = version_ || "";
         root.upgradeModeKind = upgradeMode_ | 0;
         root.items = installedDeps_ || [];
         root.loadedItems = loadedDeps_ || [];
+        root.depChanges = depChanges_ || [];
+        root.targets = [];
+        root._explicitClose = false;
+        open();
+    }
+
+    // Fresh catalog-install variant. Unlike upgradeCascade there is no
+    // dependent-impact set (nothing is uninstalled/unloaded); the dialog
+    // simply confirms the install and lists the transitive `depChanges`.
+    // Continue / Cancel still flow through continueClicked / cancelClicked;
+    // the backend routes those to confirmInstallGate / cancelInstallGate.
+    function openWithInstallGate(name_, version_, depChanges_) {
+        root.mode = "installGate";
+        root.moduleName = name_ || "";
+        root.upgradeTargetVersion = version_ || "";
+        root.items = [];
+        root.loadedItems = [];
+        root.depChanges = depChanges_ || [];
         root.targets = [];
         root._explicitClose = false;
         open();
@@ -197,6 +232,8 @@ Dialog {
                             return "Upgrade Package?";
                         return "Install Package?";
                     }
+                    if (root.mode === "installGate")
+                        return "Install Package?";
                     return "";
                 }
                 font.pixelSize: Theme.typography.panelTitleText
@@ -267,6 +304,18 @@ Dialog {
                         return "An existing version is installed. Review the details "
                              + "below and confirm the upgrade:";
                     return "Review the package details below before installing:";
+                }
+                if (root.mode === "installGate") {
+                    var ivPhrase = root.upgradeTargetVersion.length > 0
+                                   ? " v" + root.upgradeTargetVersion : "";
+                    var iHead = "Install '" + _label + "'" + ivPhrase + ".";
+                    // The dep-change list below spells out the transitive set.
+                    // When it's empty, say so plainly so a bare install still
+                    // reads as a deliberate, complete confirmation.
+                    if ((root.depChanges || []).length === 0)
+                        return iHead + " No other packages need to change.";
+                    return iHead + " Installing it also applies the dependency "
+                                 + "changes listed below:";
                 }
                 return "";
             }
@@ -426,6 +475,103 @@ Dialog {
                         text: "• " + (root.displayNameLookup(modelData) || modelData)
                         color: "#e0e0e0"
                         font.pixelSize: 13
+                    }
+                }
+            }
+        }
+
+        // Transitive dependency-change list — shared by upgradeCascade and
+        // installGate. Renders each change as [action chip] name (repo) vA → vB,
+        // mirroring the package_manager_ui per-row confirm so the single
+        // basecamp dialog surfaces exactly what else the operation installs /
+        // upgrades / downgrades. Hidden when the initiator resolved no changes.
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 6
+            visible: (root.mode === "upgradeCascade" || root.mode === "installGate")
+                     && (root.depChanges || []).length > 0
+
+            LogosText {
+                Layout.fillWidth: true
+                Layout.topMargin: 4
+                text: "Dependency changes:"
+                color: "#c0c0c0"
+                font.pixelSize: 13
+                font.weight: Theme.typography.weightBold
+                wrapMode: Text.Wrap
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                color: "#1e1e1e"
+                radius: 4
+                border.color: "#3d3d3d"
+                border.width: 1
+                implicitHeight: depChangeList.implicitHeight + 16
+
+                ListView {
+                    id: depChangeList
+                    anchors.fill: parent
+                    anchors.margins: 8
+                    model: root.depChanges
+                    spacing: 4
+                    clip: true
+                    interactive: contentHeight > height
+                    implicitHeight: Math.min(160, Math.max(contentHeight, 0))
+
+                    delegate: RowLayout {
+                        width: ListView.view ? ListView.view.width : 0
+                        spacing: 8
+
+                        // Action chip — colour-keyed like the PMU row pills.
+                        Rectangle {
+                            Layout.preferredWidth: 76
+                            Layout.preferredHeight: 20
+                            radius: 10
+                            color: {
+                                switch (modelData.action) {
+                                case "install":   return Theme.colors.getColor(Theme.palette.success, 0.18);
+                                case "upgrade":   return Theme.colors.getColor(Theme.palette.info,    0.18);
+                                case "downgrade": return Theme.colors.getColor(Theme.palette.warning, 0.18);
+                                default:          return Theme.colors.getColor(Theme.palette.info,    0.18);
+                                }
+                            }
+                            LogosText {
+                                anchors.centerIn: parent
+                                text: {
+                                    var a = modelData.action || "";
+                                    return a ? a.charAt(0).toUpperCase() + a.slice(1) : "";
+                                }
+                                color: {
+                                    switch (modelData.action) {
+                                    case "install":   return Theme.palette.success;
+                                    case "upgrade":   return Theme.palette.info;
+                                    case "downgrade": return Theme.palette.warning;
+                                    default:          return Theme.palette.text;
+                                    }
+                                }
+                                font.pixelSize: 12
+                                font.weight: Theme.typography.weightMedium
+                            }
+                        }
+
+                        // name (repo)  vFrom → vTo
+                        LogosText {
+                            Layout.fillWidth: true
+                            text: {
+                                var name = modelData.name || "";
+                                var repo = modelData.repository || "";
+                                var to   = modelData.toVersion ? "v" + modelData.toVersion : "";
+                                var from = modelData.fromVersion ? "v" + modelData.fromVersion : "";
+                                var ver  = (from && to && from !== to) ? (from + " → " + to)
+                                                                       : (to ? to : "");
+                                var head = repo ? (name + " (" + repo + ")") : name;
+                                return ver ? (head + "  " + ver) : head;
+                            }
+                            color: "#e0e0e0"
+                            font.pixelSize: 13
+                            elide: Text.ElideMiddle
+                        }
                     }
                 }
             }
@@ -666,6 +812,7 @@ Dialog {
                         if (root.metadata.isAlreadyInstalled) return "Upgrade";
                         return "Install";
                     }
+                    if (root.mode === "installGate") return "Install";
                     return "OK";
                 }
 
@@ -726,7 +873,8 @@ Dialog {
             return;
         }
         if (root.mode === "unloadCascade" || root.mode === "uninstallCascade"
-            || root.mode === "upgradeCascade" || root.mode === "installConfirm") {
+            || root.mode === "upgradeCascade" || root.mode === "installConfirm"
+            || root.mode === "installGate") {
             if (root.targets.length > 0)
                 root.cancelClickedMulti(root.targets);
             else

--- a/src/Basecamp/Shell/OverlayDialogs.qml
+++ b/src/Basecamp/Shell/OverlayDialogs.qml
@@ -32,6 +32,7 @@ Item {
                                   || uninstallCascadeDialog.visible
                                   || upgradeCascadeDialog.visible
                                   || installConfirmDialog.visible
+                                  || installGateDialog.visible
                                   || addApplicationDialog.visible
 
     signal overlayActiveChanged(bool active)
@@ -89,6 +90,19 @@ Item {
         displayNameLookup: _dialogDeps.displayNameLookup
         onContinueClicked: backend.confirmInstall()
         onCancelClicked: backend.cancelInstall()
+    }
+
+    // Fresh catalog-install gate initiated by package_manager_ui (via the
+    // module's requestInstall). Distinct from installConfirmDialog (local-LGX
+    // inspect flow): confirm/cancel forward the decision back through the
+    // module gate so PMU downloads+installs (or aborts). Lists the resolved
+    // transitive dep changes so this is the single install confirmation.
+    ConfirmationDialog {
+        id: installGateDialog
+        mode: "installGate"
+        displayNameLookup: _dialogDeps.displayNameLookup
+        onContinueClicked: (name) => backend.confirmInstallGate(name)
+        onCancelClicked: (name) => backend.cancelInstallGate(name)
     }
 
     // App-Manager "Add Application" dialog.
@@ -183,13 +197,21 @@ Item {
         // "Upgrade to vX.Y.Z" / "Downgrade to vX.Y.Z" / "Reinstall vX.Y.Z"
         // instead of a bare uninstall heading.
         function onUpgradeCascadeConfirmationRequested(name, releaseTag, mode,
-                                                       installedDependents, loadedDependents) {
+                                                       installedDependents, loadedDependents,
+                                                       depChanges) {
             upgradeCascadeDialog.openWithUpgrade(name, releaseTag, mode,
-                                                 installedDependents, loadedDependents);
+                                                 installedDependents, loadedDependents,
+                                                 depChanges);
         }
 
         function onInstallConfirmationRequested(metadata) {
             installConfirmDialog.openWithMetadata(metadata);
+        }
+
+        // Fresh catalog-install gate (package_manager_ui-initiated). releaseTag
+        // is the target version; depChanges is the resolved transitive set.
+        function onInstallGateConfirmationRequested(name, releaseTag, depChanges) {
+            installGateDialog.openWithInstallGate(name, releaseTag, depChanges);
         }
 
         function onLaunchAppRequested(name) {

--- a/src/MainUIBackend.cpp
+++ b/src/MainUIBackend.cpp
@@ -98,6 +98,8 @@ MainUIBackend::MainUIBackend(LogosAPI* logosAPI, QObject* parent)
     // "upgradeCascade" mode of ConfirmationDialog.
     connect(m_packageCoordinator, &PackageCoordinator::upgradeCascadeConfirmationRequested,
             this,             &MainUIBackend::upgradeCascadeConfirmationRequested);
+    connect(m_packageCoordinator, &PackageCoordinator::installGateConfirmationRequested,
+            this,             &MainUIBackend::installGateConfirmationRequested);
     connect(m_packageCoordinator, &PackageCoordinator::uninstallMultiCascadeConfirmationRequested,
             this,             &MainUIBackend::uninstallMultiCascadeConfirmationRequested);
     connect(m_packageCoordinator, &PackageCoordinator::requestOpenAddApplicationDialog,
@@ -240,6 +242,8 @@ void MainUIBackend::confirmUninstallMultiCascade(const QStringList& names) { m_p
 void MainUIBackend::cancelMultiUninstall(const QStringList& names)         { m_packageCoordinator->cancelMultiUninstall(names); }
 void MainUIBackend::confirmInstall()                          { m_packageCoordinator->confirmInstall(); }
 void MainUIBackend::cancelInstall()                           { m_packageCoordinator->cancelInstall(); }
+void MainUIBackend::confirmInstallGate(const QString& n)      { m_packageCoordinator->confirmInstallGate(n); }
+void MainUIBackend::cancelInstallGate(const QString& n)       { m_packageCoordinator->cancelInstallGate(n); }
 void MainUIBackend::openApp(const QString& name, const QString& repositoryUrl, const QVariantMap& versionPins, bool allowFastLaunch)
 { m_packageCoordinator->openApp(name, repositoryUrl, versionPins, allowFastLaunch); }
 void MainUIBackend::confirmCatalogInstall(const QString& name, const QString& repositoryUrl, const QVariantMap& versionPins)

--- a/src/MainUIBackend.h
+++ b/src/MainUIBackend.h
@@ -167,6 +167,13 @@ public slots:
     Q_INVOKABLE void confirmInstall();
     Q_INVOKABLE void cancelInstall();
 
+    // Fresh catalog-install gate (package_manager_ui-initiated) — delegated to
+    // PackageCoordinator, which forwards the decision to the module's
+    // confirmInstall / cancelInstall gate. Distinct from confirmInstall()
+    // above (the local-LGX inspect flow).
+    Q_INVOKABLE void confirmInstallGate(const QString& name);
+    Q_INVOKABLE void cancelInstallGate(const QString& name);
+
     // App-Manager catalog open — delegated to PackageCoordinator.
     Q_INVOKABLE void openApp(const QString& name,
                              const QString& repositoryUrl,
@@ -237,7 +244,8 @@ signals:
                                              const QString& releaseTag,
                                              int mode,
                                              const QStringList& installedDependents,
-                                             const QStringList& loadedDependents);
+                                             const QStringList& loadedDependents,
+                                             const QVariantList& depChanges);
     void uninstallMultiCascadeConfirmationRequested(const QStringList& names,
                                                     const QStringList& installedDependents,
                                                     const QStringList& loadedDependents);
@@ -245,6 +253,14 @@ signals:
     // Install confirmation — emitted when the user picks an LGX file and we've
     // inspected it. metadata contains name, version, type, signatureStatus, etc.
     void installConfirmationRequested(const QVariantMap& metadata);
+
+    // Fresh catalog-install gate (package_manager_ui-initiated) — pure re-emit
+    // of PackageCoordinator::installGateConfirmationRequested. releaseTag is the
+    // target version; depChanges is the resolved transitive set the single
+    // basecamp dialog lists.
+    void installGateConfirmationRequested(const QString& name,
+                                          const QString& releaseTag,
+                                          const QVariantList& depChanges);
 
     // MDI coordination (re-emitted from UIPluginManager).
     void pluginWindowRequested(QWidget* widget, const QString& title);

--- a/src/PackageCoordinator.cpp
+++ b/src/PackageCoordinator.cpp
@@ -155,7 +155,28 @@ void PackageCoordinator::subscribeToPackageInstallationEvents()
         for (const QJsonValue& v : obj.value("installedDependents").toArray()) {
             if (v.isString()) installedDeps.append(v.toString());
         }
-        onBeforeUpgrade(name, releaseTag, mode, installedDeps);
+        // Transitive dep changes the initiator (PMU) resolved for this swap —
+        // opaque display data the dialog lists. Absent/empty on a bare upgrade.
+        const QVariantList depChanges = obj.value("depChanges").toArray().toVariantList();
+        onBeforeUpgrade(name, releaseTag, mode, installedDeps, depChanges);
+    });
+
+    // beforeInstall — the catalog-install gate. Same ack-then-dialog shape as
+    // beforeUpgrade, but with no dependents (a fresh install unloads nothing).
+    logos.package_manager.on("beforeInstall", [this](const QVariantList& data) {
+        if (data.isEmpty()) return;
+        const QByteArray payload = data.first().toString().toUtf8();
+        QJsonParseError err{};
+        const QJsonDocument doc = QJsonDocument::fromJson(payload, &err);
+        if (err.error != QJsonParseError::NoError || !doc.isObject()) {
+            qWarning() << "beforeInstall payload parse error:" << err.errorString();
+            return;
+        }
+        const QJsonObject obj = doc.object();
+        const QString name       = obj.value("name").toString();
+        const QString releaseTag = obj.value("releaseTag").toString();
+        const QVariantList depChanges = obj.value("depChanges").toArray().toVariantList();
+        onBeforeInstall(name, releaseTag, depChanges);
     });
 
     // Multi-uninstall is a separate event so existing single-uninstall handlers
@@ -613,7 +634,8 @@ void PackageCoordinator::onBeforeUninstall(const QString& name, const QStringLis
 }
 
 void PackageCoordinator::onBeforeUpgrade(const QString& name, const QString& releaseTag,
-                                     int mode, const QStringList& installedDeps)
+                                     int mode, const QStringList& installedDeps,
+                                     const QVariantList& depChanges)
 {
     if (!m_logosAPI) return;
 
@@ -626,7 +648,7 @@ void PackageCoordinator::onBeforeUpgrade(const QString& name, const QString& rel
     LogosModules logos(m_logosAPI);
     QPointer<PackageCoordinator> self(this);
     logos.package_manager.ackPendingActionAsync(name,
-        [self, name, releaseTag, mode, installedDeps](QVariantMap result) {
+        [self, name, releaseTag, mode, installedDeps, depChanges](QVariantMap result) {
             if (!self) return;
             if (!result.value("success", false).toBool()) {
                 qWarning() << "ackPendingAction rejected for" << name << ":"
@@ -646,8 +668,60 @@ void PackageCoordinator::onBeforeUpgrade(const QString& name, const QString& rel
             // Dependents?" — which previously caused user confusion on
             // downgrades that looked like a pure uninstall.
             emit self->upgradeCascadeConfirmationRequested(
-                name, releaseTag, mode, installedDeps, loadedDeps);
+                name, releaseTag, mode, installedDeps, loadedDeps, depChanges);
         });
+}
+
+void PackageCoordinator::onBeforeInstall(const QString& name, const QString& releaseTag,
+                                         const QVariantList& depChanges)
+{
+    if (!m_logosAPI) return;
+
+    if (name.isEmpty()) {
+        qWarning() << "PackageCoordinator::onBeforeInstall received empty name — ignoring";
+        return;
+    }
+
+    LogosModules logos(m_logosAPI);
+    QPointer<PackageCoordinator> self(this);
+    logos.package_manager.ackPendingActionAsync(name,
+        [self, name, releaseTag, depChanges](QVariantMap result) {
+            if (!self) return;
+            if (!result.value("success", false).toBool()) {
+                qWarning() << "ackPendingAction rejected for" << name << ":"
+                           << result.value("error").toString();
+                return;
+            }
+            // No pending-slot / cascade work — a fresh install unloads nothing.
+            // The dialog's confirm/cancel forward straight to the module gate.
+            emit self->installGateConfirmationRequested(name, releaseTag, depChanges);
+        });
+}
+
+void PackageCoordinator::confirmInstallGate(const QString& name)
+{
+    if (!m_logosAPI || name.isEmpty()) return;
+    LogosModules logos(m_logosAPI);
+    QPointer<PackageCoordinator> self(this);
+    logos.package_manager.confirmInstallAsync(name, [self, name](QVariantMap result) {
+        if (!self) return;
+        if (!result.value("success", false).toBool())
+            qWarning() << "confirmInstall rejected for" << name << ":"
+                       << result.value("error").toString();
+    });
+}
+
+void PackageCoordinator::cancelInstallGate(const QString& name)
+{
+    if (!m_logosAPI || name.isEmpty()) return;
+    LogosModules logos(m_logosAPI);
+    QPointer<PackageCoordinator> self(this);
+    logos.package_manager.cancelInstallAsync(name, [self, name](QVariantMap result) {
+        if (!self) return;
+        if (!result.value("success", false).toBool())
+            qWarning() << "cancelInstall rejected for" << name << ":"
+                       << result.value("error").toString();
+    });
 }
 
 void PackageCoordinator::onBeforeMultiUninstall(const QStringList& names,

--- a/src/PackageCoordinator.cpp
+++ b/src/PackageCoordinator.cpp
@@ -706,7 +706,7 @@ void PackageCoordinator::confirmInstallGate(const QString& name)
     logos.package_manager.confirmInstallAsync(name, [self, name](QVariantMap result) {
         if (!self) return;
         if (!result.value("success", false).toBool())
-            qWarning() << "confirmInstall rejected for" << name << ":"
+            qWarning() << "confirmInstallGate rejected for" << name << ":"
                        << result.value("error").toString();
     });
 }
@@ -719,7 +719,7 @@ void PackageCoordinator::cancelInstallGate(const QString& name)
     logos.package_manager.cancelInstallAsync(name, [self, name](QVariantMap result) {
         if (!self) return;
         if (!result.value("success", false).toBool())
-            qWarning() << "cancelInstall rejected for" << name << ":"
+            qWarning() << "cancelInstallGate rejected for" << name << ":"
                        << result.value("error").toString();
     });
 }

--- a/src/PackageCoordinator.h
+++ b/src/PackageCoordinator.h
@@ -85,6 +85,14 @@ public slots:
     Q_INVOKABLE void confirmInstall();
     Q_INVOKABLE void cancelInstall();
 
+    // Catalog-install gate (package_manager_ui-initiated). The module holds the
+    // pending install; these just forward the user's decision back so it either
+    // emits installApproved (PMU then downloads+installs) or installCancelled.
+    // Distinct from confirmInstall()/cancelInstall() above, which drive the
+    // local-LGX inspect-then-install flow.
+    Q_INVOKABLE void confirmInstallGate(const QString& name);
+    Q_INVOKABLE void cancelInstallGate(const QString& name);
+
     Q_INVOKABLE void openApp(const QString& name,
                              const QString& repositoryUrl,
                              const QVariantMap& versionPins = QVariantMap(),
@@ -192,7 +200,20 @@ signals:
                                              const QString& releaseTag,
                                              int mode,
                                              const QStringList& installedDependents,
-                                             const QStringList& loadedDependents);
+                                             const QStringList& loadedDependents,
+                                             const QVariantList& depChanges);
+
+    // Fresh-install confirmation dialog trigger — the sibling of the upgrade
+    // cascade for a not-yet-installed package coming through the module's
+    // requestInstall gate. Unlike a fresh local-LGX install (which uses
+    // installConfirmationRequested with inspected metadata), this is a catalog
+    // install initiated by another UI (package_manager_ui): it carries the
+    // target version and the resolved transitive `depChanges` so the single
+    // basecamp dialog lists exactly what else will be installed. No dependents
+    // list — a fresh install removes/unloads nothing.
+    void installGateConfirmationRequested(const QString& name,
+                                          const QString& releaseTag,
+                                          const QVariantList& depChanges);
 
     // Multi-uninstall cascade dialog trigger. `names` is the full batch of
     // packages being uninstalled. `installedDependents` is the union of each
@@ -225,7 +246,17 @@ private slots:
     // we stay silent rather than showing a dead dialog.
     void onBeforeUninstall(const QString& name, const QStringList& installedDeps);
     void onBeforeUpgrade(const QString& name, const QString& releaseTag,
-                         int mode, const QStringList& installedDeps);
+                         int mode, const QStringList& installedDeps,
+                         const QVariantList& depChanges);
+
+    // beforeInstall handler — the catalog-install counterpart of onBeforeUpgrade.
+    // Acks synchronously (cancelling the module's ack timer), then emits
+    // installGateConfirmationRequested so the shared dialog can confirm the
+    // install and list its transitive dep changes. No pending-slot / cascade
+    // work: a fresh install unloads nothing, so confirm/cancel just forward the
+    // decision to the module via confirmInstallGate / cancelInstallGate.
+    void onBeforeInstall(const QString& name, const QString& releaseTag,
+                         const QVariantList& depChanges);
 
     // Multi-uninstall variant — same ack-then-emit-dialog shape, but holds the
     // batch's full name list in m_pendingAction.names so confirm/cancel can


### PR DESCRIPTION
## What

basecamp now owns **one** confirmation dialog for catalog install, upgrade, and downgrade, replacing the double-dialog where `package_manager_ui` and basecamp both confirmed an upgrade/downgrade. The single dialog also lists the transitive dependency changes the operation will apply.

- Subscribes to the module's new `beforeInstall` gate; `onBeforeInstall` acks and raises the shared `ConfirmationDialog` (new `installGate` mode). Confirm/cancel forward to the module via `confirmInstallGate` / `cancelInstallGate`.
- `onBeforeUpgrade` parses the `depChanges` the initiator resolved and threads it into `upgradeCascadeConfirmationRequested`.
- `ConfirmationDialog.qml` renders a transitive dependency-change list (install / upgrade / downgrade rows) for the `upgradeCascade` + `installGate` modes.

## Context

Follow-up to the install-UX work: after "always confirm", upgrade/downgrade showed two popups (PMU's + basecamp's). This makes basecamp's native dialog the single one and moves the dependency-change disclosure into it.

## Depends on

**logos-package-manager-module#57** (the gate) and pairs with **logos-package-manager-ui#53** (which stops showing its own dialog). Merge #57 first, then re-pin.

Validated: full `logos-basecamp` integration build green with all components local. Runtime one-dialog behavior to be confirmed in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)