### PR TITLE
fix(windows): bundle Basecamp with the real bundler instead of bypassing it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -180,9 +180,14 @@
 
           # Pre-installed modules/plugins (bundle + lgpm install in one step).
           # Dev build: raw derivation (depends on /nix/store at runtime).
-          # Distributed build: portable self-contained bundle (nix-bundle-dir pre-applied
-          # off Windows; see binBundleDir for why Windows skips that step).
-          onWindows = pkgs.stdenv.hostPlatform.isWindows;
+          # Distributed build: portable self-contained bundle. Off Windows that
+          # portability comes from nix-bundle-dir; on Windows nix-bundle-lgx
+          # takes its own `mkWindowsPayload` path instead and does not call
+          # nix-bundle-dir at all. That is nix-bundle-lgx's business, not this
+          # flake's -- a MODULE must not carry the Qt/OpenSSL/runtime DLLs the
+          # host already ships in bin/, so the PE path needs a hostLibs strip
+          # that nix-bundle-dir does not have yet. Unrelated to binBundleDir
+          # below, which is the APP and therefore is the thing that ships them.
           installedDev = map installDev [
             logosPackageManagerModuleLib
             logosPackageDownloaderModuleLib
@@ -265,32 +270,103 @@
               mainProgram = "LogosBasecamp";
             };
           });
-          # INTERIM, and neither branch of this is right yet -- see below.
+          # dirBundler on EVERY platform, Windows included.
           #
-          # nix-bundle-dir does two separable jobs. (a) RELOCATION: rewriting
-          # rpaths / install names so binaries stop pointing into /nix/store.
-          # A PE genuinely needs none of that -- its import table carries DLL
-          # BASE NAMES only, Windows searches the executable's own directory
-          # first, and win-dll-link.sh has already staged bin/. (b) Qt STAGING:
-          # the Qt plugin scan, the QML module scan and qt.conf generation.
-          # (b) is FORMAT-AGNOSTIC and is required on Windows just as much as
-          # anywhere else -- Qt plugins and QML module DLLs are LoadLibrary'd,
-          # so nothing in the import closure reveals them.
+          # The `winBundler = drv: drv` / `bundleFor` bypass that used to sit
+          # here was placed on an explicit condition: "the real fix is a PE
+          # branch in nix-bundle-dir's bundle.sh that skips relocation and keeps
+          # Qt staging; when that lands, DELETE bundleFor". It has landed, and
+          # this flake's root `nix-bundle-dir` input already resolves to it
+          # (f843b8ec, which is `main`), so the condition is met and the bypass
+          # is gone.
           #
-          # Running the bundler unmodified on Windows takes the (a) path, whose
-          # `file -b` chain has no PE case, and emits an EMPTY payload while
-          # exiting 0. Skipping it entirely -- what this does -- keeps the app
-          # and the modules but produces no qt.conf, no lib/qt-6/plugins and no
-          # qwindows.dll, so the app cannot start either.
+          # Why it was never a working alternative: nix-bundle-dir does two
+          # separable jobs. (a) RELOCATION -- rewriting rpaths / install names
+          # so binaries stop pointing into /nix/store. (b) Qt STAGING -- the Qt
+          # plugin scan, the QML module scan and qt.conf generation; that half
+          # is FORMAT-AGNOSTIC and Windows needs it exactly as much as anywhere
+          # else, because Qt plugins and QML module DLLs are LoadLibrary'd and
+          # nothing in the import table reveals them.
           #
