### PR TITLE
doctest: QML-only full-api UI (basecamp-fullapi-ui-qml)

### DIFF
--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -154,11 +154,16 @@ jobs:
           #     drives every method type + receives typed events, all from local
           #     install-portable outputs (no catalog, no peer connection). This
           #     replaces the flaky cross-version chat check.
+          #   basecamp-fullapi-ui-qml — the QML-only twin of the above: a
+          #     ui_qml plugin with NO C++ backend consumes test_fullapi_cpp
+          #     directly from QML via the `logos` bridge (logos.callModule /
+          #     onModuleEvent), covering the QML-expressible surface.
           nix run github:logos-co/logos-doctest -- run \
             doctests/basecamp-modules.test.yaml \
             doctests/basecamp-modules-bundle.test.yaml \
             doctests/basecamp-crossversion-accounts.test.yaml \
             doctests/basecamp-fullapi-ui.test.yaml \
+            doctests/basecamp-fullapi-ui-qml.test.yaml \
             --verbose \
             --continue-on-fail \
             --release-for logos-basecamp=${{ steps.commit.outputs.sha }} \
@@ -186,7 +191,7 @@ jobs:
 
       - name: Verify markdown generation
         run: |
-          for spec in basecamp-modules basecamp-modules-bundle basecamp-crossversion-accounts basecamp-fullapi-ui; do
+          for spec in basecamp-modules basecamp-modules-bundle basecamp-crossversion-accounts basecamp-fullapi-ui basecamp-fullapi-ui-qml; do
             nix run github:logos-co/logos-doctest -- generate \
               "doctests/${spec}.test.yaml" \
               --release-for logos-basecamp=${{ steps.commit.outputs.sha }} \

