### PR TITLE
ci: fix job paths after move under logos folder

### DIFF
--- a/ci/combined.Jenkinsfile
+++ b/ci/combined.Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
       parallel {
         stage('Linux/x86_64') { steps { script {
           linux_x86_64 = getArtifacts(
-            'Linux', jenkins.Build('logos-basecamp/systems/linux/x86_64/package')
+            'Linux', jenkins.Build('logos/logos-basecamp/systems/linux/x86_64/package')
           )
         } } }
         stage('Linux/aarch64') { steps { script {
@@ -48,7 +48,7 @@ pipeline {
         } } }
         stage('macOS/aarch64') { steps { script {
           macos_aarch64 = getArtifacts(
-            'macOS', jenkins.Build('logos-basecamp/systems/macos/aarch64/package')
+            'macOS', jenkins.Build('logos/logos-basecamp/systems/macos/aarch64/package')
           )
         } } }
       }
@@ -84,7 +84,7 @@ pipeline {
  * - A user explicitly specified a value
  * Since release builds create and re-create GitHub drafts every time. */
 def Boolean getPublishDefault(Boolean previousValue) {
-  if (env.JOB_NAME.startsWith('logos-basecamp/release')) { return true }
+  if (env.JOB_NAME.startsWith('logos/logos-basecamp/release')) { return true }
   if (previousValue != null) { return previousValue }
   return false
 }

--- a/ci/linux.Jenkinsfile
+++ b/ci/linux.Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
       abortPrevious: isPRBuild
     )
     /* Allows combined build to copy */
-    copyArtifactPermission('/logos-basecamp/*')
+    copyArtifactPermission('/logos/logos-basecamp/*')
   }
 
   environment {

--- a/ci/macos.Jenkinsfile
+++ b/ci/macos.Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
       abortPrevious: isPRBuild
     )
     /* Allows combined build to copy */
-    copyArtifactPermission('/logos-basecamp/*')
+    copyArtifactPermission('/logos/logos-basecamp/*')
   }
 
   environment {


### PR DESCRIPTION
Jenkins jobs moved from /logos-basecamp/* to /logos/logos-basecamp/*, which broke everything referencing the old paths: the combined build could no longer resolve child package jobs, getPublishDefault never matched the new JOB_NAME so release builds lost their PUBLISH=true default, and copyArtifactPermission no longer covered the combined job's new location.