-          # The real fix is a PE branch in nix-bundle-dir's bundle.sh that skips
-          # (a) and keeps (b), plus a fixpoint sweep of the DLL closure over the
-          # staged plugins. When that lands, DELETE bundleFor and go back to
-          # dirBundler on every platform.
-          winBundler = drv: drv;
-          bundleFor = if onWindows then winBundler else dirBundler;
-          binBundleDir = withMainProgram (bundleFor appDistributed);
-          binBundleDirInspector = withMainProgram (bundleFor appDistributedWithInspector);
+          # The bypass was argued for on the grounds that a PE needs none of
+          # (a). Only the rpath REWRITING half of that is true, and the
+          # measurement below is what corrects it: the un-bundled tree reaches
+          # a third of its bin/ through 12 SYMLINKS into /nix/store, which no
+          # amount of "PE imports are base names" makes portable. Phase 1's
+          # `cp -aL` is what dereferences them, and skipping the bundler
+          # skipped that as surely as it skipped (b).
+          #
+          # Measured, not assumed. Both trees were realised on x86_64-linux
+          # from ONE tree -- same appDistributed derivation, the only variable
+          # being whether dirBundler is applied -- and compared entry by entry:
+          #
+          #                              bypass(drv:drv)   dirBundler
+          #     entries                              85         1740
+          #     regular files                        59         1657
+          #     symlinks                             12            0
+          #     bytes                            259 MB       479 MB
+          #     *.dll in bin/                        33           88
+          #     bin/qt.conf                     MISSING      present
+          #     lib/qt-6/…/platforms/qwindows.dll
+          #                                     MISSING      present
+          #     lib/qt-6 (plugins + qml)        MISSING   1533 files
+          #     nix closure refs                     12            1
+          #
+          # Those 12 symlinks are the part that matters most, and they are why
+          # "the bypass at least shipped the app" was never true. bin/Qt6Core
+          # .dll, Qt6Gui.dll, Qt6Widgets.dll, Qt6Network.dll, Qt6RemoteObjects
+          # .dll, libssl/libcrypto, libpng16, libzstd, libb2, pcre2 and
+          # double-conversion were SYMLINKS into /nix/store. Copy that tree to
+          # a Windows box -- the entire point of a portable bundle -- and every
+          # one of them dangles: 0xC0000135, no output, before main(). The
+          # bundled tree resolves all 12 into real files and has no symlink
+          # left. Its single remaining nix reference is an inert /nix string
+          # embedded in a PE's data, which imports nothing.
+          #
+          # 55 DLLs exist only in the bundled bin/: the Qt Quick / Controls /
+          # Labs set the fixpoint sweep pulls in once the QML modules are
+          # staged, plus libcurl and its TLS/HTTP2 chain mirrored beside the
+          # package_downloader module that imports them.
+          #
+          # The one thing the bundler does NOT carry over: README.txt and
+          # share/ (a .desktop file and a hicolor icon, 9 paths). That is not a
+          # Windows regression -- bundle.sh Phase 1 copies bin/, lib/ and
+          # extraDirs on EVERY platform, so the shipping Linux and macOS
+          # bundles have never had them either; the bypass "kept" them only by
+          # doing nothing at all. Both are dead weight off-store anyway:
+          # README.txt is a build-info file whose every line is a /nix/store
+          # path, and a .desktop file does nothing on Windows.
+          #
+          # Getting here also required three additions to the app's
+          # passthru.extraClosurePaths (see nix/app.nix) -- qtdeclarative,
+          # libjpeg.bin, sqlite.bin. Each was a build the bundler FAILED,
+          # naming the missing DLL and the plugin that imported it, rather than
+          # shipping a tree that dies before main(). That is the behaviour the
+          # bypass was hiding.
+          #
+          # NOT demonstrated, stated plainly:
+          #
+          #  * None of this has been RUN on Windows, by this change or by CI,
+          #    which has never executed a Windows binary. Every claim above is
+          #    build-time and tree-shape only.
+          #  * The two trees measured came from a harness that drops ONE entry
+          #    from installedDistributed -- packageManagerUIPlugin -- because
+          #    logos-package-manager-ui does not cross-compile at the rev this
+          #    flake pins: its generated logos_sdk.h includes
+          #    package_manager_api.h, which is not produced for the Windows
+          #    target. That is pre-existing and independent of this change; the
+          #    identical derivation fails when built straight from the pinned
+          #    rev with no basecamp involved. Everything above concerns Qt
+          #    staging and the DLL closure, which that one plugin does not
+          #    participate in -- but the numbers are from a bundle missing it.
+          #  * For the same reason `nix build .#packages.x86_64-windows.*`
+          #    cannot succeed on this branch as pinned. A second, unrelated
+          #    blocker sits in front of it at EVAL time: line ~119's
+          #    logos-package-downloader-module has no x86_64-windows target, so
+          #    the attribute cannot even be evaluated. Both blockers predate
+          #    this change and are identical with the bypass in place.
+          binBundleDir = withMainProgram (dirBundler appDistributed);
+          binBundleDirInspector = withMainProgram (dirBundler appDistributedWithInspector);
         in
         {
           # Individual outputs

--- a/nix/app.nix
+++ b/nix/app.nix
@@ -186,7 +186,51 @@ pkgs.stdenv.mkDerivation rec {
   passthru = {
     extraDirs = [ "modules" "plugins" ];
     extraClosurePaths = qtWebview ++ [ pkgs.qt6.qtsvg ]
-      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.qt6.qtwayland ];
+      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.qt6.qtwayland ]
+      # Windows ONLY, and NOT because Windows needs extra Qt features -- it
+      # needs the same ones, DECLARED differently.
+      #
+      # An ELF or Mach-O binary records where its dependencies live: the
+      # qtdeclarative / libjpeg / sqlite store paths end up in rpaths and
+      # install names, Nix scans them out as references, and closureInfo gets
+      # all three without anyone naming them. A PE import table carries DLL
+      # BASE NAMES only ("libjpeg-62.dll") and embeds no /nix/store string
+      # anywhere, so Nix records NO reference and these paths never enter the
+      # closure at all. The bundler cannot stage what is not in the closure.
+      #
+      # Measured -- each entry below is a build that FAILED without it, on the
+      # real x86_64-windows Basecamp bundle, once flake.nix stopped bypassing
+      # the bundler:
+      #
+      #   qtdeclarative  Phase 2b staged 17 Qt plugin files, then: "QtQuick/
+      #                  QtQml DLLs are in bin/, so this bundle renders QML,
+      #                  but no QML module directory for this target was found
+      #                  in the closure." Adding it stages 1651 QML files and
+      #                  lets the Phase 2e sweep pull in 40 more Qt DLLs.
+      #   libjpeg.bin    "libjpeg-62.dll -- imported by
+      #                  lib/qt-6/plugins/imageformats/qjpeg.dll".
+      #   sqlite.bin     "libsqlite3-0.dll -- imported by
+      #                  lib/qt-6/plugins/sqldrivers/qsqlite.dll".
+      #
+      # `.bin`, not the default output, is deliberate and was checked rather
+      # than assumed: for both packages the mingw DLL is installed into the
+      # `bin` output (`…-libjpeg-turbo-…-bin/bin/libjpeg-62.dll`,
+      # `…-sqlite-…-bin/bin/libsqlite3-0.dll`), so rooting the closure at the
+      # default output would add nothing and the build would fail unchanged.
+      #
+      # These last two are Qt's OWN plugin dependencies, not Basecamp's -- we
+      # never call libjpeg or sqlite. They have to be declared here anyway,
+      # because passthru.extraClosurePaths on the bundled derivation is the
+      # only channel nix-bundle-dir reads.
+      #
+      # Windows-gated rather than unconditional so it provably cannot perturb
+      # the Linux/macOS bundles, where the references already exist and adding
+      # them would be a no-op that would still have to be re-proven.
+      ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isWindows [
+        pkgs.qt6.qtdeclarative
+        pkgs.libjpeg.bin
+        pkgs.sqlite.bin
+      ];
   };
 
   # This is an aggregate runtime layout; avoid stripping to prevent hook errors