--- a/doctests/basecamp-fullapi-ui-qml.test.yaml
+++ b/doctests/basecamp-fullapi-ui-qml.test.yaml
@@ -1,0 +1,146 @@
+name: "Driving the full API surface through a QML-only UI plugin in Basecamp"
+output: basecamp-fullapi-ui-qml.md
+release: ""
+
+intro: |
+  This doc-test drives the **entire QML-expressible API surface** of a Logos
+  module through a **QML-only UI plugin** (no C++ backend) running inside
+  Basecamp. The plugin (`test_fullapi_ui_qml`) consumes `test_fullapi_cpp`
+  **directly from QML/JS** through the `logos` bridge injected by the view
+  runtime: `logos.callModule(...)` for every method type and
+  `logos.onModuleEvent(...)` / `onModuleEventReceived` for every typed event.
+  All of the pass/fail logic lives in QML/JS — there is no generated backend,
+  no `.rep`, and no interface dependency.
+
+  It complements `basecamp-fullapi-ui.test.yaml`, which drives the same surface
+  through a C++ (QtRO) backend. `bstr` is the one type not exercised here:
+  QML/JS has no native byte literal, so `echoBytes` / `bytesEvent` aren't
+  expressible from QML (the C++-backend variant covers them).
+
+  Everything is built from `logos-test-modules` and the Nix binary cache and
+  installed into a local `--user-dir`: **no package-catalog download and no
+  network peer connection**, so the check is fully hermetic.
+
+what_you_build: |
+  The Basecamp bundle (inspector-enabled) and the logos-qt-mcp UI driver, a
+  user-dir containing the `test_fullapi_cpp` provider and the QML-only UI
+  plugin, and a headless UI run that clicks through the plugin and asserts that
+  every method type and every typed event round-tripped purely from QML.
+
+what_you_learn:
+  - How a QML-only ui_qml plugin consumes another module with no C++ backend
+  - How QML calls module methods via `logos.callModule` and reads the JSON result
+  - How QML subscribes to typed events via `logos.onModuleEvent` + `onModuleEventReceived`
+  - How to stage locally-built modules into a Basecamp `--user-dir` (no catalog)
+
+prerequisites:
+  - |
+    **Nix** with flakes enabled. Install from [nixos.org](https://nixos.org/download.html), then enable flakes:
+
+    ```bash
+    mkdir -p ~/.config/nix
+    echo 'experimental-features = nix-command flakes' >> ~/.config/nix/nix.conf
+    ```
+
+    Verify: `nix flake --help >/dev/null 2>&1 && echo "Flakes enabled"`
+  - |
+    **Network access** to fetch the flakes and Nix binary cache. Once everything
+    is built, the run itself is offline — no catalog download, no peer connection.
+
+sections:
+  - title: "Build the UI test driver"
+    step: true
+    text: |
+      Build the logos-qt-mcp driver that connects to the app's QML inspector.
+    steps:
+      - title: "Build logos-qt-mcp"
+        run: "nix build \"${QT_MCP_FLAKE:-github:logos-co/logos-qt-mcp}\" -o result-mcp"
+        check_file: "result-mcp"
+
+  - title: "Build the Basecamp bundle"
+    step: true
+    text: |
+      Build the inspector-enabled portable bundle — the same shippable dir
+      bundle, with the QML inspector compiled in so the driver can attach.
+    steps:
+      - title: "Build the bundle"
+        run: "nix build 'github:logos-co/logos-basecamp{release}#bin-bundle-dir-inspector' -o result-bundle"
+        check_file: "result-bundle/bin/LogosBasecamp"
+
+  - title: "Install the provider + QML-only UI into a user-dir"
+    step: true
+    text: |
+      Build the `test_fullapi_cpp` provider and the `test_fullapi_ui_qml`
+      QML-only UI plugin from `logos-test-modules` as **portable** install
+      outputs, then assemble a `--user-dir` by plain copy: the provider under
+      `modules/`, the UI plugin under `plugins/`. No `lgpd`, no catalog, no
+      network.
+    steps:
+      - title: "Build and stage the modules"
+        run: |
+          SYSTEM=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          rm -rf testdata/fullapi-qml
+          mkdir -p testdata/fullapi-qml/modules testdata/fullapi-qml/plugins
+          nix build "${TEST_MODULES_FLAKE:-github:logos-co/logos-test-modules}#modules.$SYSTEM.test_fullapi_cpp.install-portable" --out-link result-port-cpp
+          cp -RL result-port-cpp/modules/. testdata/fullapi-qml/modules/
+          nix build "${TEST_MODULES_FLAKE:-github:logos-co/logos-test-modules}#modules.$SYSTEM.test_fullapi_ui_qml.install-portable" --out-link result-port-ui-qml
+          cp -RL result-port-ui-qml/plugins/. testdata/fullapi-qml/plugins/
+          chmod -R u+w testdata/fullapi-qml
+          echo "modules:"; ls testdata/fullapi-qml/modules
+          echo "plugins:"; ls testdata/fullapi-qml/plugins
+        expect_contains:
+          - "test_fullapi_cpp"
+          - "test_fullapi_ui_qml"
+
+  - title: "Launch Basecamp and drive the QML-only plugin"
+    step: true
+    text: |
+      Launch the bundle against the assembled user-dir and drive the QML-only
+      Full API UI plugin headlessly: open it, run every QML-expressible method
+      type against the provider (aggregated in QML), then fire every typed event
+      and confirm they all arrived back in QML.
+    steps:
+      - title: "Drive the plugin"
+        ui_test:
+          launch: "./result-bundle/bin/LogosBasecamp --user-dir ./testdata/fullapi-qml"
+          qt_mcp: "result-mcp"
+          launch_timeout: 300
+          tests:
+            - name: "App window opens with the sidebar visible"
+              action: wait_for
+              texts: ["Applications", "Settings"]
+              timeout: 60000
+              text: "The bundle launches headless against the assembled user-dir."
+              screenshot: "fullapi-qml-launch.png"
+
+            - name: "Open the QML-only Full API UI plugin"
+              action: click
+              target: "Full API UI (QML-only)"
+
+            - name: "The plugin view renders with its controls"
+              action: wait_for
+              texts: ["Run All Methods", "Fire Events"]
+              timeout: 30000
+              screenshot: "fullapi-qml-view.png"
+
+            - name: "Run every QML-expressible method type from QML"
+              action: click
+              target: "Run All Methods"
+
+            - name: "Every method type round-trips through logos.callModule"
+              action: wait_for
+              texts: ["ALL_OK_QML:test_fullapi_cpp"]
+              timeout: 60000
+              text: "QML/JS called every method type via logos.callModule, parsed each JSON result, and published a single ALL_OK_QML token."
+              screenshot: "fullapi-qml-methods.png"
+
+            - name: "Fire every typed event from QML"
+              action: click
+              target: "Fire Events"
+
+            - name: "Every typed event arrives back in QML via onModuleEventReceived"
+              action: wait_for
+              texts: ["ALL_EVENTS_OK_QML:test_fullapi_cpp"]
+              timeout: 30000
+              text: "QML subscribed via logos.onModuleEvent, triggered every fire<X>Event, and matched each received payload."
+              screenshot: "fullapi-qml-events.png"

--- a/flake.lock
+++ b/flake.lock
@@ -85994,11 +85994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784651192,
+        "lastModified": 1784655444,
         "narHash": "sha256-oSGwmFf879xiBhm0/bwU38yG0nxjNpaLyqgSElR9h2k=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "b6ec74f00a4b44d03d505ebd49b0c1c27270fb85",
+        "rev": "a644be266908895d114f3452e8475d4a14aaea9f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -85994,11 +85994,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784318533,
-        "narHash": "sha256-4UfIyPAb8H8/94XSulyUZp2YxfH1u5avGdfc53APoOo=",
+        "lastModified": 1784651192,
+        "narHash": "sha256-oSGwmFf879xiBhm0/bwU38yG0nxjNpaLyqgSElR9h2k=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "42729dc2713a4f5a1e73ba3925e41ecbbbdb2ba4",
+        "rev": "b6ec74f00a4b44d03d505ebd49b0c1c27270fb85",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What

Adds `basecamp-fullapi-ui-qml.test.yaml` — a hermetic doctest that drives the **entire QML-expressible API surface** through a **QML-only** UI plugin (no C++ backend) running inside Basecamp. The plugin (`test_fullapi_ui_qml`, new in [logos-test-modules#26](https://github.com/logos-co/logos-test-modules/pull/26)) consumes `test_fullapi_cpp` **directly from QML/JS** via the `logos` bridge — `logos.callModule(...)` for methods, `logos.onModuleEvent(...)` / `onModuleEventReceived` for typed events. All pass/fail logic lives in QML; there is no generated backend, no `.rep`, no interface dependency.

It's the QML-only twin of `basecamp-fullapi-ui.test.yaml` (which drives the same surface through a C++ QtRO backend), closing the gap where we had no coverage of a plugin that consumes another module with pure QML.

## The run

Like the existing full-API UI doctest, it's fully hermetic — everything is built from `logos-test-modules` + the Nix binary cache and staged into a `--user-dir` by plain copy (no catalog download, no network peer). It:
1. builds the qt-mcp driver + the inspector-enabled Basecamp bundle;
2. stages `test_fullapi_cpp` (→ `modules/`) and `test_fullapi_ui_qml` (→ `plugins/`);
3. launches Basecamp headless, opens **"Full API UI (QML-only)"**, clicks **Run All Methods** → asserts `ALL_OK_QML:test_fullapi_cpp`, then **Fire Events** → asserts `ALL_EVENTS_OK_QML:test_fullapi_cpp`.

Registered in `.github/workflows/doctests.yml` (both the `run` list and the markdown-gen list). Adds a `TEST_MODULES_FLAKE` env override (defaults to master) so a fork/branch can be targeted locally.

`bstr` is the one type not exercised — QML/JS has no native byte literal (the C++-backend variant covers it).

## Validation status (please read)

- The `test_fullapi_ui_qml` module **builds clean**, and this doctest mirrors the structure of the already-merged `basecamp-fullapi-ui.test.yaml` exactly.
- The **UI-drive step has not yet been run end-to-end**: local validation is currently blocked by a transient `cache.nix.logos.co` **HTTP 500** outage (the Basecamp bundle can't be fetched), compounded by the attic key rotation in #271 (master still carries the old key). The one genuinely new path is typed-scalar-array args over the generic QtRO bridge — though master's protocol pin (#272) already includes the container-int fix, so I expect it to pass. Expected values are grounded in a prior `logoscore` probe of the same module.
- **Do not merge before** [logos-test-modules#26](https://github.com/logos-co/logos-test-modules/pull/26) (this references test-modules master). This doctest also needs the cache/#271 key situation resolved for CI to run it. I'll confirm the run goes green (and fix any type-marshaling mismatch the `FAIL:<method> got=<raw>` token surfaces) as soon as the cache is healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)