### PR TITLE
Chore/add coverage report

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,26 @@ jobs:
       - name: Integration test (UI tests)
         run: nix build .#integration-test -L
 
+      # Report-only non-blocking for now
+      - name: Coverage report
+        continue-on-error: true
+        run: |
+          nix build .#coverage -L
+          {
+            echo '## Unit-test coverage'
+            echo '```'
+            cat result/coverage.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: result/
+          if-no-files-found: ignore
+
   test-macos:
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
     runs-on: macos-latest

--- a/flake.nix
+++ b/flake.nix
@@ -277,6 +277,16 @@
           # QML component tests (Qt Quick Test)
           qml-tests = import ./nix/qml-tests.nix { inherit pkgs src logosPackageHeaders; };
 
+          # Coverage report for the unit-test suite: same targets as
+          # .#unit-tests, compiled with --coverage and reported via gcovr.
+          # Report-only for now (failUnderLine = 0) — raise the threshold as
+          # the test plan phases land to make it a gate.
+          # Build: nix build .#coverage -L && open result/coverage.html
+          coverage = import ./nix/coverage.nix {
+            inherit pkgs src logosPackageHeaders;
+            failUnderLine = 0;
+          };
+
           # Integration test (UI tests via Qt Inspector)
           integration-test = import ./nix/integration-test.nix { inherit pkgs src logosQtMcp; appPkg = app; };
 

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -1,0 +1,100 @@
+# Line/branch coverage for the C++ unit-test suite.
+#
+# Reuses tests/CMakeLists.txt verbatim — same targets, same ctest run as
+# `nix build .#unit-tests` — but compiled with --coverage, then reported
+# through gcovr. Build:
+#
+#   nix build .#coverage -L && open result/coverage.html
+#
+# Report-only by default (failUnderLine = 0). Raise the threshold as the
+# test plan phases land, either here or from the caller in flake.nix, and the
+# derivation starts failing the build when coverage regresses below it.
+#
+# Scope caveat: gcovr only sees files that were compiled into the test
+# binaries. Sources no unit test links at all (PackageCoordinator,
+# UIPluginManager, PluginLoader, MainContainer, MainUIBackend) produce no
+# .gcno and therefore do NOT appear in the report as 0% — the percentage here
+# is "coverage of the code under unit test", not of all of src/. Adding a
+# source to tests/CMakeLists.txt is what pulls it into the denominator.
+{ pkgs, src, logosPackageHeaders, failUnderLine ? 0, failUnderBranch ? 0 }:
+
+let
+  # gcov reader matching the stdenv compiler: clang emits gcov data only
+  # llvm-cov of the same LLVM version can parse, gcc emits data for its own
+  # gcov. Mismatching the two is the usual cause of "unknown gcov version".
+  gcovExecutable =
+    if pkgs.stdenv.cc.isClang
+    then "${pkgs.llvmPackages.libllvm}/bin/llvm-cov gcov"
+    else "${pkgs.stdenv.cc.cc}/bin/gcov";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "logos-basecamp-coverage";
+  version = "0.0.0";
+
+  inherit src;
+
+  nativeBuildInputs = [
+    pkgs.cmake
+    pkgs.ninja
+    pkgs.pkg-config
+    pkgs.qt6.wrapQtAppsHook
+    pkgs.gcovr
+  ];
+  buildInputs = [
+    pkgs.qt6.qtbase
+    pkgs.qt6.qtdeclarative   # Qt::Qml — InstallEnums.h includes <QtQml/qqml.h>
+  ];
+
+  dontUseCmakeConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+    # -fprofile-update=atomic keeps counters correct if a test ever spawns
+    # threads; Debug already implies -O0 -g, which keeps line mapping exact.
+    cmake -S tests -B build-cov -GNinja -DCMAKE_BUILD_TYPE=Debug \
+      -DLOGOS_PACKAGE_HEADERS="${logosPackageHeaders}/include" \
+      -DCMAKE_CXX_FLAGS="--coverage -fprofile-update=atomic" \
+      -DCMAKE_EXE_LINKER_FLAGS="--coverage"
+    cmake --build build-cov
+    runHook postBuild
+  '';
+
+  # Running the suite is what writes the .gcda counters next to the .gcno
+  # files in build-cov, so the report below depends on this phase.
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    export QT_QPA_PLATFORM=offscreen
+    ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+      export QT_PLUGIN_PATH="${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}"
+    ''}
+    ctest --test-dir build-cov --output-on-failure
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+
+    # --filter src/ keeps the report to production code (the tests' own
+    # translation units and CMake's *_autogen moc stubs are excluded).
+    gcovr \
+      --root "$PWD" \
+      --filter 'src/' \
+      --exclude '.*_autogen.*' \
+      --gcov-executable "${gcovExecutable}" \
+      --exclude-unreachable-branches \
+      --exclude-throw-branches \
+      --print-summary \
+      --html-title "logos-basecamp unit-test coverage" \
+      --txt "$out/coverage.txt" \
+      --html-details "$out/coverage.html" \
+      --cobertura "$out/coverage.xml" \
+      --json-summary "$out/summary.json" \
+      --fail-under-line ${toString failUnderLine} \
+      --fail-under-branch ${toString failUnderBranch}
+
+    cat $out/coverage.txt
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
## Summary

Add  coverage report to flake and CI to measure unit-tests line coverage. 

## Test plan
- [x] nix build .#unit-tests -L passes
- [x] nix build .#sandbox-test -L passes
- [x] nix build .#qml-tests -L passes
- [x] nix build .#smoke-test -L passes
- [x] nix build .#integration-test -L passes
- [x] nix flake check -L passes
- [x] Doctests pass (`./doctests/run.sh`, or `COMMIT="" ./doctests/run.sh` for a local unpushed HEAD, if touched)

## Checklist

- [x] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [x] No unrelated changes bundled in
- [x] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [x] Uncommitted binaries, screenshots, or `.DS_Store` files removed