### PR DESCRIPTION
Deletes the `winBundler = drv: drv` bypass and routes the Windows bundle through the real directory bundler, which is what `flake.nix:288`'s own comment said to do once the PE path landed. It has landed.

## The bypass was shipping a tree that cannot start

Not merely "no `qt.conf`". **12 of the un-bundled tree's `bin/` entries are symlinks into `/nix/store`** — `Qt6Core.dll`, `Qt6Gui.dll`, `Qt6Widgets.dll`, `Qt6Network.dll`, `Qt6RemoteObjects.dll`, libssl, libcrypto, libpng16, libzstd, libb2, pcre2, double-conversion. Copy that to a Windows box and every one dangles → `0xC0000135` before `main()`.

So the inherited justification — "a PE needs no relocation" — was half true. rpath *rewriting* is moot on PE, but Phase 1's `cp -aL` is not, and the bypass skipped it. Worth noting for anyone auditing similar claims: a naive check scores `bin/Qt6Core.dll` as **present**. It is present — as a broken link. Testing file *type* rather than existence is what caught this.

The bundled tree has **zero** symlinks.

## Removing it surfaced three real defects, each previously invisible

The bundler failed the build three times, each naming the missing DLL and the plugin importing it, and each needing an `extraClosurePaths` entry:

| missing | imported by |
|---|---|
| `qtdeclarative` | `Qt6Quick.dll` ships with no QML module tree |
| `libjpeg.bin` | `lib/qt-6/plugins/imageformats/qjpeg.dll` |
| `sqlite.bin` | `lib/qt-6/plugins/sqldrivers/qsqlite.dll` |

Same root cause every time: **a PE embeds no store path**, so Nix records no reference and the path never reaches `closureInfo`. `.bin` versus the default output was checked empirically — the DLLs really are in the `bin` output.

## Scope

Non-comment diff is 7 removed / 8 added lines. No re-pin was needed: `master` already resolves `nix-bundle-dir` to `f843b8ec`, the current tip of `main` — confirmed via `gh api`, not a local ref. **A trap worth recording:** the *unsuffixed* `nix-bundle-dir` node in `flake.lock` is not the root's; root resolves to `nix-bundle-dir_1061`. Both are `f843b8ec` here, so reading the wrong node gave the right answer by luck.

Windows-gating is proven both directions: on `aarch64-darwin` and `x86_64-linux` `app.extraClosurePaths` is byte-identical before and after, and the native `packages` attr set is unchanged.

## Two pre-existing blockers, unchanged by this PR

Both predate it and reproduce identically with the bypass in place:

1. `packages.x86_64-windows` does not evaluate on `master` at all — `logos-package-downloader-module` has no Windows target. Fixed by [logos-package-downloader-module#…](https://github.com/logos-co/logos-package-downloader-module) in this same batch.
2. `logos-package-manager-ui` does not cross-compile at pinned rev `39a5fa5` (`logos_sdk.h` includes `package_manager_api.h`, not produced for Windows). Isolated to rule out the harness: building it standalone from that rev yields the **identical derivation hash** and the same error.

Measured with (1) overridden and (2) dropped, so **these numbers come from a bundle missing `packageManagerUIPlugin`**. Given each fix above revealed the next missing DLL, a full-fat bundle could surface a fourth. Nothing here ran on Windows — build-time and tree-shape only.
