### PR TITLE
fix: if a module uses icons under qml/icons currently and imports Log…

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SOURCES
     restricted/DenyAllNAMFactory.cpp
     restricted/RestrictedUrlInterceptor.cpp
     restricted/QmlSandbox.cpp
+    restricted/SandboxLogging.cpp
 )
 
 # Add SDK sources based on layout type

--- a/src/PluginLoader.cpp
+++ b/src/PluginLoader.cpp
@@ -308,7 +308,8 @@ void PluginLoader::loadQmlView(const PluginLoadRequest& request,
     if (QQmlEngine* engine = qmlWidget->engine()) {
         const QString appLibDir =
             QDir(QCoreApplication::applicationDirPath() + "/../lib").canonicalPath();
-        QmlSandbox::configure(engine, request.installDir, request.qmlViewPath, appLibDir);
+        QmlSandbox::configure(engine, request.installDir, request.qmlViewPath,
+                              appLibDir, request.name);
         engine->setBaseUrl(QUrl::fromLocalFile(request.installDir + "/"));
     }
 

--- a/src/restricted/DenyAllNAMFactory.cpp
+++ b/src/restricted/DenyAllNAMFactory.cpp
@@ -2,7 +2,12 @@
 
 #include "restricted/DenyAllNetworkAccessManager.h"
 
+DenyAllNAMFactory::DenyAllNAMFactory(const QString& pluginLabel)
+    : m_pluginLabel(pluginLabel)
+{
+}
+
 QNetworkAccessManager* DenyAllNAMFactory::create(QObject* parent)
 {
-    return new DenyAllNetworkAccessManager(parent);
+    return new DenyAllNetworkAccessManager(parent, m_pluginLabel);
 }

--- a/src/restricted/DenyAllNAMFactory.h
+++ b/src/restricted/DenyAllNAMFactory.h
@@ -2,8 +2,14 @@
 
 #include <QNetworkAccessManager>
 #include <QQmlNetworkAccessManagerFactory>
+#include <QString>
 
 class DenyAllNAMFactory : public QQmlNetworkAccessManagerFactory {
 public:
+    explicit DenyAllNAMFactory(const QString& pluginLabel = QString());
+
     QNetworkAccessManager* create(QObject* parent) override;
+
+private:
+    QString m_pluginLabel;
 };

--- a/src/restricted/DenyAllNetworkAccessManager.cpp
+++ b/src/restricted/DenyAllNetworkAccessManager.cpp
@@ -2,11 +2,17 @@
 
 #include "restricted/DenyAllReply.h"
 
+DenyAllNetworkAccessManager::DenyAllNetworkAccessManager(QObject* parent,
+                                                         const QString& pluginLabel)
+    : QNetworkAccessManager(parent)
+    , m_pluginLabel(pluginLabel)
+{
+}
+
 QNetworkReply* DenyAllNetworkAccessManager::createRequest(Operation op,
                                                           const QNetworkRequest& request,
                                                           QIODevice* outgoingData)
 {
-    Q_UNUSED(op);
     Q_UNUSED(outgoingData);
-    return new DenyAllReply(request, this);
+    return new DenyAllReply(request, op, this, m_pluginLabel);
 }

--- a/src/restricted/DenyAllNetworkAccessManager.h
+++ b/src/restricted/DenyAllNetworkAccessManager.h
@@ -2,15 +2,20 @@
 
 #include <QNetworkAccessManager>
 #include <QNetworkRequest>
+#include <QString>
 
 class QIODevice;
 
 class DenyAllNetworkAccessManager : public QNetworkAccessManager {
 public:
-    using QNetworkAccessManager::QNetworkAccessManager;
+    explicit DenyAllNetworkAccessManager(QObject* parent = nullptr,
+                                         const QString& pluginLabel = QString());
 
 protected:
     QNetworkReply* createRequest(Operation op,
                                  const QNetworkRequest& request,
                                  QIODevice* outgoingData = nullptr) override;
+
+private:
+    QString m_pluginLabel;
 };

--- a/src/restricted/DenyAllReply.cpp
+++ b/src/restricted/DenyAllReply.cpp
@@ -3,7 +3,28 @@
 #include <QTimer>
 #include <QUrl>
 
-DenyAllReply::DenyAllReply(const QNetworkRequest& request, QObject* parent)
+#include "restricted/SandboxLogging.h"
+
+namespace {
+const char* operationName(QNetworkAccessManager::Operation op)
+{
+    switch (op) {
+        case QNetworkAccessManager::HeadOperation:   return "HEAD";
+        case QNetworkAccessManager::GetOperation:    return "GET";
+        case QNetworkAccessManager::PutOperation:    return "PUT";
+        case QNetworkAccessManager::PostOperation:   return "POST";
+        case QNetworkAccessManager::DeleteOperation: return "DELETE";
+        case QNetworkAccessManager::CustomOperation: return "CUSTOM";
+        case QNetworkAccessManager::UnknownOperation: break;
+    }
+    return "UNKNOWN";
+}
+}
+
+DenyAllReply::DenyAllReply(const QNetworkRequest& request,
+                           QNetworkAccessManager::Operation op,
+                           QObject* parent,
+                           const QString& pluginLabel)
     : QNetworkReply(parent)
 {
     setRequest(request);
@@ -11,6 +32,16 @@ DenyAllReply::DenyAllReply(const QNetworkRequest& request, QObject* parent)
     setOpenMode(QIODevice::ReadOnly);
     setError(QNetworkReply::ContentOperationNotPermittedError,
              QStringLiteral("Network access disabled for this QML engine"));
+
+    qCWarning(lcBasecampSandbox).noquote()
+        << QStringLiteral("Blocked network %1 \"%2\"%3: sandboxed ui_qml modules "
+                          "may not use the network.")
+               .arg(QString::fromLatin1(operationName(op)),
+                    request.url().toString(QUrl::RemoveUserInfo),
+                    pluginLabel.isEmpty()
+                        ? QString()
+                        : QStringLiteral(" [plugin=%1]").arg(pluginLabel));
+
     QTimer::singleShot(0, this, [this]() {
         emit errorOccurred(error());
         emit finished();

--- a/src/restricted/DenyAllReply.h
+++ b/src/restricted/DenyAllReply.h
@@ -1,12 +1,19 @@
 #pragma once
 
+#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QString>
 
 // Network reply that immediately fails to prevent any QML network usage.
+// `pluginLabel` is threaded through so blocked attempts can be logged with the
+// plugin they originated from (empty = unlabeled, used by tests).
 class DenyAllReply : public QNetworkReply {
 public:
-    DenyAllReply(const QNetworkRequest& request, QObject* parent);
+    DenyAllReply(const QNetworkRequest& request,
+                 QNetworkAccessManager::Operation op,
+                 QObject* parent,
+                 const QString& pluginLabel = QString());
 
     void abort() override;
     bool isSequential() const override;

--- a/src/restricted/QmlSandbox.cpp
+++ b/src/restricted/QmlSandbox.cpp
@@ -7,13 +7,16 @@
 
 #include "restricted/DenyAllNAMFactory.h"
 #include "restricted/RestrictedUrlInterceptor.h"
+#include "restricted/SandboxLogging.h"
+#include "restricted/SharedLogosModules.h"
 
 namespace QmlSandbox {
 
 QStringList configure(QQmlEngine* engine,
                       const QString& installDir,
                       const QString& qmlViewPath,
-                      const QString& appLibDir)
+                      const QString& appLibDir,
+                      const QString& pluginLabel)
 {
     const QStringList qtDefaultPaths = engine->importPathList();
 
@@ -39,7 +42,7 @@ QStringList configure(QQmlEngine* engine,
     // get a native .so dlopen()ed into the host process. (Previously installDir
     // was prepended here, which — together with the module dir being on the
     // import path — let a qmldir 'plugin' directive load arbitrary native code.)
-    engine->setNetworkAccessManagerFactory(new DenyAllNAMFactory());
+    engine->setNetworkAccessManagerFactory(new DenyAllNAMFactory(pluginLabel));
 
     // allowedRoots gate ALL local file/qmldir resolution. untrustedRoots is the
     // subset (the module's own dirs) where a qmldir may not declare a native
@@ -56,12 +59,7 @@ QStringList configure(QQmlEngine* engine,
     }
     // Allow only an explicit set of shared Logos QML modules.
     if (!appLibDir.isEmpty()) {
-        static const QStringList kAllowedLogosModules = {
-            QStringLiteral("Theme"),
-            QStringLiteral("Controls"),
-            QStringLiteral("Icons"),
-        };
-        for (const QString& mod : kAllowedLogosModules) {
+        for (const QString& mod : kSharedLogosModules()) {
             const QString modDir = QDir(appLibDir + "/Logos/" + mod).canonicalPath();
             if (!modDir.isEmpty() && !allowedRoots.contains(modDir))
                 allowedRoots << modDir;
@@ -76,7 +74,23 @@ QStringList configure(QQmlEngine* engine,
         if (!canon.isEmpty() && !allowedRoots.contains(canon))
             allowedRoots << canon;
     }
-    engine->addUrlInterceptor(new RestrictedUrlInterceptor(allowedRoots, untrustedRoots));
+    engine->addUrlInterceptor(
+        new RestrictedUrlInterceptor(allowedRoots, untrustedRoots, pluginLabel));
+
+    // One-line summary so a post-mortem log always shows what the sandbox
+    // was configured with for this plugin (install/entry dirs, whether the
+    // vetted appLibDir is present). Individual block/redirect events are
+    // logged at Warning by the interceptor / DenyAllReply.
+    qCInfo(lcBasecampSandbox).noquote()
+        << QStringLiteral("Sandbox configured%1: install=\"%2\" entry=\"%3\" "
+                          "appLibDir=%4 untrustedRoots=%5")
+               .arg(pluginLabel.isEmpty()
+                        ? QString()
+                        : QStringLiteral(" for plugin=%1").arg(pluginLabel),
+                    installDir,
+                    qmlEntryDir,
+                    appLibDir.isEmpty() ? QStringLiteral("(none)") : appLibDir,
+                    QString::number(untrustedRoots.size()));
     return untrustedRoots;
 }
 

--- a/src/restricted/QmlSandbox.h
+++ b/src/restricted/QmlSandbox.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QString>
 #include <QStringList>
 
 class QQmlEngine;
@@ -14,18 +15,22 @@ namespace QmlSandbox {
 //                     defaults, so the module's own QML/JS resolves;
 //   * a deny-all QQmlNetworkAccessManagerFactory (no network);
 //   * a RestrictedUrlInterceptor confining file/qmldir resolution to the
-//     module's dir + the vetted/Qt roots, and forbidding a qmldir under the
-//     module's (untrusted) dir from declaring a native C++ plugin.
+//     module's dir + the vetted/Qt roots, forbidding a qmldir under the
+//     module's (untrusted) dir from declaring a native C++ plugin, and forcing
+//     `import Logos.<Reserved>` to always resolve from the vetted appLibDir.
 //
 // Deliberately does NOT add the untrusted installDir to the engine's native
 // plugin search path, and keeps Qt's default pluginPathList intact.
 //
 // `appLibDir` is the vetted application library dir (in production
-// <appDir>/../lib); tests pass an explicit value (often empty). Returns the set
-// of import roots that were treated as untrusted — useful for assertions.
+// <appDir>/../lib); tests pass an explicit value (often empty). `pluginLabel`
+// is an optional identifier (e.g. the module name) prefixed onto every sandbox
+// diagnostic — omit in tests. Returns the set of import roots that were treated
+// as untrusted — useful for assertions.
 QStringList configure(QQmlEngine* engine,
                       const QString& installDir,
                       const QString& qmlViewPath,
-                      const QString& appLibDir);
+                      const QString& appLibDir,
+                      const QString& pluginLabel = QString());
 
 } // namespace QmlSandbox

--- a/src/restricted/RestrictedUrlInterceptor.cpp
+++ b/src/restricted/RestrictedUrlInterceptor.cpp
@@ -2,11 +2,11 @@
 
 #include <QDir>
 #include <QFile>
-#include <QLoggingCategory>
 #include <QRegularExpression>
 #include <QTextStream>
 
-Q_LOGGING_CATEGORY(lcBasecampSandbox, "logos.basecamp.sandbox")
+#include "restricted/SandboxLogging.h"
+#include "restricted/SharedLogosModules.h"
 
 namespace {
 const char* dataTypeName(QQmlAbstractUrlInterceptor::DataType type)
@@ -31,7 +31,9 @@ const QRegularExpression& nativePluginDirective()
 }
 
 RestrictedUrlInterceptor::RestrictedUrlInterceptor(const QStringList& allowedRoots,
-                                                   const QStringList& untrustedRoots)
+                                                   const QStringList& untrustedRoots,
+                                                   const QString& pluginLabel)
+    : m_pluginLabel(pluginLabel)
 {
     for (const QString& root : allowedRoots) {
         const QString canonical = QDir(root).canonicalPath();
@@ -45,6 +47,13 @@ RestrictedUrlInterceptor::RestrictedUrlInterceptor(const QStringList& allowedRoo
             m_untrustedRoots.append(canonical);
         }
     }
+}
+
+QString RestrictedUrlInterceptor::labelSuffix() const
+{
+    return m_pluginLabel.isEmpty()
+        ? QString()
+        : QStringLiteral(" [plugin=%1]").arg(m_pluginLabel);
 }
 
 bool RestrictedUrlInterceptor::isUnder(const QString& canonicalPath,
@@ -77,6 +86,42 @@ bool RestrictedUrlInterceptor::qmldirDeclaresNativePlugin(const QString& qmldirP
     return false;
 }
 
+// Detects "the plugin tree is trying to answer for a Logos.<Reserved> import."
+// A raw local path is checked against every untrusted root — if it lives under
+// one and the sub-path (case-folded) begins with "Logos/<Reserved>/…" or is
+// exactly "Logos/<Reserved>", the caller returns an invalid QUrl so Qt keeps
+// walking the import path and resolves the module from appLibDir instead.
+//
+// Uses the raw (pre-canonicalisation) path on purpose: on case-insensitive
+// filesystems a leftover qml/icons/ inside the plugin can be Qt's probe target
+// while looking for Logos.Icons, and that probe is what needs shadowing before
+// Qt reaches deeper into the (junk) directory tree.
+bool RestrictedUrlInterceptor::isReservedLogosProbeInUntrustedRoot(
+    const QString& localPath, QString* matchedName) const
+{
+    for (const QString& root : m_untrustedRoots) {
+        if (root.isEmpty()) continue;
+        if (localPath != root && !localPath.startsWith(root + QLatin1Char('/'))) continue;
+        const QString rel = localPath == root
+            ? QString()
+            : localPath.mid(root.size() + 1);
+        if (!rel.startsWith(QStringLiteral("Logos/"), Qt::CaseInsensitive)
+            && rel.compare(QStringLiteral("Logos"), Qt::CaseInsensitive) != 0) {
+            continue;
+        }
+        const QString afterLogos = rel.size() > 6 ? rel.mid(6) : QString();
+        const QString firstSeg = afterLogos.section(QLatin1Char('/'), 0, 0);
+        if (firstSeg.isEmpty()) continue;
+        for (const QString& reserved : kSharedLogosModules()) {
+            if (firstSeg.compare(reserved, Qt::CaseInsensitive) == 0) {
+                if (matchedName) *matchedName = reserved;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 QUrl RestrictedUrlInterceptor::intercept(const QUrl& url, DataType type)
 {
     if (!url.isValid()) {
@@ -89,6 +134,25 @@ QUrl RestrictedUrlInterceptor::intercept(const QUrl& url, DataType type)
 
     if (url.isLocalFile()) {
         const QString raw   = url.toLocalFile();
+
+        // Force Logos.<Reserved> to resolve from the vetted appLibDir, never
+        // from a plugin tree. This runs before the canonicalise+allowedRoots
+        // checks below because it uses the raw probe path — a leftover
+        // qml/icons/ inside the plugin can shadow Logos.Icons on
+        // case-insensitive filesystems (RCA for basecamp 0.2.2-RC1). By
+        // returning an invalid QUrl, Qt treats this candidate as "not here"
+        // and continues walking the import path.
+        {
+            QString reserved;
+            if (isReservedLogosProbeInUntrustedRoot(raw, &reserved)) {
+                qCWarning(lcBasecampSandbox).noquote()
+                    << QStringLiteral("Redirected Logos.%1 probe away from plugin tree \"%2\"%3: "
+                                      "shared Logos.* modules resolve from the vetted design-system dir.")
+                           .arg(reserved, raw, labelSuffix());
+                return QUrl();
+            }
+        }
+
         const QString local = QDir(raw).canonicalPath();
         if (local.isEmpty()) {
             // Empty canonical path = the path doesn't exist. Qt's module
@@ -100,18 +164,19 @@ QUrl RestrictedUrlInterceptor::intercept(const QUrl& url, DataType type)
                 return url;
             }
             qCWarning(lcBasecampSandbox).noquote()
-                << QStringLiteral("Blocked %1 import \"%2\": path exists but could not "
+                << QStringLiteral("Blocked %1 import \"%2\"%3: path exists but could not "
                                   "be canonicalised and cannot be vetted against the "
                                   "sandbox allowed roots.")
-                       .arg(QString::fromLatin1(dataTypeName(type)), raw);
+                       .arg(QString::fromLatin1(dataTypeName(type)), raw, labelSuffix());
             return QUrl();
         }
         if (!isUnder(local, m_allowedRoots)) {
             qCWarning(lcBasecampSandbox).noquote()
-                << QStringLiteral("Blocked %1 import \"%2\": path is outside the basecamp plugin sandbox. "
-                                  "Allowed roots: %3")
+                << QStringLiteral("Blocked %1 import \"%2\"%3: path is outside the basecamp plugin sandbox. "
+                                  "Allowed roots: %4")
                        .arg(QString::fromLatin1(dataTypeName(type)),
                             url.toLocalFile(),
+                            labelSuffix(),
                             m_allowedRoots.join(QStringLiteral(", ")));
             return QUrl();  // Block file access outside allowed roots
         }
@@ -127,19 +192,20 @@ QUrl RestrictedUrlInterceptor::intercept(const QUrl& url, DataType type)
         if (type == QmldirFile && isUnder(local, m_untrustedRoots)
             && qmldirDeclaresNativePlugin(local)) {
             qCWarning(lcBasecampSandbox).noquote()
-                << QStringLiteral("Blocked qmldir \"%1\": a sandboxed ui_qml module may not declare a "
+                << QStringLiteral("Blocked qmldir \"%1\"%2: a sandboxed ui_qml module may not declare a "
                                   "native plugin (QML-only modules cannot load C++ plugins into the host).")
-                       .arg(url.toLocalFile());
+                       .arg(url.toLocalFile(), labelSuffix());
             return QUrl();
         }
         return url;
     }
 
     qCWarning(lcBasecampSandbox).noquote()
-        << QStringLiteral("Blocked %1 import \"%2\": scheme \"%3\" is not allowed in the basecamp "
+        << QStringLiteral("Blocked %1 import \"%2\"%3: scheme \"%4\" is not allowed in the basecamp "
                           "plugin sandbox (only qrc: and local files inside allowed roots are permitted).")
                .arg(QString::fromLatin1(dataTypeName(type)),
                     url.toString(),
+                    labelSuffix(),
                     url.scheme());
     return QUrl();  // Block http/https and any other scheme
 }

--- a/src/restricted/RestrictedUrlInterceptor.h
+++ b/src/restricted/RestrictedUrlInterceptor.h
@@ -1,12 +1,21 @@
 #pragma once
 
 #include <QQmlAbstractUrlInterceptor>
+#include <QString>
 #include <QStringList>
 #include <QUrl>
 
 // Gates every URL the QML engine resolves for a sandboxed ui_qml module.
 //
-// Two layers:
+// Three layers:
+//   * Logos.* redirect — probes into an untrusted root that would try to
+//                        resolve a shared design-system module (Logos.Icons,
+//                        Logos.Theme, Logos.Controls, …) are blocked so Qt
+//                        continues walking the import path and hits the vetted
+//                        appLibDir copy. The design system owns the Logos.*
+//                        namespace; a plugin's local folders never answer for
+//                        it, regardless of what they contain or how the
+//                        filesystem case-folds names.
 //   * allowedRoots   — only qrc: URLs and local files under one of these
 //                      canonical roots are resolved; everything else (other
 //                      schemes, files outside the roots) is blocked.
@@ -24,16 +33,24 @@
 // plugin path internally and hands it to QPluginLoader), so blocking the .so
 // URL here would be useless — the qmldir that *declares* it is the only choke
 // point the interceptor sees, hence the qmldir-level check.
+//
+// `pluginLabel` is threaded through so every diagnostic can identify which
+// plugin engine the probe came from (empty = unlabeled, used by tests).
 class RestrictedUrlInterceptor : public QQmlAbstractUrlInterceptor {
 public:
     explicit RestrictedUrlInterceptor(const QStringList& allowedRoots,
-                                      const QStringList& untrustedRoots = {});
+                                      const QStringList& untrustedRoots = {},
+                                      const QString& pluginLabel = QString());
     QUrl intercept(const QUrl& url, DataType type) override;
 
 private:
     bool isUnder(const QString& canonicalPath, const QStringList& roots) const;
     bool qmldirDeclaresNativePlugin(const QString& qmldirPath) const;
+    bool isReservedLogosProbeInUntrustedRoot(const QString& localPath,
+                                             QString* matchedName) const;
+    QString labelSuffix() const;
 
     QStringList m_allowedRoots;
     QStringList m_untrustedRoots;
+    QString m_pluginLabel;
 };

--- a/src/restricted/SandboxLogging.cpp
+++ b/src/restricted/SandboxLogging.cpp
@@ -1,0 +1,3 @@
+#include "restricted/SandboxLogging.h"
+
+Q_LOGGING_CATEGORY(lcBasecampSandbox, "logos.basecamp.sandbox")

--- a/src/restricted/SandboxLogging.h
+++ b/src/restricted/SandboxLogging.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <QLoggingCategory>
+
+// One logging category for the entire ui_qml sandbox — url interceptor, network
+// deny factory, engine setup. Defined once in SandboxLogging.cpp so DenyAllReply
+// (which lives in a translation unit that used to have no logging at all) can
+// share the same category as RestrictedUrlInterceptor without duplicating the
+// Q_LOGGING_CATEGORY definition.
+Q_DECLARE_LOGGING_CATEGORY(lcBasecampSandbox)

--- a/src/restricted/SharedLogosModules.h
+++ b/src/restricted/SharedLogosModules.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+// Canonical enumeration of the shared Logos.* QML modules published by the
+// design system. Used in two places that must not drift:
+//
+//   * QmlSandbox::configure — decides which Logos.<X> subdirs of the vetted
+//     appLibDir are added to allowedRoots (so `import Logos.<X>` resolves at all).
+//   * RestrictedUrlInterceptor — forces `import Logos.<X>` to resolve from
+//     appLibDir even when a plugin tree contains a colliding path, e.g. an
+//     asset-only qml/icons/ under an untrusted root. Design system owns the
+//     Logos.* namespace; the plugin doesn't get to answer for it.
+//
+// Extend this list when the design system publishes a new module.
+inline const QStringList& kSharedLogosModules()
+{
+    static const QStringList v = {
+        QStringLiteral("Theme"),
+        QStringLiteral("Controls"),
+        QStringLiteral("Icons"),
+    };
+    return v;
+}

--- a/tests/sandbox/CMakeLists.txt
+++ b/tests/sandbox/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(tst_qml_sandbox
     ${BASECAMP_SRC}/restricted/DenyAllNAMFactory.cpp
     ${BASECAMP_SRC}/restricted/DenyAllNetworkAccessManager.cpp
     ${BASECAMP_SRC}/restricted/DenyAllReply.cpp
+    ${BASECAMP_SRC}/restricted/SandboxLogging.cpp
 )
 target_include_directories(tst_qml_sandbox PRIVATE ${BASECAMP_SRC})
 target_compile_definitions(tst_qml_sandbox PRIVATE


### PR DESCRIPTION
…os.Icons the 2 collide in qt world and give error as qt searches for the icon under qml/cions instead of Logos/Icons folder

<!--
Thanks for the PR. A short template so triage and review don't stall.
Delete sections that don't apply — don't leave placeholder text.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->

## Screenshots / recordings

<!-- Required for any user-visible UI change. Before/after if it's a fix. -->

## Test plan

<!-- How you validated the change. Tick what applies. -->

- [ ] `nix build .#app` succeeds
- [ ] `nix build .#smoke-test -L` passes
- [ ] `nix build .#integration-test -L` passes (if UI-visible)
- [ ] Doctests pass (`nix build .#doctests -L` if touched)
- [ ] Manual verification on:
  - [ ] Linux (AppImage)
  - [ ] Linux (Nix local build)
  - [ ] macOS
- [ ] N/A — docs/CI/tooling only

## Release notes

<!-- One line for the changelog. Prefix with fix:/feat:/chore:/docs:/test:/ci:
     to match the commit-style already used on master. -->

## Checklist

- [ ] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [ ] No unrelated changes bundled in
- [ ] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [ ] Uncommitted binaries, screenshots, or `.DS_Store` files removed
