### PR TITLE
fix:  update logos-module-view-runtime so that ui-modules's destructors are called gracefully on SIGTERM

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7935,11 +7935,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782492700,
-        "narHash": "sha256-Cfu9C6wMubyWTDLEh738rfCt3CuI91BZNWLj2GfTXAY=",
+        "lastModified": 1784238640,
+        "narHash": "sha256-HVHw4VDO21r6zYKPotJRM2/IimkneYSV784koLkLDkM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "350a2891e60a40aba93f273d85e8accb4803ac29",
+        "rev": "c7444bc29a1b480505025d0ed1679bedb71bfa29",
         "type": "github"
       },
       "original": {
@@ -11835,6 +11835,9 @@
     "logos-design-system_8": {
       "inputs": {
         "logos-nix": "logos-nix_297",
+        "nix-bundle-appimage": "nix-bundle-appimage_15",
+        "nix-bundle-dir": "nix-bundle-dir_50",
+        "nix-bundle-macos-app": "nix-bundle-macos-app",
         "nixpkgs": [
           "logos-design-system",
           "logos-nix",
@@ -11842,11 +11845,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781884622,
-        "narHash": "sha256-j/SCP+/qBVlOWk6MDvbateSTs92akQcsM/LwOo/3Cfk=",
+        "lastModified": 1784201753,
+        "narHash": "sha256-019xwK08ADYlM8q6yicPwER8hFrl2reDtr813CRI698=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "491e522cb94c819c85bf87ff1df893d77a5054be",
+        "rev": "fcf1255a501eee2bf32db41530c285343f988b5d",
         "type": "github"
       },
       "original": {
@@ -13511,11 +13514,11 @@
         "process-stats": "process-stats_11"
       },
       "locked": {
-        "lastModified": 1782495098,
-        "narHash": "sha256-bSvcs+UmYQq9MwFuggc7yYZMEu0RqbqKxc8+BGuBJA0=",
+        "lastModified": 1782932618,
+        "narHash": "sha256-WmDe7xGc6P4psZGAgo02qbv5wM0HiC5BbUT/JLzWpIM=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "87ae7ce5db647569a2b20219fe356c771504df4c",
+        "rev": "b8de686bce541b659b110aa03f1fd333e353736a",
         "type": "github"
       },
       "original": {
@@ -24691,11 +24694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781311603,
-        "narHash": "sha256-Ym3i52f5MWuZy8Qas3+zfoxz+mxQUsyW+Qol1no6kDs=",
+        "lastModified": 1782766905,
+        "narHash": "sha256-oYE7sMr7PS+kDoX//Cx90HmRiRHBnHONx6r4Ekkc7DI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "a3e288a71d6f79445db598b0ffcca2ee435596b9",
+        "rev": "2ec64c4a65f8966b5137cdba3a19a6498ce17b6d",
         "type": "github"
       },
       "original": {
@@ -24714,11 +24717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781873810,
-        "narHash": "sha256-GDUq1PFeN24RmXAcb7l2GH9YyjPQeLxg0hfeKOUxcmo=",
+        "lastModified": 1782766905,
+        "narHash": "sha256-oYE7sMr7PS+kDoX//Cx90HmRiRHBnHONx6r4Ekkc7DI=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "7583396720a33153f4bec85c1464bc463fb95477",
+        "rev": "2ec64c4a65f8966b5137cdba3a19a6498ce17b6d",
         "type": "github"
       },
       "original": {
@@ -47395,11 +47398,11 @@
         "nixpkgs": "nixpkgs_297"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -61468,8 +61471,8 @@
       "inputs": {
         "logos-nix": "logos-nix_738",
         "logos-package": "logos-package_88",
-        "nix-bundle-appimage": "nix-bundle-appimage_36",
-        "nix-bundle-dir": "nix-bundle-dir_123",
+        "nix-bundle-appimage": "nix-bundle-appimage_37",
+        "nix-bundle-dir": "nix-bundle-dir_124",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -61514,8 +61517,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1639",
         "logos-package": "logos-package_197",
-        "nix-bundle-appimage": "nix-bundle-appimage_81",
-        "nix-bundle-dir": "nix-bundle-dir_276",
+        "nix-bundle-appimage": "nix-bundle-appimage_82",
+        "nix-bundle-dir": "nix-bundle-dir_277",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -61781,8 +61784,8 @@
       "inputs": {
         "logos-nix": "logos-nix_329",
         "logos-package": "logos-package_36",
-        "nix-bundle-appimage": "nix-bundle-appimage_15",
-        "nix-bundle-dir": "nix-bundle-dir_51",
+        "nix-bundle-appimage": "nix-bundle-appimage_16",
+        "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61815,8 +61818,8 @@
       "inputs": {
         "logos-nix": "logos-nix_346",
         "logos-package": "logos-package_39",
-        "nix-bundle-appimage": "nix-bundle-appimage_16",
-        "nix-bundle-dir": "nix-bundle-dir_55",
+        "nix-bundle-appimage": "nix-bundle-appimage_17",
+        "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61848,8 +61851,8 @@
       "inputs": {
         "logos-nix": "logos-nix_373",
         "logos-package": "logos-package_41",
-        "nix-bundle-appimage": "nix-bundle-appimage_17",
-        "nix-bundle-dir": "nix-bundle-dir_58",
+        "nix-bundle-appimage": "nix-bundle-appimage_18",
+        "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61883,8 +61886,8 @@
       "inputs": {
         "logos-nix": "logos-nix_390",
         "logos-package": "logos-package_44",
-        "nix-bundle-appimage": "nix-bundle-appimage_18",
-        "nix-bundle-dir": "nix-bundle-dir_62",
+        "nix-bundle-appimage": "nix-bundle-appimage_19",
+        "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61917,8 +61920,8 @@
       "inputs": {
         "logos-nix": "logos-nix_401",
         "logos-package": "logos-package_46",
-        "nix-bundle-appimage": "nix-bundle-appimage_19",
-        "nix-bundle-dir": "nix-bundle-dir_65",
+        "nix-bundle-appimage": "nix-bundle-appimage_20",
+        "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -61983,8 +61986,8 @@
       "inputs": {
         "logos-nix": "logos-nix_418",
         "logos-package": "logos-package_49",
-        "nix-bundle-appimage": "nix-bundle-appimage_20",
-        "nix-bundle-dir": "nix-bundle-dir_69",
+        "nix-bundle-appimage": "nix-bundle-appimage_21",
+        "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -62013,8 +62016,8 @@
       "inputs": {
         "logos-nix": "logos-nix_432",
         "logos-package": "logos-package_51",
-        "nix-bundle-appimage": "nix-bundle-appimage_21",
-        "nix-bundle-dir": "nix-bundle-dir_72",
+        "nix-bundle-appimage": "nix-bundle-appimage_22",
+        "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-liblogos",
           "logos-package-manager",
@@ -62040,8 +62043,8 @@
       "inputs": {
         "logos-nix": "logos-nix_478",
         "logos-package": "logos-package_53",
-        "nix-bundle-appimage": "nix-bundle-appimage_22",
-        "nix-bundle-dir": "nix-bundle-dir_74",
+        "nix-bundle-appimage": "nix-bundle-appimage_23",
+        "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62076,8 +62079,8 @@
       "inputs": {
         "logos-nix": "logos-nix_495",
         "logos-package": "logos-package_56",
-        "nix-bundle-appimage": "nix-bundle-appimage_23",
-        "nix-bundle-dir": "nix-bundle-dir_78",
+        "nix-bundle-appimage": "nix-bundle-appimage_24",
+        "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62111,8 +62114,8 @@
       "inputs": {
         "logos-nix": "logos-nix_522",
         "logos-package": "logos-package_58",
-        "nix-bundle-appimage": "nix-bundle-appimage_24",
-        "nix-bundle-dir": "nix-bundle-dir_81",
+        "nix-bundle-appimage": "nix-bundle-appimage_25",
+        "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62148,8 +62151,8 @@
       "inputs": {
         "logos-nix": "logos-nix_539",
         "logos-package": "logos-package_61",
-        "nix-bundle-appimage": "nix-bundle-appimage_25",
-        "nix-bundle-dir": "nix-bundle-dir_85",
+        "nix-bundle-appimage": "nix-bundle-appimage_26",
+        "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62184,8 +62187,8 @@
       "inputs": {
         "logos-nix": "logos-nix_550",
         "logos-package": "logos-package_63",
-        "nix-bundle-appimage": "nix-bundle-appimage_26",
-        "nix-bundle-dir": "nix-bundle-dir_88",
+        "nix-bundle-appimage": "nix-bundle-appimage_27",
+        "nix-bundle-dir": "nix-bundle-dir_89",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62217,8 +62220,8 @@
       "inputs": {
         "logos-nix": "logos-nix_567",
         "logos-package": "logos-package_66",
-        "nix-bundle-appimage": "nix-bundle-appimage_27",
-        "nix-bundle-dir": "nix-bundle-dir_92",
+        "nix-bundle-appimage": "nix-bundle-appimage_28",
+        "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62249,8 +62252,8 @@
       "inputs": {
         "logos-nix": "logos-nix_608",
         "logos-package": "logos-package_68",
-        "nix-bundle-appimage": "nix-bundle-appimage_28",
-        "nix-bundle-dir": "nix-bundle-dir_95",
+        "nix-bundle-appimage": "nix-bundle-appimage_29",
+        "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62286,8 +62289,8 @@
       "inputs": {
         "logos-nix": "logos-nix_625",
         "logos-package": "logos-package_71",
-        "nix-bundle-appimage": "nix-bundle-appimage_29",
-        "nix-bundle-dir": "nix-bundle-dir_99",
+        "nix-bundle-appimage": "nix-bundle-appimage_30",
+        "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62359,8 +62362,8 @@
       "inputs": {
         "logos-nix": "logos-nix_652",
         "logos-package": "logos-package_73",
-        "nix-bundle-appimage": "nix-bundle-appimage_30",
-        "nix-bundle-dir": "nix-bundle-dir_102",
+        "nix-bundle-appimage": "nix-bundle-appimage_31",
+        "nix-bundle-dir": "nix-bundle-dir_103",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62397,8 +62400,8 @@
       "inputs": {
         "logos-nix": "logos-nix_669",
         "logos-package": "logos-package_76",
-        "nix-bundle-appimage": "nix-bundle-appimage_31",
-        "nix-bundle-dir": "nix-bundle-dir_106",
+        "nix-bundle-appimage": "nix-bundle-appimage_32",
+        "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62434,8 +62437,8 @@
       "inputs": {
         "logos-nix": "logos-nix_680",
         "logos-package": "logos-package_78",
-        "nix-bundle-appimage": "nix-bundle-appimage_32",
-        "nix-bundle-dir": "nix-bundle-dir_109",
+        "nix-bundle-appimage": "nix-bundle-appimage_33",
+        "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62468,8 +62471,8 @@
       "inputs": {
         "logos-nix": "logos-nix_697",
         "logos-package": "logos-package_81",
-        "nix-bundle-appimage": "nix-bundle-appimage_33",
-        "nix-bundle-dir": "nix-bundle-dir_113",
+        "nix-bundle-appimage": "nix-bundle-appimage_34",
+        "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62501,8 +62504,8 @@
       "inputs": {
         "logos-nix": "logos-nix_711",
         "logos-package": "logos-package_83",
-        "nix-bundle-appimage": "nix-bundle-appimage_34",
-        "nix-bundle-dir": "nix-bundle-dir_116",
+        "nix-bundle-appimage": "nix-bundle-appimage_35",
+        "nix-bundle-dir": "nix-bundle-dir_117",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62531,8 +62534,8 @@
       "inputs": {
         "logos-nix": "logos-nix_730",
         "logos-package": "logos-package_86",
-        "nix-bundle-appimage": "nix-bundle-appimage_35",
-        "nix-bundle-dir": "nix-bundle-dir_120",
+        "nix-bundle-appimage": "nix-bundle-appimage_36",
+        "nix-bundle-dir": "nix-bundle-dir_121",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62560,8 +62563,8 @@
       "inputs": {
         "logos-nix": "logos-nix_743",
         "logos-package": "logos-package_89",
-        "nix-bundle-appimage": "nix-bundle-appimage_37",
-        "nix-bundle-dir": "nix-bundle-dir_125",
+        "nix-bundle-appimage": "nix-bundle-appimage_38",
+        "nix-bundle-dir": "nix-bundle-dir_126",
         "nixpkgs": [
           "logos-package-manager",
           "logos-nix",
@@ -62586,8 +62589,8 @@
       "inputs": {
         "logos-nix": "logos-nix_783",
         "logos-package": "logos-package_90",
-        "nix-bundle-appimage": "nix-bundle-appimage_38",
-        "nix-bundle-dir": "nix-bundle-dir_127",
+        "nix-bundle-appimage": "nix-bundle-appimage_39",
+        "nix-bundle-dir": "nix-bundle-dir_128",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62622,8 +62625,8 @@
       "inputs": {
         "logos-nix": "logos-nix_800",
         "logos-package": "logos-package_93",
-        "nix-bundle-appimage": "nix-bundle-appimage_39",
-        "nix-bundle-dir": "nix-bundle-dir_131",
+        "nix-bundle-appimage": "nix-bundle-appimage_40",
+        "nix-bundle-dir": "nix-bundle-dir_132",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62657,8 +62660,8 @@
       "inputs": {
         "logos-nix": "logos-nix_827",
         "logos-package": "logos-package_95",
-        "nix-bundle-appimage": "nix-bundle-appimage_40",
-        "nix-bundle-dir": "nix-bundle-dir_134",
+        "nix-bundle-appimage": "nix-bundle-appimage_41",
+        "nix-bundle-dir": "nix-bundle-dir_135",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62730,8 +62733,8 @@
       "inputs": {
         "logos-nix": "logos-nix_844",
         "logos-package": "logos-package_98",
-        "nix-bundle-appimage": "nix-bundle-appimage_41",
-        "nix-bundle-dir": "nix-bundle-dir_138",
+        "nix-bundle-appimage": "nix-bundle-appimage_42",
+        "nix-bundle-dir": "nix-bundle-dir_139",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62766,8 +62769,8 @@
       "inputs": {
         "logos-nix": "logos-nix_855",
         "logos-package": "logos-package_100",
-        "nix-bundle-appimage": "nix-bundle-appimage_42",
-        "nix-bundle-dir": "nix-bundle-dir_141",
+        "nix-bundle-appimage": "nix-bundle-appimage_43",
+        "nix-bundle-dir": "nix-bundle-dir_142",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62799,8 +62802,8 @@
       "inputs": {
         "logos-nix": "logos-nix_872",
         "logos-package": "logos-package_103",
-        "nix-bundle-appimage": "nix-bundle-appimage_43",
-        "nix-bundle-dir": "nix-bundle-dir_145",
+        "nix-bundle-appimage": "nix-bundle-appimage_44",
+        "nix-bundle-dir": "nix-bundle-dir_146",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62831,8 +62834,8 @@
       "inputs": {
         "logos-nix": "logos-nix_913",
         "logos-package": "logos-package_105",
-        "nix-bundle-appimage": "nix-bundle-appimage_44",
-        "nix-bundle-dir": "nix-bundle-dir_148",
+        "nix-bundle-appimage": "nix-bundle-appimage_45",
+        "nix-bundle-dir": "nix-bundle-dir_149",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62868,8 +62871,8 @@
       "inputs": {
         "logos-nix": "logos-nix_930",
         "logos-package": "logos-package_108",
-        "nix-bundle-appimage": "nix-bundle-appimage_45",
-        "nix-bundle-dir": "nix-bundle-dir_152",
+        "nix-bundle-appimage": "nix-bundle-appimage_46",
+        "nix-bundle-dir": "nix-bundle-dir_153",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62904,8 +62907,8 @@
       "inputs": {
         "logos-nix": "logos-nix_957",
         "logos-package": "logos-package_110",
-        "nix-bundle-appimage": "nix-bundle-appimage_46",
-        "nix-bundle-dir": "nix-bundle-dir_155",
+        "nix-bundle-appimage": "nix-bundle-appimage_47",
+        "nix-bundle-dir": "nix-bundle-dir_156",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62942,8 +62945,8 @@
       "inputs": {
         "logos-nix": "logos-nix_974",
         "logos-package": "logos-package_113",
-        "nix-bundle-appimage": "nix-bundle-appimage_47",
-        "nix-bundle-dir": "nix-bundle-dir_159",
+        "nix-bundle-appimage": "nix-bundle-appimage_48",
+        "nix-bundle-dir": "nix-bundle-dir_160",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62979,8 +62982,8 @@
       "inputs": {
         "logos-nix": "logos-nix_985",
         "logos-package": "logos-package_115",
-        "nix-bundle-appimage": "nix-bundle-appimage_48",
-        "nix-bundle-dir": "nix-bundle-dir_162",
+        "nix-bundle-appimage": "nix-bundle-appimage_49",
+        "nix-bundle-dir": "nix-bundle-dir_163",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -63013,8 +63016,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1002",
         "logos-package": "logos-package_118",
-        "nix-bundle-appimage": "nix-bundle-appimage_49",
-        "nix-bundle-dir": "nix-bundle-dir_166",
+        "nix-bundle-appimage": "nix-bundle-appimage_50",
+        "nix-bundle-dir": "nix-bundle-dir_167",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -63046,8 +63049,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1016",
         "logos-package": "logos-package_120",
-        "nix-bundle-appimage": "nix-bundle-appimage_50",
-        "nix-bundle-dir": "nix-bundle-dir_169",
+        "nix-bundle-appimage": "nix-bundle-appimage_51",
+        "nix-bundle-dir": "nix-bundle-dir_170",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -63109,8 +63112,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1035",
         "logos-package": "logos-package_123",
-        "nix-bundle-appimage": "nix-bundle-appimage_51",
-        "nix-bundle-dir": "nix-bundle-dir_173",
+        "nix-bundle-appimage": "nix-bundle-appimage_52",
+        "nix-bundle-dir": "nix-bundle-dir_174",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -63138,8 +63141,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1043",
         "logos-package": "logos-package_125",
-        "nix-bundle-appimage": "nix-bundle-appimage_52",
-        "nix-bundle-dir": "nix-bundle-dir_176",
+        "nix-bundle-appimage": "nix-bundle-appimage_53",
+        "nix-bundle-dir": "nix-bundle-dir_177",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -63165,8 +63168,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1083",
         "logos-package": "logos-package_126",
-        "nix-bundle-appimage": "nix-bundle-appimage_53",
-        "nix-bundle-dir": "nix-bundle-dir_178",
+        "nix-bundle-appimage": "nix-bundle-appimage_54",
+        "nix-bundle-dir": "nix-bundle-dir_179",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63201,8 +63204,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1100",
         "logos-package": "logos-package_129",
-        "nix-bundle-appimage": "nix-bundle-appimage_54",
-        "nix-bundle-dir": "nix-bundle-dir_182",
+        "nix-bundle-appimage": "nix-bundle-appimage_55",
+        "nix-bundle-dir": "nix-bundle-dir_183",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63236,8 +63239,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1127",
         "logos-package": "logos-package_131",
-        "nix-bundle-appimage": "nix-bundle-appimage_55",
-        "nix-bundle-dir": "nix-bundle-dir_185",
+        "nix-bundle-appimage": "nix-bundle-appimage_56",
+        "nix-bundle-dir": "nix-bundle-dir_186",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63273,8 +63276,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1144",
         "logos-package": "logos-package_134",
-        "nix-bundle-appimage": "nix-bundle-appimage_56",
-        "nix-bundle-dir": "nix-bundle-dir_189",
+        "nix-bundle-appimage": "nix-bundle-appimage_57",
+        "nix-bundle-dir": "nix-bundle-dir_190",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63309,8 +63312,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1155",
         "logos-package": "logos-package_136",
-        "nix-bundle-appimage": "nix-bundle-appimage_57",
-        "nix-bundle-dir": "nix-bundle-dir_192",
+        "nix-bundle-appimage": "nix-bundle-appimage_58",
+        "nix-bundle-dir": "nix-bundle-dir_193",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63342,8 +63345,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1172",
         "logos-package": "logos-package_139",
-        "nix-bundle-appimage": "nix-bundle-appimage_58",
-        "nix-bundle-dir": "nix-bundle-dir_196",
+        "nix-bundle-appimage": "nix-bundle-appimage_59",
+        "nix-bundle-dir": "nix-bundle-dir_197",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63374,8 +63377,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1213",
         "logos-package": "logos-package_141",
-        "nix-bundle-appimage": "nix-bundle-appimage_59",
-        "nix-bundle-dir": "nix-bundle-dir_199",
+        "nix-bundle-appimage": "nix-bundle-appimage_60",
+        "nix-bundle-dir": "nix-bundle-dir_200",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63411,8 +63414,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1230",
         "logos-package": "logos-package_144",
-        "nix-bundle-appimage": "nix-bundle-appimage_60",
-        "nix-bundle-dir": "nix-bundle-dir_203",
+        "nix-bundle-appimage": "nix-bundle-appimage_61",
+        "nix-bundle-dir": "nix-bundle-dir_204",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63479,8 +63482,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1257",
         "logos-package": "logos-package_146",
-        "nix-bundle-appimage": "nix-bundle-appimage_61",
-        "nix-bundle-dir": "nix-bundle-dir_206",
+        "nix-bundle-appimage": "nix-bundle-appimage_62",
+        "nix-bundle-dir": "nix-bundle-dir_207",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63517,8 +63520,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1274",
         "logos-package": "logos-package_149",
-        "nix-bundle-appimage": "nix-bundle-appimage_62",
-        "nix-bundle-dir": "nix-bundle-dir_210",
+        "nix-bundle-appimage": "nix-bundle-appimage_63",
+        "nix-bundle-dir": "nix-bundle-dir_211",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63554,8 +63557,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1285",
         "logos-package": "logos-package_151",
-        "nix-bundle-appimage": "nix-bundle-appimage_63",
-        "nix-bundle-dir": "nix-bundle-dir_213",
+        "nix-bundle-appimage": "nix-bundle-appimage_64",
+        "nix-bundle-dir": "nix-bundle-dir_214",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63588,8 +63591,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1302",
         "logos-package": "logos-package_154",
-        "nix-bundle-appimage": "nix-bundle-appimage_64",
-        "nix-bundle-dir": "nix-bundle-dir_217",
+        "nix-bundle-appimage": "nix-bundle-appimage_65",
+        "nix-bundle-dir": "nix-bundle-dir_218",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63621,8 +63624,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1316",
         "logos-package": "logos-package_156",
-        "nix-bundle-appimage": "nix-bundle-appimage_65",
-        "nix-bundle-dir": "nix-bundle-dir_220",
+        "nix-bundle-appimage": "nix-bundle-appimage_66",
+        "nix-bundle-dir": "nix-bundle-dir_221",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63651,8 +63654,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1335",
         "logos-package": "logos-package_159",
-        "nix-bundle-appimage": "nix-bundle-appimage_66",
-        "nix-bundle-dir": "nix-bundle-dir_224",
+        "nix-bundle-appimage": "nix-bundle-appimage_67",
+        "nix-bundle-dir": "nix-bundle-dir_225",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -63680,8 +63683,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1379",
         "logos-package": "logos-package_162",
-        "nix-bundle-appimage": "nix-bundle-appimage_67",
-        "nix-bundle-dir": "nix-bundle-dir_227",
+        "nix-bundle-appimage": "nix-bundle-appimage_68",
+        "nix-bundle-dir": "nix-bundle-dir_228",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63717,8 +63720,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1396",
         "logos-package": "logos-package_165",
-        "nix-bundle-appimage": "nix-bundle-appimage_68",
-        "nix-bundle-dir": "nix-bundle-dir_231",
+        "nix-bundle-appimage": "nix-bundle-appimage_69",
+        "nix-bundle-dir": "nix-bundle-dir_232",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63753,8 +63756,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1423",
         "logos-package": "logos-package_167",
-        "nix-bundle-appimage": "nix-bundle-appimage_69",
-        "nix-bundle-dir": "nix-bundle-dir_234",
+        "nix-bundle-appimage": "nix-bundle-appimage_70",
+        "nix-bundle-dir": "nix-bundle-dir_235",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63791,8 +63794,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1440",
         "logos-package": "logos-package_170",
-        "nix-bundle-appimage": "nix-bundle-appimage_70",
-        "nix-bundle-dir": "nix-bundle-dir_238",
+        "nix-bundle-appimage": "nix-bundle-appimage_71",
+        "nix-bundle-dir": "nix-bundle-dir_239",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63865,8 +63868,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1451",
         "logos-package": "logos-package_172",
-        "nix-bundle-appimage": "nix-bundle-appimage_71",
-        "nix-bundle-dir": "nix-bundle-dir_241",
+        "nix-bundle-appimage": "nix-bundle-appimage_72",
+        "nix-bundle-dir": "nix-bundle-dir_242",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63899,8 +63902,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1468",
         "logos-package": "logos-package_175",
-        "nix-bundle-appimage": "nix-bundle-appimage_72",
-        "nix-bundle-dir": "nix-bundle-dir_245",
+        "nix-bundle-appimage": "nix-bundle-appimage_73",
+        "nix-bundle-dir": "nix-bundle-dir_246",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63932,8 +63935,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1509",
         "logos-package": "logos-package_177",
-        "nix-bundle-appimage": "nix-bundle-appimage_73",
-        "nix-bundle-dir": "nix-bundle-dir_248",
+        "nix-bundle-appimage": "nix-bundle-appimage_74",
+        "nix-bundle-dir": "nix-bundle-dir_249",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -63970,8 +63973,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1526",
         "logos-package": "logos-package_180",
-        "nix-bundle-appimage": "nix-bundle-appimage_74",
-        "nix-bundle-dir": "nix-bundle-dir_252",
+        "nix-bundle-appimage": "nix-bundle-appimage_75",
+        "nix-bundle-dir": "nix-bundle-dir_253",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64007,8 +64010,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1553",
         "logos-package": "logos-package_182",
-        "nix-bundle-appimage": "nix-bundle-appimage_75",
-        "nix-bundle-dir": "nix-bundle-dir_255",
+        "nix-bundle-appimage": "nix-bundle-appimage_76",
+        "nix-bundle-dir": "nix-bundle-dir_256",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64046,8 +64049,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1570",
         "logos-package": "logos-package_185",
-        "nix-bundle-appimage": "nix-bundle-appimage_76",
-        "nix-bundle-dir": "nix-bundle-dir_259",
+        "nix-bundle-appimage": "nix-bundle-appimage_77",
+        "nix-bundle-dir": "nix-bundle-dir_260",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64084,8 +64087,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1581",
         "logos-package": "logos-package_187",
-        "nix-bundle-appimage": "nix-bundle-appimage_77",
-        "nix-bundle-dir": "nix-bundle-dir_262",
+        "nix-bundle-appimage": "nix-bundle-appimage_78",
+        "nix-bundle-dir": "nix-bundle-dir_263",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64119,8 +64122,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1598",
         "logos-package": "logos-package_190",
-        "nix-bundle-appimage": "nix-bundle-appimage_78",
-        "nix-bundle-dir": "nix-bundle-dir_266",
+        "nix-bundle-appimage": "nix-bundle-appimage_79",
+        "nix-bundle-dir": "nix-bundle-dir_267",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64153,8 +64156,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1612",
         "logos-package": "logos-package_192",
-        "nix-bundle-appimage": "nix-bundle-appimage_79",
-        "nix-bundle-dir": "nix-bundle-dir_269",
+        "nix-bundle-appimage": "nix-bundle-appimage_80",
+        "nix-bundle-dir": "nix-bundle-dir_270",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64184,8 +64187,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1631",
         "logos-package": "logos-package_195",
-        "nix-bundle-appimage": "nix-bundle-appimage_80",
-        "nix-bundle-dir": "nix-bundle-dir_273",
+        "nix-bundle-appimage": "nix-bundle-appimage_81",
+        "nix-bundle-dir": "nix-bundle-dir_274",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -64250,8 +64253,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1679",
         "logos-package": "logos-package_198",
-        "nix-bundle-appimage": "nix-bundle-appimage_82",
-        "nix-bundle-dir": "nix-bundle-dir_278",
+        "nix-bundle-appimage": "nix-bundle-appimage_83",
+        "nix-bundle-dir": "nix-bundle-dir_279",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64287,8 +64290,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1696",
         "logos-package": "logos-package_201",
-        "nix-bundle-appimage": "nix-bundle-appimage_83",
-        "nix-bundle-dir": "nix-bundle-dir_282",
+        "nix-bundle-appimage": "nix-bundle-appimage_84",
+        "nix-bundle-dir": "nix-bundle-dir_283",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64323,8 +64326,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1723",
         "logos-package": "logos-package_203",
-        "nix-bundle-appimage": "nix-bundle-appimage_84",
-        "nix-bundle-dir": "nix-bundle-dir_285",
+        "nix-bundle-appimage": "nix-bundle-appimage_85",
+        "nix-bundle-dir": "nix-bundle-dir_286",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64361,8 +64364,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1740",
         "logos-package": "logos-package_206",
-        "nix-bundle-appimage": "nix-bundle-appimage_85",
-        "nix-bundle-dir": "nix-bundle-dir_289",
+        "nix-bundle-appimage": "nix-bundle-appimage_86",
+        "nix-bundle-dir": "nix-bundle-dir_290",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64398,8 +64401,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1751",
         "logos-package": "logos-package_208",
-        "nix-bundle-appimage": "nix-bundle-appimage_86",
-        "nix-bundle-dir": "nix-bundle-dir_292",
+        "nix-bundle-appimage": "nix-bundle-appimage_87",
+        "nix-bundle-dir": "nix-bundle-dir_293",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64432,8 +64435,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1768",
         "logos-package": "logos-package_211",
-        "nix-bundle-appimage": "nix-bundle-appimage_87",
-        "nix-bundle-dir": "nix-bundle-dir_296",
+        "nix-bundle-appimage": "nix-bundle-appimage_88",
+        "nix-bundle-dir": "nix-bundle-dir_297",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64465,8 +64468,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1809",
         "logos-package": "logos-package_213",
-        "nix-bundle-appimage": "nix-bundle-appimage_88",
-        "nix-bundle-dir": "nix-bundle-dir_299",
+        "nix-bundle-appimage": "nix-bundle-appimage_89",
+        "nix-bundle-dir": "nix-bundle-dir_300",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64503,8 +64506,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1826",
         "logos-package": "logos-package_216",
-        "nix-bundle-appimage": "nix-bundle-appimage_89",
-        "nix-bundle-dir": "nix-bundle-dir_303",
+        "nix-bundle-appimage": "nix-bundle-appimage_90",
+        "nix-bundle-dir": "nix-bundle-dir_304",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64540,8 +64543,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1853",
         "logos-package": "logos-package_218",
-        "nix-bundle-appimage": "nix-bundle-appimage_90",
-        "nix-bundle-dir": "nix-bundle-dir_306",
+        "nix-bundle-appimage": "nix-bundle-appimage_91",
+        "nix-bundle-dir": "nix-bundle-dir_307",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64579,8 +64582,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1870",
         "logos-package": "logos-package_221",
-        "nix-bundle-appimage": "nix-bundle-appimage_91",
-        "nix-bundle-dir": "nix-bundle-dir_310",
+        "nix-bundle-appimage": "nix-bundle-appimage_92",
+        "nix-bundle-dir": "nix-bundle-dir_311",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64655,8 +64658,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1881",
         "logos-package": "logos-package_223",
-        "nix-bundle-appimage": "nix-bundle-appimage_92",
-        "nix-bundle-dir": "nix-bundle-dir_313",
+        "nix-bundle-appimage": "nix-bundle-appimage_93",
+        "nix-bundle-dir": "nix-bundle-dir_314",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64690,8 +64693,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1898",
         "logos-package": "logos-package_226",
-        "nix-bundle-appimage": "nix-bundle-appimage_93",
-        "nix-bundle-dir": "nix-bundle-dir_317",
+        "nix-bundle-appimage": "nix-bundle-appimage_94",
+        "nix-bundle-dir": "nix-bundle-dir_318",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64724,8 +64727,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1912",
         "logos-package": "logos-package_228",
-        "nix-bundle-appimage": "nix-bundle-appimage_94",
-        "nix-bundle-dir": "nix-bundle-dir_320",
+        "nix-bundle-appimage": "nix-bundle-appimage_95",
+        "nix-bundle-dir": "nix-bundle-dir_321",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64755,8 +64758,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1931",
         "logos-package": "logos-package_231",
-        "nix-bundle-appimage": "nix-bundle-appimage_95",
-        "nix-bundle-dir": "nix-bundle-dir_324",
+        "nix-bundle-appimage": "nix-bundle-appimage_96",
+        "nix-bundle-dir": "nix-bundle-dir_325",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64785,8 +64788,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1939",
         "logos-package": "logos-package_233",
-        "nix-bundle-appimage": "nix-bundle-appimage_96",
-        "nix-bundle-dir": "nix-bundle-dir_327",
+        "nix-bundle-appimage": "nix-bundle-appimage_97",
+        "nix-bundle-dir": "nix-bundle-dir_328",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -64813,8 +64816,8 @@
       "inputs": {
         "logos-nix": "logos-nix_1950",
         "logos-package": "logos-package_234",
-        "nix-bundle-appimage": "nix-bundle-appimage_98",
-        "nix-bundle-dir": "nix-bundle-dir_331",
+        "nix-bundle-appimage": "nix-bundle-appimage_99",
+        "nix-bundle-dir": "nix-bundle-dir_332",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -76677,11 +76680,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782490644,
-        "narHash": "sha256-IRHFIBa/+a10tVNEexm6DDZ0JPF8YQgUbxWoNwIytt4=",
+        "lastModified": 1782920676,
+        "narHash": "sha256-Vb81kiYbi8yYDZbUSW6v7QhV6uO/pj7F+lCAW1coAsY=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "d5d58e7e230768505c683150f651358612abd442",
+        "rev": "d7ad26d369c4e464a99f2a357f10c5947c7174e1",
         "type": "github"
       },
       "original": {
@@ -85991,11 +85994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782494049,
-        "narHash": "sha256-wcWVA8NGvTZrO8tCGqVe5UB9uIDEP+qsxlNCyvHneVc=",
+        "lastModified": 1784036478,
+        "narHash": "sha256-uQ6i1Xviz6QYi0g/3aS5HrVv0cWzoI/KvmCWN4jQA2s=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "70f219a24847d79fa74e7a93d09798b2cc580253",
+        "rev": "b2316faac28ecaed9c3cb1a9e96bc76ef7b34368",
         "type": "github"
       },
       "original": {
@@ -86386,29 +86389,25 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
-        "nix-bundle-dir": "nix-bundle-dir_50",
+        "logos-nix": [
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -86419,8 +86418,8 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
-        "nix-bundle-dir": "nix-bundle-dir_54",
+        "logos-nix": "logos-nix_331",
+        "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -86428,7 +86427,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86451,48 +86451,13 @@
     },
     "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
-        "nix-bundle-dir": "nix-bundle-dir_57",
+        "logos-nix": "logos-nix_348",
+        "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_18": {
-      "inputs": {
-        "logos-nix": "logos-nix_392",
-        "nix-bundle-dir": "nix-bundle-dir_61",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -86516,16 +86481,53 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_19": {
+    "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
-        "nix-bundle-dir": "nix-bundle-dir_64",
+        "logos-nix": "logos-nix_375",
+        "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_19": {
+      "inputs": {
+        "logos-nix": "logos-nix_392",
+        "nix-bundle-dir": "nix-bundle-dir_62",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86582,8 +86584,38 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
+        "logos-nix": "logos-nix_403",
+        "nix-bundle-dir": "nix-bundle-dir_65",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_21": {
+      "inputs": {
         "logos-nix": "logos-nix_420",
-        "nix-bundle-dir": "nix-bundle-dir_68",
+        "nix-bundle-dir": "nix-bundle-dir_69",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -86609,46 +86641,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_21": {
-      "inputs": {
-        "logos-nix": "logos-nix_434",
-        "nix-bundle-dir": "nix-bundle-dir_71",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
-        "nix-bundle-dir": "nix-bundle-dir_73",
+        "logos-nix": "logos-nix_434",
+        "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -86672,8 +86669,8 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
-        "nix-bundle-dir": "nix-bundle-dir_77",
+        "logos-nix": "logos-nix_480",
+        "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86683,7 +86680,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86706,8 +86704,8 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
-        "nix-bundle-dir": "nix-bundle-dir_80",
+        "logos-nix": "logos-nix_497",
+        "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86715,11 +86713,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86742,8 +86738,8 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_541",
-        "nix-bundle-dir": "nix-bundle-dir_84",
+        "logos-nix": "logos-nix_524",
+        "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86754,7 +86750,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86777,8 +86774,8 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
-        "nix-bundle-dir": "nix-bundle-dir_87",
+        "logos-nix": "logos-nix_541",
+        "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86787,6 +86784,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86809,15 +86809,16 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
-        "nix-bundle-dir": "nix-bundle-dir_91",
+        "logos-nix": "logos-nix_552",
+        "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86840,20 +86841,15 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_610",
-        "nix-bundle-dir": "nix-bundle-dir_94",
+        "logos-nix": "logos-nix_569",
+        "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86876,8 +86872,8 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_627",
-        "nix-bundle-dir": "nix-bundle-dir_98",
+        "logos-nix": "logos-nix_610",
+        "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86888,7 +86884,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86947,8 +86944,8 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_654",
-        "nix-bundle-dir": "nix-bundle-dir_101",
+        "logos-nix": "logos-nix_627",
+        "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86957,11 +86954,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -86984,8 +86979,8 @@
     },
     "nix-bundle-appimage_31": {
       "inputs": {
-        "logos-nix": "logos-nix_671",
-        "nix-bundle-dir": "nix-bundle-dir_105",
+        "logos-nix": "logos-nix_654",
+        "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -86997,7 +86992,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87020,8 +87016,8 @@
     },
     "nix-bundle-appimage_32": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
-        "nix-bundle-dir": "nix-bundle-dir_108",
+        "logos-nix": "logos-nix_671",
+        "nix-bundle-dir": "nix-bundle-dir_106",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -87031,6 +87027,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87053,8 +87052,8 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
-        "nix-bundle-dir": "nix-bundle-dir_112",
+        "logos-nix": "logos-nix_682",
+        "nix-bundle-dir": "nix-bundle-dir_109",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -87062,7 +87061,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87085,13 +87085,16 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
-        "nix-bundle-dir": "nix-bundle-dir_115",
+        "logos-nix": "logos-nix_699",
+        "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87114,95 +87117,10 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
-        "nix-bundle-dir": "nix-bundle-dir_119",
+        "logos-nix": "logos-nix_713",
+        "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_36": {
-      "inputs": {
-        "logos-nix": "logos-nix_740",
-        "nix-bundle-dir": "nix-bundle-dir_122",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_37": {
-      "inputs": {
-        "logos-nix": "logos-nix_745",
-        "nix-bundle-dir": "nix-bundle-dir_124",
-        "nixpkgs": [
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_785",
-        "nix-bundle-dir": "nix-bundle-dir_126",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -87226,10 +87144,89 @@
         "type": "github"
       }
     },
+    "nix-bundle-appimage_36": {
+      "inputs": {
+        "logos-nix": "logos-nix_732",
+        "nix-bundle-dir": "nix-bundle-dir_120",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_37": {
+      "inputs": {
+        "logos-nix": "logos-nix_740",
+        "nix-bundle-dir": "nix-bundle-dir_123",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-package-downloader",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_38": {
+      "inputs": {
+        "logos-nix": "logos-nix_745",
+        "nix-bundle-dir": "nix-bundle-dir_125",
+        "nixpkgs": [
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
     "nix-bundle-appimage_39": {
       "inputs": {
-        "logos-nix": "logos-nix_802",
-        "nix-bundle-dir": "nix-bundle-dir_130",
+        "logos-nix": "logos-nix_785",
+        "nix-bundle-dir": "nix-bundle-dir_127",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87239,7 +87236,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87297,8 +87295,8 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_829",
-        "nix-bundle-dir": "nix-bundle-dir_133",
+        "logos-nix": "logos-nix_802",
+        "nix-bundle-dir": "nix-bundle-dir_131",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87306,11 +87304,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87333,8 +87329,8 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_846",
-        "nix-bundle-dir": "nix-bundle-dir_137",
+        "logos-nix": "logos-nix_829",
+        "nix-bundle-dir": "nix-bundle-dir_134",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87345,7 +87341,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87368,8 +87365,8 @@
     },
     "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_857",
-        "nix-bundle-dir": "nix-bundle-dir_140",
+        "logos-nix": "logos-nix_846",
+        "nix-bundle-dir": "nix-bundle-dir_138",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87378,6 +87375,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87400,15 +87400,16 @@
     },
     "nix-bundle-appimage_43": {
       "inputs": {
-        "logos-nix": "logos-nix_874",
-        "nix-bundle-dir": "nix-bundle-dir_144",
+        "logos-nix": "logos-nix_857",
+        "nix-bundle-dir": "nix-bundle-dir_141",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87431,20 +87432,15 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_915",
-        "nix-bundle-dir": "nix-bundle-dir_147",
+        "logos-nix": "logos-nix_874",
+        "nix-bundle-dir": "nix-bundle-dir_145",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87467,8 +87463,8 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-        "logos-nix": "logos-nix_932",
-        "nix-bundle-dir": "nix-bundle-dir_151",
+        "logos-nix": "logos-nix_915",
+        "nix-bundle-dir": "nix-bundle-dir_148",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87479,7 +87475,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87502,8 +87499,8 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-        "logos-nix": "logos-nix_959",
-        "nix-bundle-dir": "nix-bundle-dir_154",
+        "logos-nix": "logos-nix_932",
+        "nix-bundle-dir": "nix-bundle-dir_152",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87512,11 +87509,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87539,8 +87534,8 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
-        "logos-nix": "logos-nix_976",
-        "nix-bundle-dir": "nix-bundle-dir_158",
+        "logos-nix": "logos-nix_959",
+        "nix-bundle-dir": "nix-bundle-dir_155",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87552,7 +87547,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87575,8 +87571,8 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
-        "logos-nix": "logos-nix_987",
-        "nix-bundle-dir": "nix-bundle-dir_161",
+        "logos-nix": "logos-nix_976",
+        "nix-bundle-dir": "nix-bundle-dir_159",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87586,6 +87582,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87608,8 +87607,8 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
-        "logos-nix": "logos-nix_1004",
-        "nix-bundle-dir": "nix-bundle-dir_165",
+        "logos-nix": "logos-nix_987",
+        "nix-bundle-dir": "nix-bundle-dir_162",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -87617,7 +87616,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87672,13 +87672,16 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
-        "logos-nix": "logos-nix_1018",
-        "nix-bundle-dir": "nix-bundle-dir_168",
+        "logos-nix": "logos-nix_1004",
+        "nix-bundle-dir": "nix-bundle-dir_166",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87701,12 +87704,13 @@
     },
     "nix-bundle-appimage_51": {
       "inputs": {
-        "logos-nix": "logos-nix_1037",
-        "nix-bundle-dir": "nix-bundle-dir_172",
+        "logos-nix": "logos-nix_1018",
+        "nix-bundle-dir": "nix-bundle-dir_169",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87729,10 +87733,12 @@
     },
     "nix-bundle-appimage_52": {
       "inputs": {
-        "logos-nix": "logos-nix_1045",
-        "nix-bundle-dir": "nix-bundle-dir_175",
+        "logos-nix": "logos-nix_1037",
+        "nix-bundle-dir": "nix-bundle-dir_173",
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87755,19 +87761,10 @@
     },
     "nix-bundle-appimage_53": {
       "inputs": {
-        "logos-nix": "logos-nix_1085",
-        "nix-bundle-dir": "nix-bundle-dir_177",
+        "logos-nix": "logos-nix_1045",
+        "nix-bundle-dir": "nix-bundle-dir_176",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-package-manager-module",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87790,8 +87787,8 @@
     },
     "nix-bundle-appimage_54": {
       "inputs": {
-        "logos-nix": "logos-nix_1102",
-        "nix-bundle-dir": "nix-bundle-dir_181",
+        "logos-nix": "logos-nix_1085",
+        "nix-bundle-dir": "nix-bundle-dir_178",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -87801,7 +87798,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87824,8 +87822,8 @@
     },
     "nix-bundle-appimage_55": {
       "inputs": {
-        "logos-nix": "logos-nix_1129",
-        "nix-bundle-dir": "nix-bundle-dir_184",
+        "logos-nix": "logos-nix_1102",
+        "nix-bundle-dir": "nix-bundle-dir_182",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -87833,11 +87831,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87860,8 +87856,8 @@
     },
     "nix-bundle-appimage_56": {
       "inputs": {
-        "logos-nix": "logos-nix_1146",
-        "nix-bundle-dir": "nix-bundle-dir_188",
+        "logos-nix": "logos-nix_1129",
+        "nix-bundle-dir": "nix-bundle-dir_185",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -87872,7 +87868,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -87895,8 +87892,8 @@
     },
     "nix-bundle-appimage_57": {
       "inputs": {
-        "logos-nix": "logos-nix_1157",
-        "nix-bundle-dir": "nix-bundle-dir_191",
+        "logos-nix": "logos-nix_1146",
+        "nix-bundle-dir": "nix-bundle-dir_189",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -87905,34 +87902,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_1174",
-        "nix-bundle-dir": "nix-bundle-dir_195",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
@@ -87956,22 +87925,49 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_59": {
+    "nix-bundle-appimage_58": {
       "inputs": {
-        "logos-nix": "logos-nix_1215",
-        "nix-bundle-dir": "nix-bundle-dir_198",
+        "logos-nix": "logos-nix_1157",
+        "nix-bundle-dir": "nix-bundle-dir_192",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_1174",
+        "nix-bundle-dir": "nix-bundle-dir_196",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88025,8 +88021,8 @@
     },
     "nix-bundle-appimage_60": {
       "inputs": {
-        "logos-nix": "logos-nix_1232",
-        "nix-bundle-dir": "nix-bundle-dir_202",
+        "logos-nix": "logos-nix_1215",
+        "nix-bundle-dir": "nix-bundle-dir_199",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -88037,7 +88033,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88060,8 +88057,8 @@
     },
     "nix-bundle-appimage_61": {
       "inputs": {
-        "logos-nix": "logos-nix_1259",
-        "nix-bundle-dir": "nix-bundle-dir_205",
+        "logos-nix": "logos-nix_1232",
+        "nix-bundle-dir": "nix-bundle-dir_203",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -88070,11 +88067,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88097,8 +88092,8 @@
     },
     "nix-bundle-appimage_62": {
       "inputs": {
-        "logos-nix": "logos-nix_1276",
-        "nix-bundle-dir": "nix-bundle-dir_209",
+        "logos-nix": "logos-nix_1259",
+        "nix-bundle-dir": "nix-bundle-dir_206",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -88110,7 +88105,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88133,8 +88129,8 @@
     },
     "nix-bundle-appimage_63": {
       "inputs": {
-        "logos-nix": "logos-nix_1287",
-        "nix-bundle-dir": "nix-bundle-dir_212",
+        "logos-nix": "logos-nix_1276",
+        "nix-bundle-dir": "nix-bundle-dir_210",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -88144,6 +88140,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88166,8 +88165,8 @@
     },
     "nix-bundle-appimage_64": {
       "inputs": {
-        "logos-nix": "logos-nix_1304",
-        "nix-bundle-dir": "nix-bundle-dir_216",
+        "logos-nix": "logos-nix_1287",
+        "nix-bundle-dir": "nix-bundle-dir_213",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -88175,7 +88174,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88198,13 +88198,16 @@
     },
     "nix-bundle-appimage_65": {
       "inputs": {
-        "logos-nix": "logos-nix_1318",
-        "nix-bundle-dir": "nix-bundle-dir_219",
+        "logos-nix": "logos-nix_1304",
+        "nix-bundle-dir": "nix-bundle-dir_217",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88227,12 +88230,13 @@
     },
     "nix-bundle-appimage_66": {
       "inputs": {
-        "logos-nix": "logos-nix_1337",
-        "nix-bundle-dir": "nix-bundle-dir_223",
+        "logos-nix": "logos-nix_1318",
+        "nix-bundle-dir": "nix-bundle-dir_220",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88255,53 +88259,10 @@
     },
     "nix-bundle-appimage_67": {
       "inputs": {
-        "logos-nix": "logos-nix_1381",
-        "nix-bundle-dir": "nix-bundle-dir_226",
+        "logos-nix": "logos-nix_1337",
+        "nix-bundle-dir": "nix-bundle-dir_224",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_68": {
-      "inputs": {
-        "logos-nix": "logos-nix_1398",
-        "nix-bundle-dir": "nix-bundle-dir_230",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -88324,10 +88285,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_69": {
+    "nix-bundle-appimage_68": {
       "inputs": {
-        "logos-nix": "logos-nix_1425",
-        "nix-bundle-dir": "nix-bundle-dir_233",
+        "logos-nix": "logos-nix_1381",
+        "nix-bundle-dir": "nix-bundle-dir_227",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88336,11 +88297,45 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_1398",
+        "nix-bundle-dir": "nix-bundle-dir_231",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88399,8 +88394,8 @@
     },
     "nix-bundle-appimage_70": {
       "inputs": {
-        "logos-nix": "logos-nix_1442",
-        "nix-bundle-dir": "nix-bundle-dir_237",
+        "logos-nix": "logos-nix_1425",
+        "nix-bundle-dir": "nix-bundle-dir_234",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88412,7 +88407,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88435,8 +88431,8 @@
     },
     "nix-bundle-appimage_71": {
       "inputs": {
-        "logos-nix": "logos-nix_1453",
-        "nix-bundle-dir": "nix-bundle-dir_240",
+        "logos-nix": "logos-nix_1442",
+        "nix-bundle-dir": "nix-bundle-dir_238",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88446,6 +88442,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88468,8 +88467,8 @@
     },
     "nix-bundle-appimage_72": {
       "inputs": {
-        "logos-nix": "logos-nix_1470",
-        "nix-bundle-dir": "nix-bundle-dir_244",
+        "logos-nix": "logos-nix_1453",
+        "nix-bundle-dir": "nix-bundle-dir_241",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88477,7 +88476,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88500,21 +88500,16 @@
     },
     "nix-bundle-appimage_73": {
       "inputs": {
-        "logos-nix": "logos-nix_1511",
-        "nix-bundle-dir": "nix-bundle-dir_247",
+        "logos-nix": "logos-nix_1470",
+        "nix-bundle-dir": "nix-bundle-dir_245",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88537,8 +88532,8 @@
     },
     "nix-bundle-appimage_74": {
       "inputs": {
-        "logos-nix": "logos-nix_1528",
-        "nix-bundle-dir": "nix-bundle-dir_251",
+        "logos-nix": "logos-nix_1511",
+        "nix-bundle-dir": "nix-bundle-dir_248",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88550,7 +88545,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88573,8 +88569,8 @@
     },
     "nix-bundle-appimage_75": {
       "inputs": {
-        "logos-nix": "logos-nix_1555",
-        "nix-bundle-dir": "nix-bundle-dir_254",
+        "logos-nix": "logos-nix_1528",
+        "nix-bundle-dir": "nix-bundle-dir_252",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88584,11 +88580,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88611,8 +88605,8 @@
     },
     "nix-bundle-appimage_76": {
       "inputs": {
-        "logos-nix": "logos-nix_1572",
-        "nix-bundle-dir": "nix-bundle-dir_258",
+        "logos-nix": "logos-nix_1555",
+        "nix-bundle-dir": "nix-bundle-dir_255",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88625,7 +88619,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88648,8 +88643,8 @@
     },
     "nix-bundle-appimage_77": {
       "inputs": {
-        "logos-nix": "logos-nix_1583",
-        "nix-bundle-dir": "nix-bundle-dir_261",
+        "logos-nix": "logos-nix_1572",
+        "nix-bundle-dir": "nix-bundle-dir_259",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88660,6 +88655,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88682,8 +88680,8 @@
     },
     "nix-bundle-appimage_78": {
       "inputs": {
-        "logos-nix": "logos-nix_1600",
-        "nix-bundle-dir": "nix-bundle-dir_265",
+        "logos-nix": "logos-nix_1583",
+        "nix-bundle-dir": "nix-bundle-dir_262",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88692,7 +88690,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88715,14 +88714,17 @@
     },
     "nix-bundle-appimage_79": {
       "inputs": {
-        "logos-nix": "logos-nix_1614",
-        "nix-bundle-dir": "nix-bundle-dir_268",
+        "logos-nix": "logos-nix_1600",
+        "nix-bundle-dir": "nix-bundle-dir_266",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88780,8 +88782,38 @@
     },
     "nix-bundle-appimage_80": {
       "inputs": {
+        "logos-nix": "logos-nix_1614",
+        "nix-bundle-dir": "nix-bundle-dir_269",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_81": {
+      "inputs": {
         "logos-nix": "logos-nix_1633",
-        "nix-bundle-dir": "nix-bundle-dir_272",
+        "nix-bundle-dir": "nix-bundle-dir_273",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88807,10 +88839,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_81": {
+    "nix-bundle-appimage_82": {
       "inputs": {
         "logos-nix": "logos-nix_1641",
-        "nix-bundle-dir": "nix-bundle-dir_275",
+        "nix-bundle-dir": "nix-bundle-dir_276",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -88834,10 +88866,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_82": {
+    "nix-bundle-appimage_83": {
       "inputs": {
         "logos-nix": "logos-nix_1681",
-        "nix-bundle-dir": "nix-bundle-dir_277",
+        "nix-bundle-dir": "nix-bundle-dir_278",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -88850,41 +88882,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_83": {
-      "inputs": {
-        "logos-nix": "logos-nix_1698",
-        "nix-bundle-dir": "nix-bundle-dir_281",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88907,8 +88904,8 @@
     },
     "nix-bundle-appimage_84": {
       "inputs": {
-        "logos-nix": "logos-nix_1725",
-        "nix-bundle-dir": "nix-bundle-dir_284",
+        "logos-nix": "logos-nix_1698",
+        "nix-bundle-dir": "nix-bundle-dir_282",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -88917,11 +88914,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88944,8 +88939,8 @@
     },
     "nix-bundle-appimage_85": {
       "inputs": {
-        "logos-nix": "logos-nix_1742",
-        "nix-bundle-dir": "nix-bundle-dir_288",
+        "logos-nix": "logos-nix_1725",
+        "nix-bundle-dir": "nix-bundle-dir_285",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -88957,7 +88952,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -88980,8 +88976,8 @@
     },
     "nix-bundle-appimage_86": {
       "inputs": {
-        "logos-nix": "logos-nix_1753",
-        "nix-bundle-dir": "nix-bundle-dir_291",
+        "logos-nix": "logos-nix_1742",
+        "nix-bundle-dir": "nix-bundle-dir_289",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -88991,6 +88987,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89013,8 +89012,8 @@
     },
     "nix-bundle-appimage_87": {
       "inputs": {
-        "logos-nix": "logos-nix_1770",
-        "nix-bundle-dir": "nix-bundle-dir_295",
+        "logos-nix": "logos-nix_1753",
+        "nix-bundle-dir": "nix-bundle-dir_292",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89022,7 +89021,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89045,21 +89045,16 @@
     },
     "nix-bundle-appimage_88": {
       "inputs": {
-        "logos-nix": "logos-nix_1811",
-        "nix-bundle-dir": "nix-bundle-dir_298",
+        "logos-nix": "logos-nix_1770",
+        "nix-bundle-dir": "nix-bundle-dir_296",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89082,8 +89077,8 @@
     },
     "nix-bundle-appimage_89": {
       "inputs": {
-        "logos-nix": "logos-nix_1828",
-        "nix-bundle-dir": "nix-bundle-dir_302",
+        "logos-nix": "logos-nix_1811",
+        "nix-bundle-dir": "nix-bundle-dir_299",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89095,7 +89090,8 @@
           "logos-standalone-app",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89155,8 +89151,8 @@
     },
     "nix-bundle-appimage_90": {
       "inputs": {
-        "logos-nix": "logos-nix_1855",
-        "nix-bundle-dir": "nix-bundle-dir_305",
+        "logos-nix": "logos-nix_1828",
+        "nix-bundle-dir": "nix-bundle-dir_303",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89166,11 +89162,9 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89193,8 +89187,8 @@
     },
     "nix-bundle-appimage_91": {
       "inputs": {
-        "logos-nix": "logos-nix_1872",
-        "nix-bundle-dir": "nix-bundle-dir_309",
+        "logos-nix": "logos-nix_1855",
+        "nix-bundle-dir": "nix-bundle-dir_306",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89207,7 +89201,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89230,8 +89225,8 @@
     },
     "nix-bundle-appimage_92": {
       "inputs": {
-        "logos-nix": "logos-nix_1883",
-        "nix-bundle-dir": "nix-bundle-dir_312",
+        "logos-nix": "logos-nix_1872",
+        "nix-bundle-dir": "nix-bundle-dir_310",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89242,6 +89237,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -89264,8 +89262,42 @@
     },
     "nix-bundle-appimage_93": {
       "inputs": {
+        "logos-nix": "logos-nix_1883",
+        "nix-bundle-dir": "nix-bundle-dir_313",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_94": {
+      "inputs": {
         "logos-nix": "logos-nix_1900",
-        "nix-bundle-dir": "nix-bundle-dir_316",
+        "nix-bundle-dir": "nix-bundle-dir_317",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89295,10 +89327,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_94": {
+    "nix-bundle-appimage_95": {
       "inputs": {
         "logos-nix": "logos-nix_1914",
-        "nix-bundle-dir": "nix-bundle-dir_319",
+        "nix-bundle-dir": "nix-bundle-dir_320",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89325,10 +89357,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_95": {
+    "nix-bundle-appimage_96": {
       "inputs": {
         "logos-nix": "logos-nix_1933",
-        "nix-bundle-dir": "nix-bundle-dir_323",
+        "nix-bundle-dir": "nix-bundle-dir_324",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89354,10 +89386,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_96": {
+    "nix-bundle-appimage_97": {
       "inputs": {
         "logos-nix": "logos-nix_1941",
-        "nix-bundle-dir": "nix-bundle-dir_326",
+        "nix-bundle-dir": "nix-bundle-dir_327",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -89381,10 +89413,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_97": {
+    "nix-bundle-appimage_98": {
       "inputs": {
         "logos-nix": "logos-nix_1946",
-        "nix-bundle-dir": "nix-bundle-dir_328",
+        "nix-bundle-dir": "nix-bundle-dir_329",
         "nixpkgs": [
           "nix-bundle-appimage",
           "logos-nix",
@@ -89405,10 +89437,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_98": {
+    "nix-bundle-appimage_99": {
       "inputs": {
         "logos-nix": "logos-nix_1952",
-        "nix-bundle-dir": "nix-bundle-dir_330",
+        "nix-bundle-dir": "nix-bundle-dir_331",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -89500,6 +89532,40 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
+        "logos-nix": "logos-nix_629",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_101": {
+      "inputs": {
         "logos-nix": "logos-nix_632",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -89532,7 +89598,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_101": {
+    "nix-bundle-dir_102": {
       "inputs": {
         "logos-nix": "logos-nix_655",
         "nixpkgs": [
@@ -89567,7 +89633,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_102": {
+    "nix-bundle-dir_103": {
       "inputs": {
         "logos-nix": "logos-nix_656",
         "nixpkgs": [
@@ -89603,7 +89669,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_103": {
+    "nix-bundle-dir_104": {
       "inputs": {
         "logos-nix": "logos-nix_663",
         "nixpkgs": [
@@ -89638,7 +89704,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_104": {
+    "nix-bundle-dir_105": {
       "inputs": {
         "logos-nix": "logos-nix_667",
         "nixpkgs": [
@@ -89672,7 +89738,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_105": {
+    "nix-bundle-dir_106": {
       "inputs": {
         "logos-nix": "logos-nix_672",
         "nixpkgs": [
@@ -89706,7 +89772,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_106": {
+    "nix-bundle-dir_107": {
       "inputs": {
         "logos-nix": "logos-nix_673",
         "nixpkgs": [
@@ -89741,7 +89807,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_107": {
+    "nix-bundle-dir_108": {
       "inputs": {
         "logos-nix": "logos-nix_676",
         "nixpkgs": [
@@ -89776,7 +89842,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_108": {
+    "nix-bundle-dir_109": {
       "inputs": {
         "logos-nix": "logos-nix_683",
         "nixpkgs": [
@@ -89799,38 +89865,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_109": {
-      "inputs": {
-        "logos-nix": "logos-nix_684",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -89874,6 +89908,38 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
+        "logos-nix": "logos-nix_684",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_111": {
+      "inputs": {
         "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -89903,7 +89969,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_111": {
+    "nix-bundle-dir_112": {
       "inputs": {
         "logos-nix": "logos-nix_695",
         "nixpkgs": [
@@ -89933,7 +89999,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_112": {
+    "nix-bundle-dir_113": {
       "inputs": {
         "logos-nix": "logos-nix_700",
         "nixpkgs": [
@@ -89963,7 +90029,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_113": {
+    "nix-bundle-dir_114": {
       "inputs": {
         "logos-nix": "logos-nix_701",
         "nixpkgs": [
@@ -89994,7 +90060,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_114": {
+    "nix-bundle-dir_115": {
       "inputs": {
         "logos-nix": "logos-nix_704",
         "nixpkgs": [
@@ -90025,7 +90091,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_115": {
+    "nix-bundle-dir_116": {
       "inputs": {
         "logos-nix": "logos-nix_714",
         "nixpkgs": [
@@ -90052,7 +90118,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_116": {
+    "nix-bundle-dir_117": {
       "inputs": {
         "logos-nix": "logos-nix_715",
         "nixpkgs": [
@@ -90080,7 +90146,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_117": {
+    "nix-bundle-dir_118": {
       "inputs": {
         "logos-nix": "logos-nix_724",
         "nixpkgs": [
@@ -90107,7 +90173,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_118": {
+    "nix-bundle-dir_119": {
       "inputs": {
         "logos-nix": "logos-nix_728",
         "nixpkgs": [
@@ -90125,32 +90191,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_119": {
-      "inputs": {
-        "logos-nix": "logos-nix_733",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -90194,6 +90234,32 @@
     },
     "nix-bundle-dir_120": {
       "inputs": {
+        "logos-nix": "logos-nix_733",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_121": {
+      "inputs": {
         "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -90219,7 +90285,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_121": {
+    "nix-bundle-dir_122": {
       "inputs": {
         "logos-nix": "logos-nix_737",
         "nixpkgs": [
@@ -90246,7 +90312,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_122": {
+    "nix-bundle-dir_123": {
       "inputs": {
         "logos-nix": "logos-nix_741",
         "nixpkgs": [
@@ -90270,7 +90336,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_123": {
+    "nix-bundle-dir_124": {
       "inputs": {
         "logos-nix": "logos-nix_742",
         "nixpkgs": [
@@ -90295,7 +90361,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_124": {
+    "nix-bundle-dir_125": {
       "inputs": {
         "logos-nix": "logos-nix_746",
         "nixpkgs": [
@@ -90318,7 +90384,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_125": {
+    "nix-bundle-dir_126": {
       "inputs": {
         "logos-nix": "logos-nix_747",
         "nixpkgs": [
@@ -90342,7 +90408,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_126": {
+    "nix-bundle-dir_127": {
       "inputs": {
         "logos-nix": "logos-nix_786",
         "nixpkgs": [
@@ -90375,7 +90441,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_127": {
+    "nix-bundle-dir_128": {
       "inputs": {
         "logos-nix": "logos-nix_787",
         "nixpkgs": [
@@ -90409,7 +90475,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_128": {
+    "nix-bundle-dir_129": {
       "inputs": {
         "logos-nix": "logos-nix_794",
         "nixpkgs": [
@@ -90422,38 +90488,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_129": {
-      "inputs": {
-        "logos-nix": "logos-nix_798",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
@@ -90510,6 +90544,38 @@
     },
     "nix-bundle-dir_130": {
       "inputs": {
+        "logos-nix": "logos-nix_798",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_131": {
+      "inputs": {
         "logos-nix": "logos-nix_803",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -90540,7 +90606,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_131": {
+    "nix-bundle-dir_132": {
       "inputs": {
         "logos-nix": "logos-nix_804",
         "nixpkgs": [
@@ -90573,7 +90639,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_132": {
+    "nix-bundle-dir_133": {
       "inputs": {
         "logos-nix": "logos-nix_807",
         "nixpkgs": [
@@ -90606,7 +90672,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_133": {
+    "nix-bundle-dir_134": {
       "inputs": {
         "logos-nix": "logos-nix_830",
         "nixpkgs": [
@@ -90640,7 +90706,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_134": {
+    "nix-bundle-dir_135": {
       "inputs": {
         "logos-nix": "logos-nix_831",
         "nixpkgs": [
@@ -90675,7 +90741,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_135": {
+    "nix-bundle-dir_136": {
       "inputs": {
         "logos-nix": "logos-nix_838",
         "nixpkgs": [
@@ -90709,7 +90775,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_136": {
+    "nix-bundle-dir_137": {
       "inputs": {
         "logos-nix": "logos-nix_842",
         "nixpkgs": [
@@ -90742,7 +90808,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_137": {
+    "nix-bundle-dir_138": {
       "inputs": {
         "logos-nix": "logos-nix_847",
         "nixpkgs": [
@@ -90775,7 +90841,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_138": {
+    "nix-bundle-dir_139": {
       "inputs": {
         "logos-nix": "logos-nix_848",
         "nixpkgs": [
@@ -90790,40 +90856,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_139": {
-      "inputs": {
-        "logos-nix": "logos-nix_851",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -90879,6 +90911,40 @@
     },
     "nix-bundle-dir_140": {
       "inputs": {
+        "logos-nix": "logos-nix_851",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_141": {
+      "inputs": {
         "logos-nix": "logos-nix_858",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -90907,7 +90973,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_141": {
+    "nix-bundle-dir_142": {
       "inputs": {
         "logos-nix": "logos-nix_859",
         "nixpkgs": [
@@ -90938,7 +91004,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_142": {
+    "nix-bundle-dir_143": {
       "inputs": {
         "logos-nix": "logos-nix_866",
         "nixpkgs": [
@@ -90968,7 +91034,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_143": {
+    "nix-bundle-dir_144": {
       "inputs": {
         "logos-nix": "logos-nix_870",
         "nixpkgs": [
@@ -90997,7 +91063,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_144": {
+    "nix-bundle-dir_145": {
       "inputs": {
         "logos-nix": "logos-nix_875",
         "nixpkgs": [
@@ -91026,7 +91092,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_145": {
+    "nix-bundle-dir_146": {
       "inputs": {
         "logos-nix": "logos-nix_876",
         "nixpkgs": [
@@ -91056,7 +91122,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_146": {
+    "nix-bundle-dir_147": {
       "inputs": {
         "logos-nix": "logos-nix_879",
         "nixpkgs": [
@@ -91086,7 +91152,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_147": {
+    "nix-bundle-dir_148": {
       "inputs": {
         "logos-nix": "logos-nix_916",
         "nixpkgs": [
@@ -91120,7 +91186,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_148": {
+    "nix-bundle-dir_149": {
       "inputs": {
         "logos-nix": "logos-nix_917",
         "nixpkgs": [
@@ -91136,40 +91202,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_149": {
-      "inputs": {
-        "logos-nix": "logos-nix_924",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -91221,6 +91253,40 @@
     },
     "nix-bundle-dir_150": {
       "inputs": {
+        "logos-nix": "logos-nix_924",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_151": {
+      "inputs": {
         "logos-nix": "logos-nix_928",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -91252,7 +91318,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_151": {
+    "nix-bundle-dir_152": {
       "inputs": {
         "logos-nix": "logos-nix_933",
         "nixpkgs": [
@@ -91285,7 +91351,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_152": {
+    "nix-bundle-dir_153": {
       "inputs": {
         "logos-nix": "logos-nix_934",
         "nixpkgs": [
@@ -91319,7 +91385,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_153": {
+    "nix-bundle-dir_154": {
       "inputs": {
         "logos-nix": "logos-nix_937",
         "nixpkgs": [
@@ -91353,7 +91419,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_154": {
+    "nix-bundle-dir_155": {
       "inputs": {
         "logos-nix": "logos-nix_960",
         "nixpkgs": [
@@ -91388,7 +91454,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_155": {
+    "nix-bundle-dir_156": {
       "inputs": {
         "logos-nix": "logos-nix_961",
         "nixpkgs": [
@@ -91424,7 +91490,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_156": {
+    "nix-bundle-dir_157": {
       "inputs": {
         "logos-nix": "logos-nix_968",
         "nixpkgs": [
@@ -91459,7 +91525,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_157": {
+    "nix-bundle-dir_158": {
       "inputs": {
         "logos-nix": "logos-nix_972",
         "nixpkgs": [
@@ -91493,7 +91559,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_158": {
+    "nix-bundle-dir_159": {
       "inputs": {
         "logos-nix": "logos-nix_977",
         "nixpkgs": [
@@ -91519,41 +91585,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_159": {
-      "inputs": {
-        "logos-nix": "logos-nix_978",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -91595,6 +91626,41 @@
     },
     "nix-bundle-dir_160": {
       "inputs": {
+        "logos-nix": "logos-nix_978",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_161": {
+      "inputs": {
         "logos-nix": "logos-nix_981",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -91628,7 +91694,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_161": {
+    "nix-bundle-dir_162": {
       "inputs": {
         "logos-nix": "logos-nix_988",
         "nixpkgs": [
@@ -91659,7 +91725,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_162": {
+    "nix-bundle-dir_163": {
       "inputs": {
         "logos-nix": "logos-nix_989",
         "nixpkgs": [
@@ -91691,7 +91757,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_163": {
+    "nix-bundle-dir_164": {
       "inputs": {
         "logos-nix": "logos-nix_996",
         "nixpkgs": [
@@ -91722,7 +91788,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_164": {
+    "nix-bundle-dir_165": {
       "inputs": {
         "logos-nix": "logos-nix_1000",
         "nixpkgs": [
@@ -91752,7 +91818,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_165": {
+    "nix-bundle-dir_166": {
       "inputs": {
         "logos-nix": "logos-nix_1005",
         "nixpkgs": [
@@ -91782,7 +91848,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_166": {
+    "nix-bundle-dir_167": {
       "inputs": {
         "logos-nix": "logos-nix_1006",
         "nixpkgs": [
@@ -91813,7 +91879,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_167": {
+    "nix-bundle-dir_168": {
       "inputs": {
         "logos-nix": "logos-nix_1009",
         "nixpkgs": [
@@ -91844,7 +91910,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_168": {
+    "nix-bundle-dir_169": {
       "inputs": {
         "logos-nix": "logos-nix_1019",
         "nixpkgs": [
@@ -91863,34 +91929,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_169": {
-      "inputs": {
-        "logos-nix": "logos-nix_1020",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -91931,6 +91969,34 @@
     },
     "nix-bundle-dir_170": {
       "inputs": {
+        "logos-nix": "logos-nix_1020",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_171": {
+      "inputs": {
         "logos-nix": "logos-nix_1029",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -91956,7 +92022,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_171": {
+    "nix-bundle-dir_172": {
       "inputs": {
         "logos-nix": "logos-nix_1033",
         "nixpkgs": [
@@ -91982,7 +92048,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_172": {
+    "nix-bundle-dir_173": {
       "inputs": {
         "logos-nix": "logos-nix_1038",
         "nixpkgs": [
@@ -92008,7 +92074,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_173": {
+    "nix-bundle-dir_174": {
       "inputs": {
         "logos-nix": "logos-nix_1039",
         "nixpkgs": [
@@ -92035,7 +92101,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_174": {
+    "nix-bundle-dir_175": {
       "inputs": {
         "logos-nix": "logos-nix_1042",
         "nixpkgs": [
@@ -92062,7 +92128,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_175": {
+    "nix-bundle-dir_176": {
       "inputs": {
         "logos-nix": "logos-nix_1046",
         "nixpkgs": [
@@ -92086,7 +92152,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_176": {
+    "nix-bundle-dir_177": {
       "inputs": {
         "logos-nix": "logos-nix_1047",
         "nixpkgs": [
@@ -92111,7 +92177,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_177": {
+    "nix-bundle-dir_178": {
       "inputs": {
         "logos-nix": "logos-nix_1086",
         "nixpkgs": [
@@ -92144,7 +92210,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_178": {
+    "nix-bundle-dir_179": {
       "inputs": {
         "logos-nix": "logos-nix_1087",
         "nixpkgs": [
@@ -92159,39 +92225,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_179": {
-      "inputs": {
-        "logos-nix": "logos-nix_1094",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -92242,6 +92275,39 @@
     },
     "nix-bundle-dir_180": {
       "inputs": {
+        "logos-nix": "logos-nix_1094",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_181": {
+      "inputs": {
         "logos-nix": "logos-nix_1098",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -92272,7 +92338,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_181": {
+    "nix-bundle-dir_182": {
       "inputs": {
         "logos-nix": "logos-nix_1103",
         "nixpkgs": [
@@ -92304,7 +92370,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_182": {
+    "nix-bundle-dir_183": {
       "inputs": {
         "logos-nix": "logos-nix_1104",
         "nixpkgs": [
@@ -92337,7 +92403,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_183": {
+    "nix-bundle-dir_184": {
       "inputs": {
         "logos-nix": "logos-nix_1107",
         "nixpkgs": [
@@ -92370,7 +92436,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_184": {
+    "nix-bundle-dir_185": {
       "inputs": {
         "logos-nix": "logos-nix_1130",
         "nixpkgs": [
@@ -92404,7 +92470,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_185": {
+    "nix-bundle-dir_186": {
       "inputs": {
         "logos-nix": "logos-nix_1131",
         "nixpkgs": [
@@ -92439,7 +92505,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_186": {
+    "nix-bundle-dir_187": {
       "inputs": {
         "logos-nix": "logos-nix_1138",
         "nixpkgs": [
@@ -92473,7 +92539,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_187": {
+    "nix-bundle-dir_188": {
       "inputs": {
         "logos-nix": "logos-nix_1142",
         "nixpkgs": [
@@ -92506,7 +92572,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_188": {
+    "nix-bundle-dir_189": {
       "inputs": {
         "logos-nix": "logos-nix_1147",
         "nixpkgs": [
@@ -92531,40 +92597,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_189": {
-      "inputs": {
-        "logos-nix": "logos-nix_1148",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -92604,6 +92636,40 @@
     },
     "nix-bundle-dir_190": {
       "inputs": {
+        "logos-nix": "logos-nix_1148",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_191": {
+      "inputs": {
         "logos-nix": "logos-nix_1151",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -92636,7 +92702,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_191": {
+    "nix-bundle-dir_192": {
       "inputs": {
         "logos-nix": "logos-nix_1158",
         "nixpkgs": [
@@ -92666,7 +92732,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_192": {
+    "nix-bundle-dir_193": {
       "inputs": {
         "logos-nix": "logos-nix_1159",
         "nixpkgs": [
@@ -92697,7 +92763,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_193": {
+    "nix-bundle-dir_194": {
       "inputs": {
         "logos-nix": "logos-nix_1166",
         "nixpkgs": [
@@ -92727,7 +92793,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_194": {
+    "nix-bundle-dir_195": {
       "inputs": {
         "logos-nix": "logos-nix_1170",
         "nixpkgs": [
@@ -92756,7 +92822,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_195": {
+    "nix-bundle-dir_196": {
       "inputs": {
         "logos-nix": "logos-nix_1175",
         "nixpkgs": [
@@ -92785,7 +92851,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_196": {
+    "nix-bundle-dir_197": {
       "inputs": {
         "logos-nix": "logos-nix_1176",
         "nixpkgs": [
@@ -92815,7 +92881,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_197": {
+    "nix-bundle-dir_198": {
       "inputs": {
         "logos-nix": "logos-nix_1179",
         "nixpkgs": [
@@ -92845,7 +92911,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_198": {
+    "nix-bundle-dir_199": {
       "inputs": {
         "logos-nix": "logos-nix_1216",
         "nixpkgs": [
@@ -92871,41 +92937,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_199": {
-      "inputs": {
-        "logos-nix": "logos-nix_1217",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -92980,6 +93011,41 @@
     },
     "nix-bundle-dir_200": {
       "inputs": {
+        "logos-nix": "logos-nix_1217",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_201": {
+      "inputs": {
         "logos-nix": "logos-nix_1224",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -93012,7 +93078,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_201": {
+    "nix-bundle-dir_202": {
       "inputs": {
         "logos-nix": "logos-nix_1228",
         "nixpkgs": [
@@ -93045,7 +93111,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_202": {
+    "nix-bundle-dir_203": {
       "inputs": {
         "logos-nix": "logos-nix_1233",
         "nixpkgs": [
@@ -93078,7 +93144,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_203": {
+    "nix-bundle-dir_204": {
       "inputs": {
         "logos-nix": "logos-nix_1234",
         "nixpkgs": [
@@ -93112,7 +93178,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_204": {
+    "nix-bundle-dir_205": {
       "inputs": {
         "logos-nix": "logos-nix_1237",
         "nixpkgs": [
@@ -93146,7 +93212,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_205": {
+    "nix-bundle-dir_206": {
       "inputs": {
         "logos-nix": "logos-nix_1260",
         "nixpkgs": [
@@ -93181,7 +93247,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_206": {
+    "nix-bundle-dir_207": {
       "inputs": {
         "logos-nix": "logos-nix_1261",
         "nixpkgs": [
@@ -93217,7 +93283,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_207": {
+    "nix-bundle-dir_208": {
       "inputs": {
         "logos-nix": "logos-nix_1268",
         "nixpkgs": [
@@ -93252,7 +93318,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_208": {
+    "nix-bundle-dir_209": {
       "inputs": {
         "logos-nix": "logos-nix_1272",
         "nixpkgs": [
@@ -93278,40 +93344,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_209": {
-      "inputs": {
-        "logos-nix": "logos-nix_1277",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -93352,6 +93384,40 @@
     },
     "nix-bundle-dir_210": {
       "inputs": {
+        "logos-nix": "logos-nix_1277",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_211": {
+      "inputs": {
         "logos-nix": "logos-nix_1278",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -93385,7 +93451,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_211": {
+    "nix-bundle-dir_212": {
       "inputs": {
         "logos-nix": "logos-nix_1281",
         "nixpkgs": [
@@ -93420,7 +93486,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_212": {
+    "nix-bundle-dir_213": {
       "inputs": {
         "logos-nix": "logos-nix_1288",
         "nixpkgs": [
@@ -93451,7 +93517,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_213": {
+    "nix-bundle-dir_214": {
       "inputs": {
         "logos-nix": "logos-nix_1289",
         "nixpkgs": [
@@ -93483,7 +93549,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_214": {
+    "nix-bundle-dir_215": {
       "inputs": {
         "logos-nix": "logos-nix_1296",
         "nixpkgs": [
@@ -93514,7 +93580,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_215": {
+    "nix-bundle-dir_216": {
       "inputs": {
         "logos-nix": "logos-nix_1300",
         "nixpkgs": [
@@ -93544,7 +93610,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_216": {
+    "nix-bundle-dir_217": {
       "inputs": {
         "logos-nix": "logos-nix_1305",
         "nixpkgs": [
@@ -93574,7 +93640,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_217": {
+    "nix-bundle-dir_218": {
       "inputs": {
         "logos-nix": "logos-nix_1306",
         "nixpkgs": [
@@ -93605,7 +93671,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_218": {
+    "nix-bundle-dir_219": {
       "inputs": {
         "logos-nix": "logos-nix_1309",
         "nixpkgs": [
@@ -93628,33 +93694,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_219": {
-      "inputs": {
-        "logos-nix": "logos-nix_1319",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -93699,6 +93738,33 @@
     },
     "nix-bundle-dir_220": {
       "inputs": {
+        "logos-nix": "logos-nix_1319",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_221": {
+      "inputs": {
         "logos-nix": "logos-nix_1320",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -93725,7 +93791,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_221": {
+    "nix-bundle-dir_222": {
       "inputs": {
         "logos-nix": "logos-nix_1329",
         "nixpkgs": [
@@ -93752,7 +93818,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_222": {
+    "nix-bundle-dir_223": {
       "inputs": {
         "logos-nix": "logos-nix_1333",
         "nixpkgs": [
@@ -93778,7 +93844,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_223": {
+    "nix-bundle-dir_224": {
       "inputs": {
         "logos-nix": "logos-nix_1338",
         "nixpkgs": [
@@ -93804,7 +93870,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_224": {
+    "nix-bundle-dir_225": {
       "inputs": {
         "logos-nix": "logos-nix_1339",
         "nixpkgs": [
@@ -93831,7 +93897,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_225": {
+    "nix-bundle-dir_226": {
       "inputs": {
         "logos-nix": "logos-nix_1342",
         "nixpkgs": [
@@ -93858,7 +93924,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_226": {
+    "nix-bundle-dir_227": {
       "inputs": {
         "logos-nix": "logos-nix_1382",
         "nixpkgs": [
@@ -93892,7 +93958,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_227": {
+    "nix-bundle-dir_228": {
       "inputs": {
         "logos-nix": "logos-nix_1383",
         "nixpkgs": [
@@ -93927,7 +93993,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_228": {
+    "nix-bundle-dir_229": {
       "inputs": {
         "logos-nix": "logos-nix_1390",
         "nixpkgs": [
@@ -93941,39 +94007,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_229": {
-      "inputs": {
-        "logos-nix": "logos-nix_1394",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
@@ -94031,6 +94064,39 @@
     },
     "nix-bundle-dir_230": {
       "inputs": {
+        "logos-nix": "logos-nix_1394",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_231": {
+      "inputs": {
         "logos-nix": "logos-nix_1399",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -94062,7 +94128,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_231": {
+    "nix-bundle-dir_232": {
       "inputs": {
         "logos-nix": "logos-nix_1400",
         "nixpkgs": [
@@ -94096,7 +94162,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_232": {
+    "nix-bundle-dir_233": {
       "inputs": {
         "logos-nix": "logos-nix_1403",
         "nixpkgs": [
@@ -94130,7 +94196,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_233": {
+    "nix-bundle-dir_234": {
       "inputs": {
         "logos-nix": "logos-nix_1426",
         "nixpkgs": [
@@ -94165,7 +94231,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_234": {
+    "nix-bundle-dir_235": {
       "inputs": {
         "logos-nix": "logos-nix_1427",
         "nixpkgs": [
@@ -94201,7 +94267,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_235": {
+    "nix-bundle-dir_236": {
       "inputs": {
         "logos-nix": "logos-nix_1434",
         "nixpkgs": [
@@ -94236,7 +94302,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_236": {
+    "nix-bundle-dir_237": {
       "inputs": {
         "logos-nix": "logos-nix_1438",
         "nixpkgs": [
@@ -94270,7 +94336,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_237": {
+    "nix-bundle-dir_238": {
       "inputs": {
         "logos-nix": "logos-nix_1443",
         "nixpkgs": [
@@ -94304,7 +94370,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_238": {
+    "nix-bundle-dir_239": {
       "inputs": {
         "logos-nix": "logos-nix_1444",
         "nixpkgs": [
@@ -94320,41 +94386,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_239": {
-      "inputs": {
-        "logos-nix": "logos-nix_1447",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -94410,6 +94441,41 @@
     },
     "nix-bundle-dir_240": {
       "inputs": {
+        "logos-nix": "logos-nix_1447",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_241": {
+      "inputs": {
         "logos-nix": "logos-nix_1454",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -94439,7 +94505,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_241": {
+    "nix-bundle-dir_242": {
       "inputs": {
         "logos-nix": "logos-nix_1455",
         "nixpkgs": [
@@ -94471,7 +94537,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_242": {
+    "nix-bundle-dir_243": {
       "inputs": {
         "logos-nix": "logos-nix_1462",
         "nixpkgs": [
@@ -94502,7 +94568,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_243": {
+    "nix-bundle-dir_244": {
       "inputs": {
         "logos-nix": "logos-nix_1466",
         "nixpkgs": [
@@ -94532,7 +94598,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_244": {
+    "nix-bundle-dir_245": {
       "inputs": {
         "logos-nix": "logos-nix_1471",
         "nixpkgs": [
@@ -94562,7 +94628,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_245": {
+    "nix-bundle-dir_246": {
       "inputs": {
         "logos-nix": "logos-nix_1472",
         "nixpkgs": [
@@ -94593,7 +94659,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_246": {
+    "nix-bundle-dir_247": {
       "inputs": {
         "logos-nix": "logos-nix_1475",
         "nixpkgs": [
@@ -94624,7 +94690,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_247": {
+    "nix-bundle-dir_248": {
       "inputs": {
         "logos-nix": "logos-nix_1512",
         "nixpkgs": [
@@ -94659,7 +94725,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_248": {
+    "nix-bundle-dir_249": {
       "inputs": {
         "logos-nix": "logos-nix_1513",
         "nixpkgs": [
@@ -94676,41 +94742,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_249": {
-      "inputs": {
-        "logos-nix": "logos-nix_1520",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -94765,6 +94796,41 @@
     },
     "nix-bundle-dir_250": {
       "inputs": {
+        "logos-nix": "logos-nix_1520",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_251": {
+      "inputs": {
         "logos-nix": "logos-nix_1524",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -94797,7 +94863,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_251": {
+    "nix-bundle-dir_252": {
       "inputs": {
         "logos-nix": "logos-nix_1529",
         "nixpkgs": [
@@ -94831,7 +94897,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_252": {
+    "nix-bundle-dir_253": {
       "inputs": {
         "logos-nix": "logos-nix_1530",
         "nixpkgs": [
@@ -94866,7 +94932,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_253": {
+    "nix-bundle-dir_254": {
       "inputs": {
         "logos-nix": "logos-nix_1533",
         "nixpkgs": [
@@ -94901,7 +94967,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_254": {
+    "nix-bundle-dir_255": {
       "inputs": {
         "logos-nix": "logos-nix_1556",
         "nixpkgs": [
@@ -94937,7 +95003,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_255": {
+    "nix-bundle-dir_256": {
       "inputs": {
         "logos-nix": "logos-nix_1557",
         "nixpkgs": [
@@ -94974,7 +95040,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_256": {
+    "nix-bundle-dir_257": {
       "inputs": {
         "logos-nix": "logos-nix_1564",
         "nixpkgs": [
@@ -95010,7 +95076,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_257": {
+    "nix-bundle-dir_258": {
       "inputs": {
         "logos-nix": "logos-nix_1568",
         "nixpkgs": [
@@ -95045,7 +95111,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_258": {
+    "nix-bundle-dir_259": {
       "inputs": {
         "logos-nix": "logos-nix_1573",
         "nixpkgs": [
@@ -95072,42 +95138,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_259": {
-      "inputs": {
-        "logos-nix": "logos-nix_1574",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -95151,6 +95181,42 @@
     },
     "nix-bundle-dir_260": {
       "inputs": {
+        "logos-nix": "logos-nix_1574",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_261": {
+      "inputs": {
         "logos-nix": "logos-nix_1577",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -95185,7 +95251,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_261": {
+    "nix-bundle-dir_262": {
       "inputs": {
         "logos-nix": "logos-nix_1584",
         "nixpkgs": [
@@ -95217,7 +95283,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_262": {
+    "nix-bundle-dir_263": {
       "inputs": {
         "logos-nix": "logos-nix_1585",
         "nixpkgs": [
@@ -95250,7 +95316,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_263": {
+    "nix-bundle-dir_264": {
       "inputs": {
         "logos-nix": "logos-nix_1592",
         "nixpkgs": [
@@ -95282,7 +95348,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_264": {
+    "nix-bundle-dir_265": {
       "inputs": {
         "logos-nix": "logos-nix_1596",
         "nixpkgs": [
@@ -95313,7 +95379,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_265": {
+    "nix-bundle-dir_266": {
       "inputs": {
         "logos-nix": "logos-nix_1601",
         "nixpkgs": [
@@ -95344,7 +95410,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_266": {
+    "nix-bundle-dir_267": {
       "inputs": {
         "logos-nix": "logos-nix_1602",
         "nixpkgs": [
@@ -95376,7 +95442,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_267": {
+    "nix-bundle-dir_268": {
       "inputs": {
         "logos-nix": "logos-nix_1605",
         "nixpkgs": [
@@ -95408,7 +95474,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_268": {
+    "nix-bundle-dir_269": {
       "inputs": {
         "logos-nix": "logos-nix_1615",
         "nixpkgs": [
@@ -95428,35 +95494,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_269": {
-      "inputs": {
-        "logos-nix": "logos-nix_1616",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -95501,6 +95538,35 @@
     },
     "nix-bundle-dir_270": {
       "inputs": {
+        "logos-nix": "logos-nix_1616",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_271": {
+      "inputs": {
         "logos-nix": "logos-nix_1625",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -95527,7 +95593,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_271": {
+    "nix-bundle-dir_272": {
       "inputs": {
         "logos-nix": "logos-nix_1629",
         "nixpkgs": [
@@ -95554,7 +95620,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_272": {
+    "nix-bundle-dir_273": {
       "inputs": {
         "logos-nix": "logos-nix_1634",
         "nixpkgs": [
@@ -95581,7 +95647,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_273": {
+    "nix-bundle-dir_274": {
       "inputs": {
         "logos-nix": "logos-nix_1635",
         "nixpkgs": [
@@ -95609,7 +95675,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_274": {
+    "nix-bundle-dir_275": {
       "inputs": {
         "logos-nix": "logos-nix_1638",
         "nixpkgs": [
@@ -95637,7 +95703,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_275": {
+    "nix-bundle-dir_276": {
       "inputs": {
         "logos-nix": "logos-nix_1642",
         "nixpkgs": [
@@ -95662,7 +95728,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_276": {
+    "nix-bundle-dir_277": {
       "inputs": {
         "logos-nix": "logos-nix_1643",
         "nixpkgs": [
@@ -95688,7 +95754,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_277": {
+    "nix-bundle-dir_278": {
       "inputs": {
         "logos-nix": "logos-nix_1682",
         "nixpkgs": [
@@ -95722,7 +95788,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_278": {
+    "nix-bundle-dir_279": {
       "inputs": {
         "logos-nix": "logos-nix_1683",
         "nixpkgs": [
@@ -95738,40 +95804,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_279": {
-      "inputs": {
-        "logos-nix": "logos-nix_1690",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -95827,6 +95859,40 @@
     },
     "nix-bundle-dir_280": {
       "inputs": {
+        "logos-nix": "logos-nix_1690",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_281": {
+      "inputs": {
         "logos-nix": "logos-nix_1694",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -95858,7 +95924,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_281": {
+    "nix-bundle-dir_282": {
       "inputs": {
         "logos-nix": "logos-nix_1699",
         "nixpkgs": [
@@ -95891,7 +95957,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_282": {
+    "nix-bundle-dir_283": {
       "inputs": {
         "logos-nix": "logos-nix_1700",
         "nixpkgs": [
@@ -95925,7 +95991,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_283": {
+    "nix-bundle-dir_284": {
       "inputs": {
         "logos-nix": "logos-nix_1703",
         "nixpkgs": [
@@ -95959,7 +96025,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_284": {
+    "nix-bundle-dir_285": {
       "inputs": {
         "logos-nix": "logos-nix_1726",
         "nixpkgs": [
@@ -95994,7 +96060,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_285": {
+    "nix-bundle-dir_286": {
       "inputs": {
         "logos-nix": "logos-nix_1727",
         "nixpkgs": [
@@ -96030,7 +96096,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_286": {
+    "nix-bundle-dir_287": {
       "inputs": {
         "logos-nix": "logos-nix_1734",
         "nixpkgs": [
@@ -96065,7 +96131,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_287": {
+    "nix-bundle-dir_288": {
       "inputs": {
         "logos-nix": "logos-nix_1738",
         "nixpkgs": [
@@ -96099,7 +96165,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_288": {
+    "nix-bundle-dir_289": {
       "inputs": {
         "logos-nix": "logos-nix_1743",
         "nixpkgs": [
@@ -96125,41 +96191,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_289": {
-      "inputs": {
-        "logos-nix": "logos-nix_1744",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -96205,6 +96236,41 @@
     },
     "nix-bundle-dir_290": {
       "inputs": {
+        "logos-nix": "logos-nix_1744",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_291": {
+      "inputs": {
         "logos-nix": "logos-nix_1747",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -96238,7 +96304,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_291": {
+    "nix-bundle-dir_292": {
       "inputs": {
         "logos-nix": "logos-nix_1754",
         "nixpkgs": [
@@ -96269,7 +96335,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_292": {
+    "nix-bundle-dir_293": {
       "inputs": {
         "logos-nix": "logos-nix_1755",
         "nixpkgs": [
@@ -96301,7 +96367,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_293": {
+    "nix-bundle-dir_294": {
       "inputs": {
         "logos-nix": "logos-nix_1762",
         "nixpkgs": [
@@ -96332,7 +96398,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_294": {
+    "nix-bundle-dir_295": {
       "inputs": {
         "logos-nix": "logos-nix_1766",
         "nixpkgs": [
@@ -96362,7 +96428,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_295": {
+    "nix-bundle-dir_296": {
       "inputs": {
         "logos-nix": "logos-nix_1771",
         "nixpkgs": [
@@ -96392,7 +96458,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_296": {
+    "nix-bundle-dir_297": {
       "inputs": {
         "logos-nix": "logos-nix_1772",
         "nixpkgs": [
@@ -96423,7 +96489,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_297": {
+    "nix-bundle-dir_298": {
       "inputs": {
         "logos-nix": "logos-nix_1775",
         "nixpkgs": [
@@ -96454,7 +96520,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_298": {
+    "nix-bundle-dir_299": {
       "inputs": {
         "logos-nix": "logos-nix_1812",
         "nixpkgs": [
@@ -96481,42 +96547,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_299": {
-      "inputs": {
-        "logos-nix": "logos-nix_1813",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -96596,6 +96626,42 @@
     },
     "nix-bundle-dir_300": {
       "inputs": {
+        "logos-nix": "logos-nix_1813",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_301": {
+      "inputs": {
         "logos-nix": "logos-nix_1820",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -96629,7 +96695,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_301": {
+    "nix-bundle-dir_302": {
       "inputs": {
         "logos-nix": "logos-nix_1824",
         "nixpkgs": [
@@ -96663,7 +96729,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_302": {
+    "nix-bundle-dir_303": {
       "inputs": {
         "logos-nix": "logos-nix_1829",
         "nixpkgs": [
@@ -96697,7 +96763,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_303": {
+    "nix-bundle-dir_304": {
       "inputs": {
         "logos-nix": "logos-nix_1830",
         "nixpkgs": [
@@ -96732,7 +96798,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_304": {
+    "nix-bundle-dir_305": {
       "inputs": {
         "logos-nix": "logos-nix_1833",
         "nixpkgs": [
@@ -96767,7 +96833,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_305": {
+    "nix-bundle-dir_306": {
       "inputs": {
         "logos-nix": "logos-nix_1856",
         "nixpkgs": [
@@ -96803,7 +96869,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_306": {
+    "nix-bundle-dir_307": {
       "inputs": {
         "logos-nix": "logos-nix_1857",
         "nixpkgs": [
@@ -96840,7 +96906,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_307": {
+    "nix-bundle-dir_308": {
       "inputs": {
         "logos-nix": "logos-nix_1864",
         "nixpkgs": [
@@ -96876,7 +96942,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_308": {
+    "nix-bundle-dir_309": {
       "inputs": {
         "logos-nix": "logos-nix_1868",
         "nixpkgs": [
@@ -96903,41 +96969,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_309": {
-      "inputs": {
-        "logos-nix": "logos-nix_1873",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -96983,6 +97014,41 @@
     },
     "nix-bundle-dir_310": {
       "inputs": {
+        "logos-nix": "logos-nix_1873",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_311": {
+      "inputs": {
         "logos-nix": "logos-nix_1874",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -97017,7 +97083,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_311": {
+    "nix-bundle-dir_312": {
       "inputs": {
         "logos-nix": "logos-nix_1877",
         "nixpkgs": [
@@ -97053,7 +97119,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_312": {
+    "nix-bundle-dir_313": {
       "inputs": {
         "logos-nix": "logos-nix_1884",
         "nixpkgs": [
@@ -97085,7 +97151,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_313": {
+    "nix-bundle-dir_314": {
       "inputs": {
         "logos-nix": "logos-nix_1885",
         "nixpkgs": [
@@ -97118,7 +97184,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_314": {
+    "nix-bundle-dir_315": {
       "inputs": {
         "logos-nix": "logos-nix_1892",
         "nixpkgs": [
@@ -97150,7 +97216,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_315": {
+    "nix-bundle-dir_316": {
       "inputs": {
         "logos-nix": "logos-nix_1896",
         "nixpkgs": [
@@ -97181,7 +97247,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_316": {
+    "nix-bundle-dir_317": {
       "inputs": {
         "logos-nix": "logos-nix_1901",
         "nixpkgs": [
@@ -97212,7 +97278,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_317": {
+    "nix-bundle-dir_318": {
       "inputs": {
         "logos-nix": "logos-nix_1902",
         "nixpkgs": [
@@ -97244,7 +97310,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_318": {
+    "nix-bundle-dir_319": {
       "inputs": {
         "logos-nix": "logos-nix_1905",
         "nixpkgs": [
@@ -97268,34 +97334,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_319": {
-      "inputs": {
-        "logos-nix": "logos-nix_1915",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -97340,6 +97378,34 @@
     },
     "nix-bundle-dir_320": {
       "inputs": {
+        "logos-nix": "logos-nix_1915",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_321": {
+      "inputs": {
         "logos-nix": "logos-nix_1916",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -97367,7 +97433,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_321": {
+    "nix-bundle-dir_322": {
       "inputs": {
         "logos-nix": "logos-nix_1925",
         "nixpkgs": [
@@ -97395,7 +97461,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_322": {
+    "nix-bundle-dir_323": {
       "inputs": {
         "logos-nix": "logos-nix_1929",
         "nixpkgs": [
@@ -97422,7 +97488,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_323": {
+    "nix-bundle-dir_324": {
       "inputs": {
         "logos-nix": "logos-nix_1934",
         "nixpkgs": [
@@ -97449,7 +97515,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_324": {
+    "nix-bundle-dir_325": {
       "inputs": {
         "logos-nix": "logos-nix_1935",
         "nixpkgs": [
@@ -97477,7 +97543,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_325": {
+    "nix-bundle-dir_326": {
       "inputs": {
         "logos-nix": "logos-nix_1938",
         "nixpkgs": [
@@ -97505,7 +97571,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_326": {
+    "nix-bundle-dir_327": {
       "inputs": {
         "logos-nix": "logos-nix_1942",
         "nixpkgs": [
@@ -97530,7 +97596,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_327": {
+    "nix-bundle-dir_328": {
       "inputs": {
         "logos-nix": "logos-nix_1943",
         "nixpkgs": [
@@ -97556,34 +97622,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_328": {
+    "nix-bundle-dir_329": {
       "inputs": {
         "logos-nix": "logos-nix_1947",
         "nixpkgs": [
           "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_329": {
-      "inputs": {
-        "logos-nix": "logos-nix_1948",
-        "nixpkgs": [
-          "nix-bundle-dir",
-          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -97637,6 +97680,29 @@
     },
     "nix-bundle-dir_330": {
       "inputs": {
+        "logos-nix": "logos-nix_1948",
+        "nixpkgs": [
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782913618,
+        "narHash": "sha256-WzkZzJ3VSotFMOjbEDfjHZP0KoBW6GVi1Xc9i1E6mMY=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4f72d7a64dd83979d771c17161f23ebc9dbedb40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_331": {
+      "inputs": {
         "logos-nix": "logos-nix_1953",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -97659,7 +97725,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_331": {
+    "nix-bundle-dir_332": {
       "inputs": {
         "logos-nix": "logos-nix_1954",
         "nixpkgs": [
@@ -97684,7 +97750,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_332": {
+    "nix-bundle-dir_333": {
       "inputs": {
         "logos-nix": "logos-nix_1957",
         "nixpkgs": [
@@ -98249,6 +98315,31 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
+        "logos-nix": [
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782913618,
+        "narHash": "sha256-WzkZzJ3VSotFMOjbEDfjHZP0KoBW6GVi1Xc9i1E6mMY=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4f72d7a64dd83979d771c17161f23ebc9dbedb40",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_51": {
+      "inputs": {
         "logos-nix": "logos-nix_332",
         "nixpkgs": [
           "logos-liblogos",
@@ -98278,7 +98369,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_51": {
+    "nix-bundle-dir_52": {
       "inputs": {
         "logos-nix": "logos-nix_333",
         "nixpkgs": [
@@ -98310,7 +98401,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_52": {
+    "nix-bundle-dir_53": {
       "inputs": {
         "logos-nix": "logos-nix_340",
         "nixpkgs": [
@@ -98341,7 +98432,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_53": {
+    "nix-bundle-dir_54": {
       "inputs": {
         "logos-nix": "logos-nix_344",
         "nixpkgs": [
@@ -98371,7 +98462,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_54": {
+    "nix-bundle-dir_55": {
       "inputs": {
         "logos-nix": "logos-nix_349",
         "nixpkgs": [
@@ -98401,7 +98492,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_55": {
+    "nix-bundle-dir_56": {
       "inputs": {
         "logos-nix": "logos-nix_350",
         "nixpkgs": [
@@ -98432,7 +98523,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_56": {
+    "nix-bundle-dir_57": {
       "inputs": {
         "logos-nix": "logos-nix_353",
         "nixpkgs": [
@@ -98463,7 +98554,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_57": {
+    "nix-bundle-dir_58": {
       "inputs": {
         "logos-nix": "logos-nix_376",
         "nixpkgs": [
@@ -98495,7 +98586,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_58": {
+    "nix-bundle-dir_59": {
       "inputs": {
         "logos-nix": "logos-nix_377",
         "nixpkgs": [
@@ -98509,38 +98600,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_59": {
-      "inputs": {
-        "logos-nix": "logos-nix_384",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -98595,6 +98654,38 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
+        "logos-nix": "logos-nix_384",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_61": {
+      "inputs": {
         "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logos-liblogos",
@@ -98624,7 +98715,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_61": {
+    "nix-bundle-dir_62": {
       "inputs": {
         "logos-nix": "logos-nix_393",
         "nixpkgs": [
@@ -98655,7 +98746,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_62": {
+    "nix-bundle-dir_63": {
       "inputs": {
         "logos-nix": "logos-nix_394",
         "nixpkgs": [
@@ -98687,7 +98778,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_63": {
+    "nix-bundle-dir_64": {
       "inputs": {
         "logos-nix": "logos-nix_397",
         "nixpkgs": [
@@ -98719,7 +98810,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_64": {
+    "nix-bundle-dir_65": {
       "inputs": {
         "logos-nix": "logos-nix_404",
         "nixpkgs": [
@@ -98747,7 +98838,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_65": {
+    "nix-bundle-dir_66": {
       "inputs": {
         "logos-nix": "logos-nix_405",
         "nixpkgs": [
@@ -98776,7 +98867,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_66": {
+    "nix-bundle-dir_67": {
       "inputs": {
         "logos-nix": "logos-nix_412",
         "nixpkgs": [
@@ -98804,7 +98895,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_67": {
+    "nix-bundle-dir_68": {
       "inputs": {
         "logos-nix": "logos-nix_416",
         "nixpkgs": [
@@ -98831,7 +98922,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_68": {
+    "nix-bundle-dir_69": {
       "inputs": {
         "logos-nix": "logos-nix_421",
         "nixpkgs": [
@@ -98850,34 +98941,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_69": {
-      "inputs": {
-        "logos-nix": "logos-nix_422",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -98921,6 +98984,34 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
+        "logos-nix": "logos-nix_422",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_71": {
+      "inputs": {
         "logos-nix": "logos-nix_425",
         "nixpkgs": [
           "logos-liblogos",
@@ -98947,7 +99038,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_71": {
+    "nix-bundle-dir_72": {
       "inputs": {
         "logos-nix": "logos-nix_435",
         "nixpkgs": [
@@ -98971,7 +99062,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_72": {
+    "nix-bundle-dir_73": {
       "inputs": {
         "logos-nix": "logos-nix_436",
         "nixpkgs": [
@@ -98996,7 +99087,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_73": {
+    "nix-bundle-dir_74": {
       "inputs": {
         "logos-nix": "logos-nix_481",
         "nixpkgs": [
@@ -99029,7 +99120,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_74": {
+    "nix-bundle-dir_75": {
       "inputs": {
         "logos-nix": "logos-nix_482",
         "nixpkgs": [
@@ -99063,7 +99154,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_75": {
+    "nix-bundle-dir_76": {
       "inputs": {
         "logos-nix": "logos-nix_489",
         "nixpkgs": [
@@ -99096,7 +99187,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_76": {
+    "nix-bundle-dir_77": {
       "inputs": {
         "logos-nix": "logos-nix_493",
         "nixpkgs": [
@@ -99128,7 +99219,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_77": {
+    "nix-bundle-dir_78": {
       "inputs": {
         "logos-nix": "logos-nix_498",
         "nixpkgs": [
@@ -99160,7 +99251,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_78": {
+    "nix-bundle-dir_79": {
       "inputs": {
         "logos-nix": "logos-nix_499",
         "nixpkgs": [
@@ -99174,39 +99265,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_79": {
-      "inputs": {
-        "logos-nix": "logos-nix_502",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -99262,6 +99320,39 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
+        "logos-nix": "logos-nix_502",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_81": {
+      "inputs": {
         "logos-nix": "logos-nix_525",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -99294,7 +99385,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_81": {
+    "nix-bundle-dir_82": {
       "inputs": {
         "logos-nix": "logos-nix_526",
         "nixpkgs": [
@@ -99329,7 +99420,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_82": {
+    "nix-bundle-dir_83": {
       "inputs": {
         "logos-nix": "logos-nix_533",
         "nixpkgs": [
@@ -99363,7 +99454,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_83": {
+    "nix-bundle-dir_84": {
       "inputs": {
         "logos-nix": "logos-nix_537",
         "nixpkgs": [
@@ -99396,7 +99487,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_84": {
+    "nix-bundle-dir_85": {
       "inputs": {
         "logos-nix": "logos-nix_542",
         "nixpkgs": [
@@ -99429,7 +99520,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_85": {
+    "nix-bundle-dir_86": {
       "inputs": {
         "logos-nix": "logos-nix_543",
         "nixpkgs": [
@@ -99463,7 +99554,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_86": {
+    "nix-bundle-dir_87": {
       "inputs": {
         "logos-nix": "logos-nix_546",
         "nixpkgs": [
@@ -99497,7 +99588,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_87": {
+    "nix-bundle-dir_88": {
       "inputs": {
         "logos-nix": "logos-nix_553",
         "nixpkgs": [
@@ -99527,7 +99618,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_88": {
+    "nix-bundle-dir_89": {
       "inputs": {
         "logos-nix": "logos-nix_554",
         "nixpkgs": [
@@ -99539,36 +99630,6 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_89": {
-      "inputs": {
-        "logos-nix": "logos-nix_561",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -99625,6 +99686,36 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
+        "logos-nix": "logos-nix_561",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455641,
+        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_91": {
+      "inputs": {
         "logos-nix": "logos-nix_565",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -99652,7 +99743,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_91": {
+    "nix-bundle-dir_92": {
       "inputs": {
         "logos-nix": "logos-nix_570",
         "nixpkgs": [
@@ -99681,7 +99772,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_92": {
+    "nix-bundle-dir_93": {
       "inputs": {
         "logos-nix": "logos-nix_571",
         "nixpkgs": [
@@ -99711,7 +99802,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_93": {
+    "nix-bundle-dir_94": {
       "inputs": {
         "logos-nix": "logos-nix_574",
         "nixpkgs": [
@@ -99741,7 +99832,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_94": {
+    "nix-bundle-dir_95": {
       "inputs": {
         "logos-nix": "logos-nix_611",
         "nixpkgs": [
@@ -99775,7 +99866,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_95": {
+    "nix-bundle-dir_96": {
       "inputs": {
         "logos-nix": "logos-nix_612",
         "nixpkgs": [
@@ -99810,7 +99901,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_96": {
+    "nix-bundle-dir_97": {
       "inputs": {
         "logos-nix": "logos-nix_619",
         "nixpkgs": [
@@ -99844,7 +99935,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_97": {
+    "nix-bundle-dir_98": {
       "inputs": {
         "logos-nix": "logos-nix_623",
         "nixpkgs": [
@@ -99877,7 +99968,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_98": {
+    "nix-bundle-dir_99": {
       "inputs": {
         "logos-nix": "logos-nix_628",
         "nixpkgs": [
@@ -99902,40 +99993,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_99": {
-      "inputs": {
-        "logos-nix": "logos-nix_629",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455641,
-        "narHash": "sha256-HrVJguPxhIoZMCH+x8Wooa0tE6slUhgNOU6P89t2uQc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "3d155cab09051703a0b02ff2de166a53c30cbca8",
         "type": "github"
       },
       "original": {
@@ -100015,7 +100072,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1460",
         "logos-package": "logos-package_173",
-        "nix-bundle-dir": "nix-bundle-dir_242",
+        "nix-bundle-dir": "nix-bundle-dir_243",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100047,7 +100104,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1464",
         "logos-package": "logos-package_174",
-        "nix-bundle-dir": "nix-bundle-dir_243",
+        "nix-bundle-dir": "nix-bundle-dir_244",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100078,7 +100135,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1473",
         "logos-package": "logos-package_176",
-        "nix-bundle-dir": "nix-bundle-dir_246",
+        "nix-bundle-dir": "nix-bundle-dir_247",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100110,7 +100167,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1518",
         "logos-package": "logos-package_178",
-        "nix-bundle-dir": "nix-bundle-dir_249",
+        "nix-bundle-dir": "nix-bundle-dir_250",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100145,7 +100202,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1522",
         "logos-package": "logos-package_179",
-        "nix-bundle-dir": "nix-bundle-dir_250",
+        "nix-bundle-dir": "nix-bundle-dir_251",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100180,7 +100237,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1531",
         "logos-package": "logos-package_181",
-        "nix-bundle-dir": "nix-bundle-dir_253",
+        "nix-bundle-dir": "nix-bundle-dir_254",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100216,7 +100273,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1562",
         "logos-package": "logos-package_183",
-        "nix-bundle-dir": "nix-bundle-dir_256",
+        "nix-bundle-dir": "nix-bundle-dir_257",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100252,7 +100309,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1566",
         "logos-package": "logos-package_184",
-        "nix-bundle-dir": "nix-bundle-dir_257",
+        "nix-bundle-dir": "nix-bundle-dir_258",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100288,7 +100345,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1575",
         "logos-package": "logos-package_186",
-        "nix-bundle-dir": "nix-bundle-dir_260",
+        "nix-bundle-dir": "nix-bundle-dir_261",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100325,7 +100382,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1590",
         "logos-package": "logos-package_188",
-        "nix-bundle-dir": "nix-bundle-dir_263",
+        "nix-bundle-dir": "nix-bundle-dir_264",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100392,7 +100449,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1594",
         "logos-package": "logos-package_189",
-        "nix-bundle-dir": "nix-bundle-dir_264",
+        "nix-bundle-dir": "nix-bundle-dir_265",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100424,7 +100481,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1603",
         "logos-package": "logos-package_191",
-        "nix-bundle-dir": "nix-bundle-dir_267",
+        "nix-bundle-dir": "nix-bundle-dir_268",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100457,7 +100514,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1623",
         "logos-package": "logos-package_193",
-        "nix-bundle-dir": "nix-bundle-dir_270",
+        "nix-bundle-dir": "nix-bundle-dir_271",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100486,7 +100543,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1627",
         "logos-package": "logos-package_194",
-        "nix-bundle-dir": "nix-bundle-dir_271",
+        "nix-bundle-dir": "nix-bundle-dir_272",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100514,7 +100571,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1636",
         "logos-package": "logos-package_196",
-        "nix-bundle-dir": "nix-bundle-dir_274",
+        "nix-bundle-dir": "nix-bundle-dir_275",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -100543,7 +100600,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1688",
         "logos-package": "logos-package_199",
-        "nix-bundle-dir": "nix-bundle-dir_279",
+        "nix-bundle-dir": "nix-bundle-dir_280",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100577,7 +100634,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1692",
         "logos-package": "logos-package_200",
-        "nix-bundle-dir": "nix-bundle-dir_280",
+        "nix-bundle-dir": "nix-bundle-dir_281",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100611,7 +100668,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1701",
         "logos-package": "logos-package_202",
-        "nix-bundle-dir": "nix-bundle-dir_283",
+        "nix-bundle-dir": "nix-bundle-dir_284",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100646,7 +100703,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1732",
         "logos-package": "logos-package_204",
-        "nix-bundle-dir": "nix-bundle-dir_286",
+        "nix-bundle-dir": "nix-bundle-dir_287",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100681,7 +100738,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1736",
         "logos-package": "logos-package_205",
-        "nix-bundle-dir": "nix-bundle-dir_287",
+        "nix-bundle-dir": "nix-bundle-dir_288",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100751,7 +100808,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1745",
         "logos-package": "logos-package_207",
-        "nix-bundle-dir": "nix-bundle-dir_290",
+        "nix-bundle-dir": "nix-bundle-dir_291",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100787,7 +100844,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1760",
         "logos-package": "logos-package_209",
-        "nix-bundle-dir": "nix-bundle-dir_293",
+        "nix-bundle-dir": "nix-bundle-dir_294",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100819,7 +100876,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1764",
         "logos-package": "logos-package_210",
-        "nix-bundle-dir": "nix-bundle-dir_294",
+        "nix-bundle-dir": "nix-bundle-dir_295",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100850,7 +100907,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1773",
         "logos-package": "logos-package_212",
-        "nix-bundle-dir": "nix-bundle-dir_297",
+        "nix-bundle-dir": "nix-bundle-dir_298",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100882,7 +100939,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1818",
         "logos-package": "logos-package_214",
-        "nix-bundle-dir": "nix-bundle-dir_300",
+        "nix-bundle-dir": "nix-bundle-dir_301",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100917,7 +100974,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1822",
         "logos-package": "logos-package_215",
-        "nix-bundle-dir": "nix-bundle-dir_301",
+        "nix-bundle-dir": "nix-bundle-dir_302",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100952,7 +101009,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1831",
         "logos-package": "logos-package_217",
-        "nix-bundle-dir": "nix-bundle-dir_304",
+        "nix-bundle-dir": "nix-bundle-dir_305",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -100988,7 +101045,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1862",
         "logos-package": "logos-package_219",
-        "nix-bundle-dir": "nix-bundle-dir_307",
+        "nix-bundle-dir": "nix-bundle-dir_308",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101024,7 +101081,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1866",
         "logos-package": "logos-package_220",
-        "nix-bundle-dir": "nix-bundle-dir_308",
+        "nix-bundle-dir": "nix-bundle-dir_309",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101060,7 +101117,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1875",
         "logos-package": "logos-package_222",
-        "nix-bundle-dir": "nix-bundle-dir_311",
+        "nix-bundle-dir": "nix-bundle-dir_312",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101132,7 +101189,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1890",
         "logos-package": "logos-package_224",
-        "nix-bundle-dir": "nix-bundle-dir_314",
+        "nix-bundle-dir": "nix-bundle-dir_315",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101165,7 +101222,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1894",
         "logos-package": "logos-package_225",
-        "nix-bundle-dir": "nix-bundle-dir_315",
+        "nix-bundle-dir": "nix-bundle-dir_316",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101197,7 +101254,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1903",
         "logos-package": "logos-package_227",
-        "nix-bundle-dir": "nix-bundle-dir_318",
+        "nix-bundle-dir": "nix-bundle-dir_319",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101230,7 +101287,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1923",
         "logos-package": "logos-package_229",
-        "nix-bundle-dir": "nix-bundle-dir_321",
+        "nix-bundle-dir": "nix-bundle-dir_322",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101259,7 +101316,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1927",
         "logos-package": "logos-package_230",
-        "nix-bundle-dir": "nix-bundle-dir_322",
+        "nix-bundle-dir": "nix-bundle-dir_323",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101287,7 +101344,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1936",
         "logos-package": "logos-package_232",
-        "nix-bundle-dir": "nix-bundle-dir_325",
+        "nix-bundle-dir": "nix-bundle-dir_326",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -101316,7 +101373,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1955",
         "logos-package": "logos-package_235",
-        "nix-bundle-dir": "nix-bundle-dir_332",
+        "nix-bundle-dir": "nix-bundle-dir_333",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -101624,7 +101681,7 @@
       "inputs": {
         "logos-nix": "logos-nix_338",
         "logos-package": "logos-package_37",
-        "nix-bundle-dir": "nix-bundle-dir_52",
+        "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101655,7 +101712,7 @@
       "inputs": {
         "logos-nix": "logos-nix_342",
         "logos-package": "logos-package_38",
-        "nix-bundle-dir": "nix-bundle-dir_53",
+        "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101686,7 +101743,7 @@
       "inputs": {
         "logos-nix": "logos-nix_351",
         "logos-package": "logos-package_40",
-        "nix-bundle-dir": "nix-bundle-dir_56",
+        "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101718,7 +101775,7 @@
       "inputs": {
         "logos-nix": "logos-nix_382",
         "logos-package": "logos-package_42",
-        "nix-bundle-dir": "nix-bundle-dir_59",
+        "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101750,7 +101807,7 @@
       "inputs": {
         "logos-nix": "logos-nix_386",
         "logos-package": "logos-package_43",
-        "nix-bundle-dir": "nix-bundle-dir_60",
+        "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101782,7 +101839,7 @@
       "inputs": {
         "logos-nix": "logos-nix_395",
         "logos-package": "logos-package_45",
-        "nix-bundle-dir": "nix-bundle-dir_63",
+        "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101815,7 +101872,7 @@
       "inputs": {
         "logos-nix": "logos-nix_410",
         "logos-package": "logos-package_47",
-        "nix-bundle-dir": "nix-bundle-dir_66",
+        "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101844,7 +101901,7 @@
       "inputs": {
         "logos-nix": "logos-nix_414",
         "logos-package": "logos-package_48",
-        "nix-bundle-dir": "nix-bundle-dir_67",
+        "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101906,7 +101963,7 @@
       "inputs": {
         "logos-nix": "logos-nix_423",
         "logos-package": "logos-package_50",
-        "nix-bundle-dir": "nix-bundle-dir_70",
+        "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -101935,7 +101992,7 @@
       "inputs": {
         "logos-nix": "logos-nix_487",
         "logos-package": "logos-package_54",
-        "nix-bundle-dir": "nix-bundle-dir_75",
+        "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -101968,7 +102025,7 @@
       "inputs": {
         "logos-nix": "logos-nix_491",
         "logos-package": "logos-package_55",
-        "nix-bundle-dir": "nix-bundle-dir_76",
+        "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102001,7 +102058,7 @@
       "inputs": {
         "logos-nix": "logos-nix_500",
         "logos-package": "logos-package_57",
-        "nix-bundle-dir": "nix-bundle-dir_79",
+        "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102035,7 +102092,7 @@
       "inputs": {
         "logos-nix": "logos-nix_531",
         "logos-package": "logos-package_59",
-        "nix-bundle-dir": "nix-bundle-dir_82",
+        "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102069,7 +102126,7 @@
       "inputs": {
         "logos-nix": "logos-nix_535",
         "logos-package": "logos-package_60",
-        "nix-bundle-dir": "nix-bundle-dir_83",
+        "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102103,7 +102160,7 @@
       "inputs": {
         "logos-nix": "logos-nix_544",
         "logos-package": "logos-package_62",
-        "nix-bundle-dir": "nix-bundle-dir_86",
+        "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102138,7 +102195,7 @@
       "inputs": {
         "logos-nix": "logos-nix_559",
         "logos-package": "logos-package_64",
-        "nix-bundle-dir": "nix-bundle-dir_89",
+        "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102169,7 +102226,7 @@
       "inputs": {
         "logos-nix": "logos-nix_563",
         "logos-package": "logos-package_65",
-        "nix-bundle-dir": "nix-bundle-dir_90",
+        "nix-bundle-dir": "nix-bundle-dir_91",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102199,7 +102256,7 @@
       "inputs": {
         "logos-nix": "logos-nix_572",
         "logos-package": "logos-package_67",
-        "nix-bundle-dir": "nix-bundle-dir_93",
+        "nix-bundle-dir": "nix-bundle-dir_94",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102264,7 +102321,7 @@
       "inputs": {
         "logos-nix": "logos-nix_617",
         "logos-package": "logos-package_69",
-        "nix-bundle-dir": "nix-bundle-dir_96",
+        "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102298,7 +102355,7 @@
       "inputs": {
         "logos-nix": "logos-nix_621",
         "logos-package": "logos-package_70",
-        "nix-bundle-dir": "nix-bundle-dir_97",
+        "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102332,7 +102389,7 @@
       "inputs": {
         "logos-nix": "logos-nix_630",
         "logos-package": "logos-package_72",
-        "nix-bundle-dir": "nix-bundle-dir_100",
+        "nix-bundle-dir": "nix-bundle-dir_101",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102367,7 +102424,7 @@
       "inputs": {
         "logos-nix": "logos-nix_661",
         "logos-package": "logos-package_74",
-        "nix-bundle-dir": "nix-bundle-dir_103",
+        "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102402,7 +102459,7 @@
       "inputs": {
         "logos-nix": "logos-nix_665",
         "logos-package": "logos-package_75",
-        "nix-bundle-dir": "nix-bundle-dir_104",
+        "nix-bundle-dir": "nix-bundle-dir_105",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102437,7 +102494,7 @@
       "inputs": {
         "logos-nix": "logos-nix_674",
         "logos-package": "logos-package_77",
-        "nix-bundle-dir": "nix-bundle-dir_107",
+        "nix-bundle-dir": "nix-bundle-dir_108",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102473,7 +102530,7 @@
       "inputs": {
         "logos-nix": "logos-nix_689",
         "logos-package": "logos-package_79",
-        "nix-bundle-dir": "nix-bundle-dir_110",
+        "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102505,7 +102562,7 @@
       "inputs": {
         "logos-nix": "logos-nix_693",
         "logos-package": "logos-package_80",
-        "nix-bundle-dir": "nix-bundle-dir_111",
+        "nix-bundle-dir": "nix-bundle-dir_112",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102536,7 +102593,7 @@
       "inputs": {
         "logos-nix": "logos-nix_702",
         "logos-package": "logos-package_82",
-        "nix-bundle-dir": "nix-bundle-dir_114",
+        "nix-bundle-dir": "nix-bundle-dir_115",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102568,7 +102625,7 @@
       "inputs": {
         "logos-nix": "logos-nix_722",
         "logos-package": "logos-package_84",
-        "nix-bundle-dir": "nix-bundle-dir_117",
+        "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102630,7 +102687,7 @@
       "inputs": {
         "logos-nix": "logos-nix_726",
         "logos-package": "logos-package_85",
-        "nix-bundle-dir": "nix-bundle-dir_118",
+        "nix-bundle-dir": "nix-bundle-dir_119",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102657,7 +102714,7 @@
       "inputs": {
         "logos-nix": "logos-nix_735",
         "logos-package": "logos-package_87",
-        "nix-bundle-dir": "nix-bundle-dir_121",
+        "nix-bundle-dir": "nix-bundle-dir_122",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -102685,7 +102742,7 @@
       "inputs": {
         "logos-nix": "logos-nix_792",
         "logos-package": "logos-package_91",
-        "nix-bundle-dir": "nix-bundle-dir_128",
+        "nix-bundle-dir": "nix-bundle-dir_129",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102718,7 +102775,7 @@
       "inputs": {
         "logos-nix": "logos-nix_796",
         "logos-package": "logos-package_92",
-        "nix-bundle-dir": "nix-bundle-dir_129",
+        "nix-bundle-dir": "nix-bundle-dir_130",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102751,7 +102808,7 @@
       "inputs": {
         "logos-nix": "logos-nix_805",
         "logos-package": "logos-package_94",
-        "nix-bundle-dir": "nix-bundle-dir_132",
+        "nix-bundle-dir": "nix-bundle-dir_133",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102785,7 +102842,7 @@
       "inputs": {
         "logos-nix": "logos-nix_836",
         "logos-package": "logos-package_96",
-        "nix-bundle-dir": "nix-bundle-dir_135",
+        "nix-bundle-dir": "nix-bundle-dir_136",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102819,7 +102876,7 @@
       "inputs": {
         "logos-nix": "logos-nix_840",
         "logos-package": "logos-package_97",
-        "nix-bundle-dir": "nix-bundle-dir_136",
+        "nix-bundle-dir": "nix-bundle-dir_137",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102853,7 +102910,7 @@
       "inputs": {
         "logos-nix": "logos-nix_849",
         "logos-package": "logos-package_99",
-        "nix-bundle-dir": "nix-bundle-dir_139",
+        "nix-bundle-dir": "nix-bundle-dir_140",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102888,7 +102945,7 @@
       "inputs": {
         "logos-nix": "logos-nix_864",
         "logos-package": "logos-package_101",
-        "nix-bundle-dir": "nix-bundle-dir_142",
+        "nix-bundle-dir": "nix-bundle-dir_143",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102919,7 +102976,7 @@
       "inputs": {
         "logos-nix": "logos-nix_868",
         "logos-package": "logos-package_102",
-        "nix-bundle-dir": "nix-bundle-dir_143",
+        "nix-bundle-dir": "nix-bundle-dir_144",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -102984,7 +103041,7 @@
       "inputs": {
         "logos-nix": "logos-nix_877",
         "logos-package": "logos-package_104",
-        "nix-bundle-dir": "nix-bundle-dir_146",
+        "nix-bundle-dir": "nix-bundle-dir_147",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103015,7 +103072,7 @@
       "inputs": {
         "logos-nix": "logos-nix_922",
         "logos-package": "logos-package_106",
-        "nix-bundle-dir": "nix-bundle-dir_149",
+        "nix-bundle-dir": "nix-bundle-dir_150",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103049,7 +103106,7 @@
       "inputs": {
         "logos-nix": "logos-nix_926",
         "logos-package": "logos-package_107",
-        "nix-bundle-dir": "nix-bundle-dir_150",
+        "nix-bundle-dir": "nix-bundle-dir_151",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103083,7 +103140,7 @@
       "inputs": {
         "logos-nix": "logos-nix_935",
         "logos-package": "logos-package_109",
-        "nix-bundle-dir": "nix-bundle-dir_153",
+        "nix-bundle-dir": "nix-bundle-dir_154",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103118,7 +103175,7 @@
       "inputs": {
         "logos-nix": "logos-nix_966",
         "logos-package": "logos-package_111",
-        "nix-bundle-dir": "nix-bundle-dir_156",
+        "nix-bundle-dir": "nix-bundle-dir_157",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103153,7 +103210,7 @@
       "inputs": {
         "logos-nix": "logos-nix_970",
         "logos-package": "logos-package_112",
-        "nix-bundle-dir": "nix-bundle-dir_157",
+        "nix-bundle-dir": "nix-bundle-dir_158",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103188,7 +103245,7 @@
       "inputs": {
         "logos-nix": "logos-nix_979",
         "logos-package": "logos-package_114",
-        "nix-bundle-dir": "nix-bundle-dir_160",
+        "nix-bundle-dir": "nix-bundle-dir_161",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103224,7 +103281,7 @@
       "inputs": {
         "logos-nix": "logos-nix_994",
         "logos-package": "logos-package_116",
-        "nix-bundle-dir": "nix-bundle-dir_163",
+        "nix-bundle-dir": "nix-bundle-dir_164",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103256,7 +103313,7 @@
       "inputs": {
         "logos-nix": "logos-nix_998",
         "logos-package": "logos-package_117",
-        "nix-bundle-dir": "nix-bundle-dir_164",
+        "nix-bundle-dir": "nix-bundle-dir_165",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103287,7 +103344,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1007",
         "logos-package": "logos-package_119",
-        "nix-bundle-dir": "nix-bundle-dir_167",
+        "nix-bundle-dir": "nix-bundle-dir_168",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103350,7 +103407,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1027",
         "logos-package": "logos-package_121",
-        "nix-bundle-dir": "nix-bundle-dir_170",
+        "nix-bundle-dir": "nix-bundle-dir_171",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103378,7 +103435,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1031",
         "logos-package": "logos-package_122",
-        "nix-bundle-dir": "nix-bundle-dir_171",
+        "nix-bundle-dir": "nix-bundle-dir_172",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103405,7 +103462,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1040",
         "logos-package": "logos-package_124",
-        "nix-bundle-dir": "nix-bundle-dir_174",
+        "nix-bundle-dir": "nix-bundle-dir_175",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -103433,7 +103490,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1092",
         "logos-package": "logos-package_127",
-        "nix-bundle-dir": "nix-bundle-dir_179",
+        "nix-bundle-dir": "nix-bundle-dir_180",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103466,7 +103523,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1096",
         "logos-package": "logos-package_128",
-        "nix-bundle-dir": "nix-bundle-dir_180",
+        "nix-bundle-dir": "nix-bundle-dir_181",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103499,7 +103556,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1105",
         "logos-package": "logos-package_130",
-        "nix-bundle-dir": "nix-bundle-dir_183",
+        "nix-bundle-dir": "nix-bundle-dir_184",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103533,7 +103590,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1136",
         "logos-package": "logos-package_132",
-        "nix-bundle-dir": "nix-bundle-dir_186",
+        "nix-bundle-dir": "nix-bundle-dir_187",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103567,7 +103624,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1140",
         "logos-package": "logos-package_133",
-        "nix-bundle-dir": "nix-bundle-dir_187",
+        "nix-bundle-dir": "nix-bundle-dir_188",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103601,7 +103658,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1149",
         "logos-package": "logos-package_135",
-        "nix-bundle-dir": "nix-bundle-dir_190",
+        "nix-bundle-dir": "nix-bundle-dir_191",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103636,7 +103693,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1164",
         "logos-package": "logos-package_137",
-        "nix-bundle-dir": "nix-bundle-dir_193",
+        "nix-bundle-dir": "nix-bundle-dir_194",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103697,7 +103754,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1168",
         "logos-package": "logos-package_138",
-        "nix-bundle-dir": "nix-bundle-dir_194",
+        "nix-bundle-dir": "nix-bundle-dir_195",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103727,7 +103784,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1177",
         "logos-package": "logos-package_140",
-        "nix-bundle-dir": "nix-bundle-dir_197",
+        "nix-bundle-dir": "nix-bundle-dir_198",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103758,7 +103815,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1222",
         "logos-package": "logos-package_142",
-        "nix-bundle-dir": "nix-bundle-dir_200",
+        "nix-bundle-dir": "nix-bundle-dir_201",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103792,7 +103849,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1226",
         "logos-package": "logos-package_143",
-        "nix-bundle-dir": "nix-bundle-dir_201",
+        "nix-bundle-dir": "nix-bundle-dir_202",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103826,7 +103883,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1235",
         "logos-package": "logos-package_145",
-        "nix-bundle-dir": "nix-bundle-dir_204",
+        "nix-bundle-dir": "nix-bundle-dir_205",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103861,7 +103918,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1266",
         "logos-package": "logos-package_147",
-        "nix-bundle-dir": "nix-bundle-dir_207",
+        "nix-bundle-dir": "nix-bundle-dir_208",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103896,7 +103953,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1270",
         "logos-package": "logos-package_148",
-        "nix-bundle-dir": "nix-bundle-dir_208",
+        "nix-bundle-dir": "nix-bundle-dir_209",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103931,7 +103988,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1279",
         "logos-package": "logos-package_150",
-        "nix-bundle-dir": "nix-bundle-dir_211",
+        "nix-bundle-dir": "nix-bundle-dir_212",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103967,7 +104024,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1294",
         "logos-package": "logos-package_152",
-        "nix-bundle-dir": "nix-bundle-dir_214",
+        "nix-bundle-dir": "nix-bundle-dir_215",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -103999,7 +104056,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1298",
         "logos-package": "logos-package_153",
-        "nix-bundle-dir": "nix-bundle-dir_215",
+        "nix-bundle-dir": "nix-bundle-dir_216",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -104061,7 +104118,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1307",
         "logos-package": "logos-package_155",
-        "nix-bundle-dir": "nix-bundle-dir_218",
+        "nix-bundle-dir": "nix-bundle-dir_219",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -104093,7 +104150,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1327",
         "logos-package": "logos-package_157",
-        "nix-bundle-dir": "nix-bundle-dir_221",
+        "nix-bundle-dir": "nix-bundle-dir_222",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -104121,7 +104178,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1331",
         "logos-package": "logos-package_158",
-        "nix-bundle-dir": "nix-bundle-dir_222",
+        "nix-bundle-dir": "nix-bundle-dir_223",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -104148,7 +104205,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1340",
         "logos-package": "logos-package_160",
-        "nix-bundle-dir": "nix-bundle-dir_225",
+        "nix-bundle-dir": "nix-bundle-dir_226",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -104176,7 +104233,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1388",
         "logos-package": "logos-package_163",
-        "nix-bundle-dir": "nix-bundle-dir_228",
+        "nix-bundle-dir": "nix-bundle-dir_229",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -104210,7 +104267,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1392",
         "logos-package": "logos-package_164",
-        "nix-bundle-dir": "nix-bundle-dir_229",
+        "nix-bundle-dir": "nix-bundle-dir_230",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -104244,7 +104301,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1401",
         "logos-package": "logos-package_166",
-        "nix-bundle-dir": "nix-bundle-dir_232",
+        "nix-bundle-dir": "nix-bundle-dir_233",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -104279,7 +104336,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1432",
         "logos-package": "logos-package_168",
-        "nix-bundle-dir": "nix-bundle-dir_235",
+        "nix-bundle-dir": "nix-bundle-dir_236",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -104314,7 +104371,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1436",
         "logos-package": "logos-package_169",
-        "nix-bundle-dir": "nix-bundle-dir_236",
+        "nix-bundle-dir": "nix-bundle-dir_237",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -104349,7 +104406,7 @@
       "inputs": {
         "logos-nix": "logos-nix_1445",
         "logos-package": "logos-package_171",
-        "nix-bundle-dir": "nix-bundle-dir_239",
+        "nix-bundle-dir": "nix-bundle-dir_240",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -105856,6 +105913,35 @@
       }
     },
     "nix-bundle-macos-app": {
+      "inputs": {
+        "logos-nix": [
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781728271,
+        "narHash": "sha256-LHdzXrQPJCEVLC9cntURu8O9qSPPrePoVBzZd0UFGN0=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "rev": "d6b0cc518e599ab7a52258bf3e1f8123c8a01d31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "type": "github"
+      }
+    },
+    "nix-bundle-macos-app_2": {
       "inputs": {
         "logos-nix": "logos-nix_1958",
         "nix-bundle-dir": [
@@ -138735,10 +138821,10 @@
         "logos-qt-mcp": "logos-qt-mcp_46",
         "logos-qt-sdk": "logos-qt-sdk_44",
         "logos-view-module-runtime": "logos-view-module-runtime_46",
-        "nix-bundle-appimage": "nix-bundle-appimage_97",
-        "nix-bundle-dir": "nix-bundle-dir_329",
+        "nix-bundle-appimage": "nix-bundle-appimage_98",
+        "nix-bundle-dir": "nix-bundle-dir_330",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_46",
-        "nix-bundle-macos-app": "nix-bundle-macos-app",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_2",
         "nixpkgs": [
           "logos-nix",
           "nixpkgs"


### PR DESCRIPTION

<!--
Thanks for the PR. A short template so triage and review don't stall.
Delete sections that don't apply — don't leave placeholder text.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->

## Screenshots / recordings

<!-- Required for any user-visible UI change. Before/after if it's a fix. -->

## Test plan

<!-- How you validated the change. Tick what applies. -->

- [ ] `nix build .#app` succeeds
- [ ] `nix build .#smoke-test -L` passes
- [ ] `nix build .#integration-test -L` passes (if UI-visible)
- [ ] Doctests pass (`nix build .#doctests -L` if touched)
- [ ] Manual verification on:
  - [ ] Linux (AppImage)
  - [ ] Linux (Nix local build)
  - [ ] macOS
- [ ] N/A — docs/CI/tooling only

## Release notes

<!-- One line for the changelog. Prefix with fix:/feat:/chore:/docs:/test:/ci:
     to match the commit-style already used on master. -->

## Checklist

- [ ] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [ ] No unrelated changes bundled in
- [ ] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [ ] Uncommitted binaries, screenshots, or `.DS_Store` files removed
