### PR TITLE
ci(doctests): fix 404 on the Pages home page

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -259,7 +259,7 @@ jobs:
           # index.html at the Pages root, that URL 404s even though the per-ref
           # reports exist under main/ and pr-<N>/. Regenerate it on pushes to the
           # default branch (BASE=main) so the home page always points at the
-          # latest master report. keep_files:true preserves it across PR runs.
+          # latest main/ report. keep_files:true preserves it across PR runs.
           if [ "$BASE" = "main" ]; then
             {
               echo "<!doctype html><meta charset=utf-8>"
@@ -269,7 +269,7 @@ jobs:
               echo "<p>Executable end-to-end doc-tests for" \
                    "<a href=\"https://github.com/${GITHUB_REPOSITORY}\">${GITHUB_REPOSITORY##*/}</a>," \
                    "rendered as a two-column HTML report (each command/action run alongside its output).</p>"
-              echo "<h2>Latest (master)</h2><ul>"
+              echo "<h2>Latest (main)</h2><ul>"
               for os in ubuntu-latest macos-latest; do
                 if [ -d "site/$BASE/$os" ]; then
                   echo "<li><a href=\"./main/$os/\">$os</a></li>"

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -33,7 +33,10 @@ name: basecamp Doc-Tests
 # Each run publishes the two-column HTML report to:
 #   https://<owner>.github.io/<repo>/pr-<N>/<os>/      (pull requests)
 #   https://<owner>.github.io/<repo>/main/<os>/        (pushes to main/master)
-# and (for PRs) posts/updates a comment with the links.
+# and (for PRs) posts/updates a comment with the links. Pushes to the default
+# branch also (re)generate the Pages root index.html, so
+#   https://<owner>.github.io/<repo>/                  links to the latest reports
+# instead of 404ing.
 #
 # Note: pull requests opened from forks get a read-only GITHUB_TOKEN, so the
 # Pages push and PR comment are skipped for them — the downloadable artifact is
@@ -251,6 +254,32 @@ jobs:
             done
             echo "</ul>"
           } > "site/$BASE/index.html"
+
+          # Root landing page for https://<owner>.github.io/<repo>/. Without an
+          # index.html at the Pages root, that URL 404s even though the per-ref
+          # reports exist under main/ and pr-<N>/. Regenerate it on pushes to the
+          # default branch (BASE=main) so the home page always points at the
+          # latest master report. keep_files:true preserves it across PR runs.
+          if [ "$BASE" = "main" ]; then
+            {
+              echo "<!doctype html><meta charset=utf-8>"
+              echo "<title>basecamp doc-test reports</title>"
+              echo "<style>body{font:16px system-ui;margin:40px;max-width:640px}a{color:#2563eb}</style>"
+              echo "<h1>basecamp doc-test reports</h1>"
+              echo "<p>Executable end-to-end doc-tests for" \
+                   "<a href=\"https://github.com/${GITHUB_REPOSITORY}\">${GITHUB_REPOSITORY##*/}</a>," \
+                   "rendered as a two-column HTML report (each command/action run alongside its output).</p>"
+              echo "<h2>Latest (master)</h2><ul>"
+              for os in ubuntu-latest macos-latest; do
+                if [ -d "site/$BASE/$os" ]; then
+                  echo "<li><a href=\"./main/$os/\">$os</a></li>"
+                fi
+              done
+              echo "</ul>"
+              echo "<p>Per-pull-request reports are published under <code>pr-&lt;N&gt;/</code>" \
+                   "and linked from a comment on each pull request.</p>"
+            } > "site/index.html"
+          fi
 
       - name: Deploy to gh-pages
         if: steps.arrange.outputs.found != ''


### PR DESCRIPTION
## Problem

The doc-tests home page 404s:

- ❌ `https://logos-co.github.io/logos-basecamp/` → **404**
- ✅ `https://logos-co.github.io/logos-basecamp/main/` → 200
- ✅ `https://logos-co.github.io/logos-basecamp/main/{ubuntu,macos}-latest/` → 200

The `publish-report` job writes per-ref landing pages under `main/` and `pr-<N>/` on the `gh-pages` branch, but never an `index.html` at the **root**. GitHub Pages serves `index.html` for a directory and 404s when there's none, so the repo-root URL fails even though every underlying report is live.

## Fix

On pushes to the default branch (`BASE=main`), the "Arrange site directory" step now also (re)generates a root `site/index.html` that links to the latest master reports. `keep_files: true` on the deploy step preserves it across PR publishes.

Validated locally: `doctests.yml` parses as YAML, and a dry-run of the added bash emits the expected HTML linking to `./main/ubuntu-latest/` and `./main/macos-latest/`.

Note: the root page is refreshed by the workflow on the next push to master. To unbreak the currently-live page immediately, a root `index.html` was also committed directly to `gh-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)